### PR TITLE
* compatibility TYPO3 8.7: deprecation 77934: select_key

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2022-09-09 Franz Holzinger <franz@ttproducts.de>
+    * compatibility TYPO3 8.7: deprecation no 77934: The field `select_key` of the table `tt_content` is not used in the core and has been removed.
+
 2022-08-17 Franz Holzinger <franz@ttproducts.de>
     * Breaking no.88143: Version-related database field “t3ver_id” removed
     * Breaking no.87193: Deprecated functionality removed: database field “t3ver_label“ removed

--- a/Classes/Controller/Plugin/WizardIcon.php
+++ b/Classes/Controller/Plugin/WizardIcon.php
@@ -39,7 +39,7 @@ class WizardIcon
     public function proc(array $wizardItems)
     {
         $wizardIcon = 'res/icons/be/ce_wiz.gif';
-        $params = '&defVals[tt_content][CType]=list&defVals[tt_content][list_type]=5&defVals[tt_content][select_key]=HELP';
+        $params = '&defVals[tt_content][CType]=list&defVals[tt_content][list_type]=5';
 
         $wizardItem = array(
             'title' => $GLOBALS['LANG']->sL('LLL:EXT:' . TT_PRODUCTS_EXT . DIV2007_LANGUAGE_SUBPATH . 'locallang.xlf:plugins_title'),

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,7 +5,7 @@ call_user_func(function () {
 
     $table = 'tt_content';
 
-    $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist']['5'] = 'layout,select_key';
+    $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist']['5'] = 'layout';
     $GLOBALS['TCA'][$table]['types']['list']['subtypes_addlist']['5'] = 'pi_flexform';
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('5', 'FILE:EXT:' . TT_PRODUCTS_EXT . '/pi1/flexform_ds_pi1.xml');
@@ -13,7 +13,7 @@ call_user_func(function () {
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('searchbox')) {
 
         $listType = TT_PRODUCTS_EXT . '_pi_search';
-        $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist'][$listType] = 'layout,select_key';
+        $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist'][$listType] = 'layout';
         $GLOBALS['TCA'][$table]['types']['list']['subtypes_addlist'][$listType] = 'pi_flexform';
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($listType, 'FILE:EXT:' . TT_PRODUCTS_EXT . '/pi_search/flexform_ds_pi_search.xml');
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
@@ -28,7 +28,7 @@ call_user_func(function () {
     }
 
     $listType = TT_PRODUCTS_EXT . '_pi_int';
-    $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist'][$listType] = 'layout,select_key';
+    $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist'][$listType] = 'layout';
     $GLOBALS['TCA'][$table]['types']['list']['subtypes_addlist'][$listType] = 'pi_flexform';
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($listType, 'FILE:EXT:' . TT_PRODUCTS_EXT . '/pi_int/flexform_ds_pi_int.xml');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(

--- a/Configuration/TypoScript/PluginSetup/Main/setup.txt
+++ b/Configuration/TypoScript/PluginSetup/Main/setup.txt
@@ -23,7 +23,7 @@ plugin.tt_products {
   errorLog = {$plugin.tt_products.file.errorLog}
   templateStyle = css-styled
   pid_list = {$plugin.tt_products.pid_list}
-  code.field = select_key
+  code.field = 
   defaultCode = HELP
   defaultImageDir =
   wrapInBaseClass = 1


### PR DESCRIPTION
 The field `select_key` of the table `tt_content` is not used in the core and has been removed.