### PR TITLE
TASK: Use spaces instead of tabs in php files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*.php]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/Classes/Api/BasketApi.php
+++ b/Classes/Api/BasketApi.php
@@ -43,69 +43,69 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class BasketApi {
 
-	static public function getQuantity ($content, $basketConf) {
-		$count = '';
-		$basketExt = \tx_ttproducts_control_basket::getStoredBasketExt();
+    static public function getQuantity ($content, $basketConf) {
+        $count = '';
+        $basketExt = \tx_ttproducts_control_basket::getStoredBasketExt();
 
-		if (
-			isset($basketExt) &&
-			is_array($basketExt) &&
-			!empty($basketExt) &&
-			isset($basketConf['ref']) &&
-			isset($basketConf['row'])
-		) {
-			$conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
-			$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$cnfObj->init(
-				$conf,
-				[]
-			);
+        if (
+            isset($basketExt) &&
+            is_array($basketExt) &&
+            !empty($basketExt) &&
+            isset($basketConf['ref']) &&
+            isset($basketConf['row'])
+        ) {
+            $conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
+            $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $cnfObj->init(
+                $conf,
+                []
+            );
 
-			$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
-			$cObj->start([]);
+            $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
+            $cObj->start([]);
             $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-			$uid = intval($basketConf['ref']);
-			$row = $basketConf['row'];
-			$variant = '';
-			$useArticles = $cnfObj->getUseArticles();
+            $uid = intval($basketConf['ref']);
+            $row = $basketConf['row'];
+            $variant = '';
+            $useArticles = $cnfObj->getUseArticles();
 
-			if (
-				isset($basketConf['variant']) &&
-				!empty($basketConf['variant'])
-			) {
-				$variant = $basketConf['variant'];
-			} else {
-				$funcTablename = 'tt_products';
-				$productTable = $tablesObj->get($funcTablename);
-				$variantRow =
-					$productTable->variant->getVariantRow($row, []);
-				$variant =
-					$productTable->variant->getVariantFromProductRow(
-						$row,
-						$variantRow,
-						$useArticles
-					);
-			}
+            if (
+                isset($basketConf['variant']) &&
+                !empty($basketConf['variant'])
+            ) {
+                $variant = $basketConf['variant'];
+            } else {
+                $funcTablename = 'tt_products';
+                $productTable = $tablesObj->get($funcTablename);
+                $variantRow =
+                    $productTable->variant->getVariantRow($row, []);
+                $variant =
+                    $productTable->variant->getVariantFromProductRow(
+                        $row,
+                        $variantRow,
+                        $useArticles
+                    );
+            }
 
-			\tx_ttproducts_control_basket::init(
-				$conf,
-				$tablesObj,
-				$conf['pid_list'],
-				$useArticles
-			);
+            \tx_ttproducts_control_basket::init(
+                $conf,
+                $tablesObj,
+                $conf['pid_list'],
+                $useArticles
+            );
 
-			$count =
-				\tx_ttproducts_control_basket::getBasketCount(
-					$row,
-					$variant,
-					$conf['quantityIsFloat']
-				);
-			\tx_ttproducts_control_basket::destruct();
-		}
+            $count =
+                \tx_ttproducts_control_basket::getBasketCount(
+                    $row,
+                    $variant,
+                    $conf['quantityIsFloat']
+                );
+            \tx_ttproducts_control_basket::destruct();
+        }
 
-		return $count;
-	}
+        return $count;
+    }
 
     /**
     * get the product rows contained in the basket
@@ -169,80 +169,80 @@ class BasketApi {
         return $result;
     }
 
-	static public function getRecordvariantAndPriceFromRows (
-		&$variant,
-		&$price,
-		&$externalUidArray,
-		$externalRowArray
-	) {
-		$result = false;
-		$variant = '';
-		$price = 0;
-		$downloadUid = 0;
-		foreach ($externalRowArray as $tablename => $externalRow) {
-			switch ($tablename) {
-				case 'tt_products_downloads':
-					$externalUid = $externalRow['uid'];
-					if (
-						isset($externalRow['price_enable']) &&
-						$externalRow['price_enable'] &&
-						isset($externalRow['price'])
-					) {
-						$price = $externalRow['price'];
-					}
+    static public function getRecordvariantAndPriceFromRows (
+        &$variant,
+        &$price,
+        &$externalUidArray,
+        $externalRowArray
+    ) {
+        $result = false;
+        $variant = '';
+        $price = 0;
+        $downloadUid = 0;
+        foreach ($externalRowArray as $tablename => $externalRow) {
+            switch ($tablename) {
+                case 'tt_products_downloads':
+                    $externalUid = $externalRow['uid'];
+                    if (
+                        isset($externalRow['price_enable']) &&
+                        $externalRow['price_enable'] &&
+                        isset($externalRow['price'])
+                    ) {
+                        $price = $externalRow['price'];
+                    }
 
-					if ($externalUid) {
-						$variant .= '|records:dl=' . $externalUid;
-					}
-					$externalUidArray[$tablename] = $externalUid;
-					break;
-				case 'sys_file_reference':
-					if (
-						isset($externalRow['tx_ttproducts_price_enable']) &&
-						$externalRow['tx_ttproducts_price_enable'] &&
-						isset($externalRow['tx_ttproducts_price'])
-					) {
-						$price = $externalRow['tx_ttproducts_price'];
-					}
+                    if ($externalUid) {
+                        $variant .= '|records:dl=' . $externalUid;
+                    }
+                    $externalUidArray[$tablename] = $externalUid;
+                    break;
+                case 'sys_file_reference':
+                    if (
+                        isset($externalRow['tx_ttproducts_price_enable']) &&
+                        $externalRow['tx_ttproducts_price_enable'] &&
+                        isset($externalRow['tx_ttproducts_price'])
+                    ) {
+                        $price = $externalRow['tx_ttproducts_price'];
+                    }
 
-					if (
-						isset($externalUidArray['tt_products_downloads']) &&
-						$externalUidArray['tt_products_downloads'] > 0
-					) {
-						$variant .= \tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal=' . $externalRow['uid'];
-					}
-					$externalUidArray[$tablename] = $externalRow['uid'];
-					break;
-			}
-		}
+                    if (
+                        isset($externalUidArray['tt_products_downloads']) &&
+                        $externalUidArray['tt_products_downloads'] > 0
+                    ) {
+                        $variant .= \tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal=' . $externalRow['uid'];
+                    }
+                    $externalUidArray[$tablename] = $externalRow['uid'];
+                    break;
+            }
+        }
 
-		if ($variant != '') {
-			$result = true;
-		}
-		return $result;
-	}
+        if ($variant != '') {
+            $result = true;
+        }
+        return $result;
+    }
 
 
-	/**
-	 * get basket record for tracking, billing and delivery data row
-	 */
-	static public function getBasketRec (
-		$row,
-		$typeArray = [
-			'payment',
-			'shipping',
-			'handling'
-		]
-	) {
-		$extraArray = [];
-		foreach ($typeArray as $type) {
-			$tmpArray = GeneralUtility::trimExplode(':', $row[$type]);
-			$extraArray[$type] = $tmpArray['0'];
-		}
+    /**
+     * get basket record for tracking, billing and delivery data row
+     */
+    static public function getBasketRec (
+        $row,
+        $typeArray = [
+            'payment',
+            'shipping',
+            'handling'
+        ]
+    ) {
+        $extraArray = [];
+        foreach ($typeArray as $type) {
+            $tmpArray = GeneralUtility::trimExplode(':', $row[$type]);
+            $extraArray[$type] = $tmpArray['0'];
+        }
 
-		$basketRec = ['tt_products' => $extraArray];
+        $basketRec = ['tt_products' => $extraArray];
 
-		return $basketRec;
-	}
+        return $basketRec;
+    }
 }
 

--- a/Classes/Api/ControlApi.php
+++ b/Classes/Api/ControlApi.php
@@ -41,7 +41,7 @@ namespace JambageCom\TtProducts\Api;
 
 
 class ControlApi {
-	static protected $conf = [];
+    static protected $conf = [];
     static protected $cObj = null;
 
     static public function init ($conf, $cObj) {
@@ -57,26 +57,26 @@ class ControlApi {
         return static::$cObj;
     }
 
-	static public function isOverwriteMode ($infoArray) {
-		$overwriteMode = false;
-		$conf = self::getConf();
+    static public function isOverwriteMode ($infoArray) {
+        $overwriteMode = false;
+        $conf = self::getConf();
 
-		$checkField = \JambageCom\TtProducts\Api\CustomerApi::getPossibleCheckField();
+        $checkField = \JambageCom\TtProducts\Api\CustomerApi::getPossibleCheckField();
 
-		if (
-			(
-				!$infoArray['billing'] ||
-				!$infoArray['billing'][$checkField] ||
-				$conf['editLockedLoginInfo'] ||
-				!empty($infoArray['billing']['error'])
-			) &&
-			$conf['lockLoginUserInfo']
-		) {
-			$overwriteMode = true;
-		}
+        if (
+            (
+                !$infoArray['billing'] ||
+                !$infoArray['billing'][$checkField] ||
+                $conf['editLockedLoginInfo'] ||
+                !empty($infoArray['billing']['error'])
+            ) &&
+            $conf['lockLoginUserInfo']
+        ) {
+            $overwriteMode = true;
+        }
 
-		return $overwriteMode;
-	}
+        return $overwriteMode;
+    }
 }
 
 

--- a/Classes/Api/CustomerApi.php
+++ b/Classes/Api/CustomerApi.php
@@ -44,177 +44,177 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 abstract class CustomerTypes {
-	const Billing = 1;
-	const Delivery = 2;
+    const Billing = 1;
+    const Delivery = 2;
 }
 
 
 
 class CustomerApi {
-	static private $billingInfo;
-	static private $shippingInfo;
-	static private $fields =
-	'name,cnum,first_name,last_name,username,email,telephone,title,salutation,address,house_no,telephone,fax,email,company,city,zip,state,country,country_code,tt_products_vat,date_of_birth,tt_products_business_partner,tt_products_organisation_form';
-	static private $requiredInfoFields = '';
-	static protected $possibleCheckFieldArray = ['name', 'last_name', 'email', 'telephone'];
-	static protected $creditpointfields = 'tt_products_creditpoints,tt_products_vouchercode';
+    static private $billingInfo;
+    static private $shippingInfo;
+    static private $fields =
+    'name,cnum,first_name,last_name,username,email,telephone,title,salutation,address,house_no,telephone,fax,email,company,city,zip,state,country,country_code,tt_products_vat,date_of_birth,tt_products_business_partner,tt_products_organisation_form';
+    static private $requiredInfoFields = '';
+    static protected $possibleCheckFieldArray = ['name', 'last_name', 'email', 'telephone'];
+    static protected $creditpointfields = 'tt_products_creditpoints,tt_products_vouchercode';
 
 
-	static public function init (
-		$conf,
-		$billingRow,
-		$deliveryRow,
-		$basketExtra
-	) {
-		if (
-			isset($basketRecs) &&
-			is_array($basketRecs) &&
-			!empty($basketRecs) &&
-			isset($billingRow) &&
-			isset($deliveryRow)
-		) {
-			self::setBillingInfo($billingRow);
-			self::setShippingInfo($deliveryRow);
-		}
+    static public function init (
+        $conf,
+        $billingRow,
+        $deliveryRow,
+        $basketExtra
+    ) {
+        if (
+            isset($basketRecs) &&
+            is_array($basketRecs) &&
+            !empty($basketRecs) &&
+            isset($billingRow) &&
+            isset($deliveryRow)
+        ) {
+            self::setBillingInfo($billingRow);
+            self::setShippingInfo($deliveryRow);
+        }
 
-		$fields = self::getFields();
+        $fields = self::getFields();
 
-		if (
-			isset($GLOBALS['TCA']['fe_users']['columns']) &&
-			is_array($GLOBALS['TCA']['fe_users']['columns'])
-		) {
-			foreach (($GLOBALS['TCA']['fe_users']['columns']) as $field => $fieldTCA) {
-				if (!GeneralUtility::inList($fields, $field)) {
-					$fields .= ',' . $field;
-				}
-			}
-		}
-		self::setFields($fields);
-		$requiredInfoFieldArray = $conf['requiredInfoFields.'] ?? [];
-		$typeArray = ['billing', 'delivery'];
+        if (
+            isset($GLOBALS['TCA']['fe_users']['columns']) &&
+            is_array($GLOBALS['TCA']['fe_users']['columns'])
+        ) {
+            foreach (($GLOBALS['TCA']['fe_users']['columns']) as $field => $fieldTCA) {
+                if (!GeneralUtility::inList($fields, $field)) {
+                    $fields .= ',' . $field;
+                }
+            }
+        }
+        self::setFields($fields);
+        $requiredInfoFieldArray = $conf['requiredInfoFields.'] ?? [];
+        $typeArray = ['billing', 'delivery'];
 
-		foreach ($typeArray as $type) {
-			if (
-				isset($requiredInfoFieldArray) &&
-				is_array($requiredInfoFieldArray) &&
-				isset($requiredInfoFieldArray[$type])
-			) {
-				$requiredInfoFields[$type] = $requiredInfoFieldArray[$type];
-			} else {
-				$requiredInfoFields[$type] = trim($conf['requiredInfoFields'] ?? '');
-			}
+        foreach ($typeArray as $type) {
+            if (
+                isset($requiredInfoFieldArray) &&
+                is_array($requiredInfoFieldArray) &&
+                isset($requiredInfoFieldArray[$type])
+            ) {
+                $requiredInfoFields[$type] = $requiredInfoFieldArray[$type];
+            } else {
+                $requiredInfoFields[$type] = trim($conf['requiredInfoFields'] ?? '');
+            }
 
-			$addRequiredInfoFields =
-				PaymentShippingHandling::getAddRequiredInfoFields(
-					$type,
-					$basketExtra
-				);
+            $addRequiredInfoFields =
+                PaymentShippingHandling::getAddRequiredInfoFields(
+                    $type,
+                    $basketExtra
+                );
 
-			if ($addRequiredInfoFields != '') {
-				$requiredInfoFields[$type] .= ',' . $addRequiredInfoFields;
-			}
-		}
+            if ($addRequiredInfoFields != '') {
+                $requiredInfoFields[$type] .= ',' . $addRequiredInfoFields;
+            }
+        }
 
-		self::setRequiredInfoFields($requiredInfoFields);
-	}
-
-
-	static public function setBillingInfo (array $value) {
-		if (
-			isset($value['name']) &&
-			isset($value['email'])
-		) {
-			self::$billingInfo = $value;
-		}
-	}
+        self::setRequiredInfoFields($requiredInfoFields);
+    }
 
 
-	static public function getBillingInfo () {
-		return self::$billingInfo;
-	}
+    static public function setBillingInfo (array $value) {
+        if (
+            isset($value['name']) &&
+            isset($value['email'])
+        ) {
+            self::$billingInfo = $value;
+        }
+    }
 
 
-	static public function setShippingInfo (array $value) {
-		if (
-			isset($value['name']) &&
-			isset($value['email'])
-		) {
-			self::$shippingInfo = $value;
-		}
-	}
+    static public function getBillingInfo () {
+        return self::$billingInfo;
+    }
 
 
-	static public function getShippingInfo () {
-		return self::$shippingInfo;
-	}
+    static public function setShippingInfo (array $value) {
+        if (
+            isset($value['name']) &&
+            isset($value['email'])
+        ) {
+            self::$shippingInfo = $value;
+        }
+    }
 
 
-	static public function getBillingIso3 ($defaultValue = '') {
-		$result = '';
-
-		$billingInfo = self::getBillingInfo();
-
-		if (
-			is_array($billingInfo) &&
-			isset($billingInfo['static_info_country'])
-		) {
-			$result = $billingInfo['static_info_country'];
-		} else if ($defaultValue != '') {
-			$result = $defaultValue;
-		}
-
-		return $result;
-	}
+    static public function getShippingInfo () {
+        return self::$shippingInfo;
+    }
 
 
-	static public function setFields ($fields) {
-		self::$fields = $fields;
-	}
+    static public function getBillingIso3 ($defaultValue = '') {
+        $result = '';
+
+        $billingInfo = self::getBillingInfo();
+
+        if (
+            is_array($billingInfo) &&
+            isset($billingInfo['static_info_country'])
+        ) {
+            $result = $billingInfo['static_info_country'];
+        } else if ($defaultValue != '') {
+            $result = $defaultValue;
+        }
+
+        return $result;
+    }
 
 
-	static public function getFields () {
-		return self::$fields;
-	}
+    static public function setFields ($fields) {
+        self::$fields = $fields;
+    }
 
 
-	static public function getCreditPointFields () {
-		return self::$creditpointfields;
-	}
+    static public function getFields () {
+        return self::$fields;
+    }
 
 
-	static public function setRequiredInfoFields ($requiredInfoFields) {
-		self::$requiredInfoFields = $requiredInfoFields;
-	}
+    static public function getCreditPointFields () {
+        return self::$creditpointfields;
+    }
 
 
-	/**
-	 * Checks if required fields are filled in
-	 */
-	static public function getRequiredInfoFields ($type) {
-		$result = false;
-		if (
-			isset(self::$requiredInfoFields[$type]) &&
-			!empty(self::$requiredInfoFields[$type])
-		) {
-			$result = self::$requiredInfoFields[$type];
-		}
-
-		return $result;
-	}
+    static public function setRequiredInfoFields ($requiredInfoFields) {
+        self::$requiredInfoFields = $requiredInfoFields;
+    }
 
 
-	static public function getPossibleCheckField () {
-		$requiredInfoFields = self::getRequiredInfoFields('billing');
-		$checkField = '';
-		foreach (self::$possibleCheckFieldArray as $possibleCheckField) {
-			if (GeneralUtility::inList($requiredInfoFields, $possibleCheckField)) {
-				$checkField = $possibleCheckField;
-				break;
-			}
-		}
+    /**
+     * Checks if required fields are filled in
+     */
+    static public function getRequiredInfoFields ($type) {
+        $result = false;
+        if (
+            isset(self::$requiredInfoFields[$type]) &&
+            !empty(self::$requiredInfoFields[$type])
+        ) {
+            $result = self::$requiredInfoFields[$type];
+        }
 
-		return $checkField;
-	}
+        return $result;
+    }
+
+
+    static public function getPossibleCheckField () {
+        $requiredInfoFields = self::getRequiredInfoFields('billing');
+        $checkField = '';
+        foreach (self::$possibleCheckFieldArray as $possibleCheckField) {
+            if (GeneralUtility::inList($requiredInfoFields, $possibleCheckField)) {
+                $checkField = $possibleCheckField;
+                break;
+            }
+        }
+
+        return $checkField;
+    }
 
 
 }

--- a/Classes/Api/PaymentApi.php
+++ b/Classes/Api/PaymentApi.php
@@ -40,78 +40,78 @@ namespace JambageCom\TtProducts\Api;
  */
 
 class PaymentApi {
-	static private $storeRecord;
-	static private $storeIso3;
+    static private $storeRecord;
+    static private $storeIso3;
 
-	static public function setStoreRecord ($value) {
-		self::$storeRecord = $value;
-		if (
-			isset($value) &&
-			is_array($value) &&
-			isset($value['static_info_country'])
-		) {
-			self::setStoreIso3($value['static_info_country']);
-		}
-	}
+    static public function setStoreRecord ($value) {
+        self::$storeRecord = $value;
+        if (
+            isset($value) &&
+            is_array($value) &&
+            isset($value['static_info_country'])
+        ) {
+            self::setStoreIso3($value['static_info_country']);
+        }
+    }
 
-	static public function getStoreRecord () {
-		return self::$storeRecord;
-	}
+    static public function getStoreRecord () {
+        return self::$storeRecord;
+    }
 
-	static public function setStoreIso3 ($value) {
-		self::$storeIso3 = $value;
-	}
+    static public function setStoreIso3 ($value) {
+        self::$storeIso3 = $value;
+    }
 
-	static public function getStoreIso3 ($defaultValue = '') {
-		$result = '';
+    static public function getStoreIso3 ($defaultValue = '') {
+        $result = '';
 
-		if (
-			self::$storeIso3 != ''
-		) {
-			$result = self::$storeIso3;
-		} else if ($defaultValue != '') {
-			$result = $defaultValue;
-		}
+        if (
+            self::$storeIso3 != ''
+        ) {
+            $result = self::$storeIso3;
+        } else if ($defaultValue != '') {
+            $result = $defaultValue;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
     static public function getPayMode (
         \JambageCom\Div2007\Base\TranslationBase $languageObj,
         $basketExtra
     ) {
-		$result = 0;
+        $result = 0;
 
-		if (
-			isset($basketExtra) &&
-			is_array($basketExtra) &&
-			isset($basketExtra['payment.']) &&
-			isset($basketExtra['payment.']['mode'])
-		) {
-			$modeText = $basketExtra['payment.']['mode'];
-			$theTable = 'sys_products_orders';
+        if (
+            isset($basketExtra) &&
+            is_array($basketExtra) &&
+            isset($basketExtra['payment.']) &&
+            isset($basketExtra['payment.']['mode'])
+        ) {
+            $modeText = $basketExtra['payment.']['mode'];
+            $theTable = 'sys_products_orders';
 
-			$colName = 'pay_mode';
-			$textSchema = $theTable . '.' . $colName . '.I.';
-			$i = 0;
-			do {
+            $colName = 'pay_mode';
+            $textSchema = $theTable . '.' . $colName . '.I.';
+            $i = 0;
+            do {
                 $usedLang = 'default';
-				$text = $languageObj->getLabel(
-					$textSchema . $i,
-					$usedLang
-				);
+                $text = $languageObj->getLabel(
+                    $textSchema . $i,
+                    $usedLang
+                );
 
-				$text = str_replace(' ', '_', $text);
-				if ($text == $modeText) {
-					$result = $i;
-					break;
-				}
-				$i++;
-			} while ($text != '' && $i < 99);
-		}
+                $text = str_replace(' ', '_', $text);
+                if ($text == $modeText) {
+                    $result = $i;
+                    break;
+                }
+                $i++;
+            } while ($text != '' && $i < 99);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 }
 

--- a/Classes/Api/PaymentShippingHandling.php
+++ b/Classes/Api/PaymentShippingHandling.php
@@ -79,255 +79,255 @@ class PaymentShippingHandling {
 
 
     static public function setPriceObj ($value) {
-		self::$priceObj = $value;
-	}
+        self::$priceObj = $value;
+    }
 
 
-	static public function getPriceObj () {
-		return self::$priceObj;
-	}
+    static public function getPriceObj () {
+        return self::$priceObj;
+    }
 
 
-	static public function getScriptPrices (
-		&$calculatedArray,
-		&$itemArray,
-		$basketExtra,
-		$pskey = 'shipping'
-	) {
-		$hookVar = 'scriptPrices';
-		if (
-			$hookVar &&
-			isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
-			is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
-			isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey]) &&
-			is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey])
-		) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init();
-				}
-				if (method_exists($hookObj, 'getScriptPrices')) {
-					$tmpArray =
-						$hookObj->getScriptPrices(
-							$calculatedArray,
-							$itemArray,
-							$basketExtra,
-							$pskey
-						);
-				}
-			}
-		}
-	}
+    static public function getScriptPrices (
+        &$calculatedArray,
+        &$itemArray,
+        $basketExtra,
+        $pskey = 'shipping'
+    ) {
+        $hookVar = 'scriptPrices';
+        if (
+            $hookVar &&
+            isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
+            is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
+            isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey]) &&
+            is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey])
+        ) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar][$pskey] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init();
+                }
+                if (method_exists($hookObj, 'getScriptPrices')) {
+                    $tmpArray =
+                        $hookObj->getScriptPrices(
+                            $calculatedArray,
+                            $itemArray,
+                            $basketExtra,
+                            $pskey
+                        );
+                }
+            }
+        }
+    }
 
 
-	static protected function helperSubpartArray (
-		$markerPrefix,
-		$bActive,
-		$keyMarker,
-		$confRow,
-		$framework,
-		$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
-		$theMarker = '###' . $markerPrefix . '_' . $keyMarker . '###';
+    static protected function helperSubpartArray (
+        $markerPrefix,
+        $bActive,
+        $keyMarker,
+        $confRow,
+        $framework,
+        $markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
+        $theMarker = '###' . $markerPrefix . '_' . $keyMarker . '###';
 
-		if ($bActive) {
-			$wrappedSubpartArray[$theMarker] = '';
-		} else {
-			$subpartArray[$theMarker] = '';
-		}
-	}
+        if ($bActive) {
+            $wrappedSubpartArray[$theMarker] = '';
+        } else {
+            $subpartArray[$theMarker] = '';
+        }
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the subpartArray with data depending on payment and shipping
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @access private
-	 */
-	static public function getSubpartArrays (
-		$basketExtra,
-		$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$framework
-	) {
+    /**
+     * Template marker substitution
+     * Fills in the subpartArray with data depending on payment and shipping
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @access private
+     */
+    static public function getSubpartArrays (
+        $basketExtra,
+        $markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $framework
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
 
-		$typeArray = self::getTypeArray();
-		$psArray = ['payment', 'shipping'];
-		$psMessageArray = [];
-		$tmpSubpartArray = [];
+        $typeArray = self::getTypeArray();
+        $psArray = ['payment', 'shipping'];
+        $psMessageArray = [];
+        $tmpSubpartArray = [];
 
-		$handleLib = $basketExtra['payment.']['handleLib'] ?? '';
+        $handleLib = $basketExtra['payment.']['handleLib'] ?? '';
 
-		if (
-			strpos($handleLib, 'transactor') !== false &&
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
-		) {
+        if (
+            strpos($handleLib, 'transactor') !== false &&
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
+        ) {
             $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-				// Payment Transactor
-			\tx_transactor_api::init($languageObj, '', $conf);
+                // Payment Transactor
+            \tx_transactor_api::init($languageObj, '', $conf);
 
-			\tx_transactor_api::getItemMarkerSubpartArrays(
-				$basketExtra['payment.']['handleLib.'] ?? '',
-				$subpartArray,
-				$wrappedSubpartArray
-			);
-		} else {	// markers for the missing payment transactor extension
-			$wrappedSubpartArray['###MESSAGE_PAYMENT_TRANSACTOR_NO###'] = '';
-			$subpartArray['###MESSAGE_PAYMENT_TRANSACTOR_YES###'] = '';
-		}
+            \tx_transactor_api::getItemMarkerSubpartArrays(
+                $basketExtra['payment.']['handleLib.'] ?? '',
+                $subpartArray,
+                $wrappedSubpartArray
+            );
+        } else {	// markers for the missing payment transactor extension
+            $wrappedSubpartArray['###MESSAGE_PAYMENT_TRANSACTOR_NO###'] = '';
+            $subpartArray['###MESSAGE_PAYMENT_TRANSACTOR_YES###'] = '';
+        }
 
-		foreach($typeArray as $k => $pskey) {
+        foreach($typeArray as $k => $pskey) {
 
-			if (in_array($pskey, $psArray)) {
-				$marker = strtoupper($pskey);
-				$markerPrefix = 'MESSAGE_' . $marker;
-				$keyArray = $basketExtra[$pskey] ?? [];
-				if (!is_array($keyArray)) {
-					$keyArray = [$keyArray];
-				}
-				$psKey = '';
-				$psMessageArray[$pskey] = '';
+            if (in_array($pskey, $psArray)) {
+                $marker = strtoupper($pskey);
+                $markerPrefix = 'MESSAGE_' . $marker;
+                $keyArray = $basketExtra[$pskey] ?? [];
+                if (!is_array($keyArray)) {
+                    $keyArray = [$keyArray];
+                }
+                $psKey = '';
+                $psMessageArray[$pskey] = '';
 
-				foreach ($keyArray as $k => $value) {
-					if ($psKey) {
-						$psKey .= '_';
-					}
-					$psKey .= $value;
-					$subFrameWork = $templateService->getSubpart($framework, '###' . $markerPrefix . '###');
+                foreach ($keyArray as $k => $value) {
+                    if ($psKey) {
+                        $psKey .= '_';
+                    }
+                    $psKey .= $value;
+                    $subFrameWork = $templateService->getSubpart($framework, '###' . $markerPrefix . '###');
 
-					if ($subFrameWork != '') {
-						$tmpSubpartArray[$pskey] = $templateService->getSubpart($subFrameWork, '###MESSAGE_' . $marker . '_' . $psKey . '###');
-						$psMessageArray[$pskey] .= $templateService->substituteMarkerArray($tmpSubpartArray[$pskey], $markerArray);
-					}
-					$subpartArray['###MESSAGE_' . $marker . '_NE_' . $psKey . '###'] = '';
-				}
-			}
-		}
-		$tagArray = $markerObj->getAllMarkers($framework);
+                    if ($subFrameWork != '') {
+                        $tmpSubpartArray[$pskey] = $templateService->getSubpart($subFrameWork, '###MESSAGE_' . $marker . '_' . $psKey . '###');
+                        $psMessageArray[$pskey] .= $templateService->substituteMarkerArray($tmpSubpartArray[$pskey], $markerArray);
+                    }
+                    $subpartArray['###MESSAGE_' . $marker . '_NE_' . $psKey . '###'] = '';
+                }
+            }
+        }
+        $tagArray = $markerObj->getAllMarkers($framework);
 
-		foreach($typeArray as $k => $pskey) {
-			$marker = strtoupper($pskey);
-			$markerPrefix = 'MESSAGE_' . $marker;
+        foreach($typeArray as $k => $pskey) {
+            $marker = strtoupper($pskey);
+            $markerPrefix = 'MESSAGE_' . $marker;
 
-			if (isset($conf[$pskey . '.']) && is_array($conf[$pskey . '.'])) {
-				foreach($conf[$pskey . '.'] as $k2 => $v2) {
+            if (isset($conf[$pskey . '.']) && is_array($conf[$pskey . '.'])) {
+                foreach($conf[$pskey . '.'] as $k2 => $v2) {
 
-					$k2int = substr($k2, 0, -1);
+                    $k2int = substr($k2, 0, -1);
 
-					if (
-						!MathUtility::canBeInterpretedAsInteger($k2int)
-					) {
-						continue;
-					}
+                    if (
+                        !MathUtility::canBeInterpretedAsInteger($k2int)
+                    ) {
+                        continue;
+                    }
 
-					if ($pskey == 'handling') {
-						if (is_array($v2)) {
-							foreach ($v2 as $k3 => $v3) {
-								$k3int = substr($k3, 0, -1);
-								if (
-									!MathUtility::canBeInterpretedAsInteger($k3int)
-								) {
-									continue;
-								}
-								$bActive = isset($basketExtra[$pskey . '.'][$k3int]['0']) && ($k3int == $basketExtra[$pskey . '.'][$k3int]['0']);
-								self::helperSubpartArray(
-									$markerPrefix . '_' . $k2int,
-									$bActive,
-									$k3int,
-									$v3,
-									$framework,
-									$markerArray,
-									$subpartArray,
-									$wrappedSubpartArray
-								);
-							}
-						}
-					} else {
-						$bActive = isset($basketExtra[$pskey][0]) && ($k2int == $basketExtra[$pskey][0]);
-						self::helperSubpartArray(
-							$markerPrefix,
-							$bActive,
-							$k2int,
-							$v2,
-							$framework,
-							$markerArray,
-							$subpartArray,
-							$wrappedSubpartArray
-						);
-					}
-				}
-			}
-			$bCheckNE = in_array($pskey, $psArray);
+                    if ($pskey == 'handling') {
+                        if (is_array($v2)) {
+                            foreach ($v2 as $k3 => $v3) {
+                                $k3int = substr($k3, 0, -1);
+                                if (
+                                    !MathUtility::canBeInterpretedAsInteger($k3int)
+                                ) {
+                                    continue;
+                                }
+                                $bActive = isset($basketExtra[$pskey . '.'][$k3int]['0']) && ($k3int == $basketExtra[$pskey . '.'][$k3int]['0']);
+                                self::helperSubpartArray(
+                                    $markerPrefix . '_' . $k2int,
+                                    $bActive,
+                                    $k3int,
+                                    $v3,
+                                    $framework,
+                                    $markerArray,
+                                    $subpartArray,
+                                    $wrappedSubpartArray
+                                );
+                            }
+                        }
+                    } else {
+                        $bActive = isset($basketExtra[$pskey][0]) && ($k2int == $basketExtra[$pskey][0]);
+                        self::helperSubpartArray(
+                            $markerPrefix,
+                            $bActive,
+                            $k2int,
+                            $v2,
+                            $framework,
+                            $markerArray,
+                            $subpartArray,
+                            $wrappedSubpartArray
+                        );
+                    }
+                }
+            }
+            $bCheckNE = in_array($pskey, $psArray);
 
-			foreach($tagArray as $k3 => $v3) {
+            foreach($tagArray as $k3 => $v3) {
 
-				if (strpos($k3, $markerPrefix) === 0 && !isset($subpartArray['###' . $k3 . '###'])) {
+                if (strpos($k3, $markerPrefix) === 0 && !isset($subpartArray['###' . $k3 . '###'])) {
 
-					if ($bCheckNE && strpos($k3, '_NE_') !== false) {
-						$wrappedSubpartArray['###' . $k3 . '###'] = '';
-						$tmpSubpartArray[$pskey] = $templateService->getSubpart($framework, '###' . $k3 . '###');
-						$psMessageArray[$pskey] .=
-							$templateService->substituteMarkerArrayCached(
-								$tmpSubpartArray[$pskey],
-								$markerArray
-							);
-					} else if (!isset($wrappedSubpartArray['###' . $k3 . '###'])) {
-						$subpartArray['###' . $k3 . '###'] = '';
-					}
-				}
-			}
+                    if ($bCheckNE && strpos($k3, '_NE_') !== false) {
+                        $wrappedSubpartArray['###' . $k3 . '###'] = '';
+                        $tmpSubpartArray[$pskey] = $templateService->getSubpart($framework, '###' . $k3 . '###');
+                        $psMessageArray[$pskey] .=
+                            $templateService->substituteMarkerArrayCached(
+                                $tmpSubpartArray[$pskey],
+                                $markerArray
+                            );
+                    } else if (!isset($wrappedSubpartArray['###' . $k3 . '###'])) {
+                        $subpartArray['###' . $k3 . '###'] = '';
+                    }
+                }
+            }
 
-			$subpartArray['###' . $markerPrefix . '###'] = $psMessageArray[$pskey] ?? [];
-		}
-	}
+            $subpartArray['###' . $markerPrefix . '###'] = $psMessageArray[$pskey] ?? [];
+        }
+    }
 
 
-	static protected function getTypeMarkerArray (
-		$theCode,
-		&$markerArray,
-		$pskey,
-		$subkey,
-		$pid,
-		$useBackPid,
-		$calculatedArray,
-		$basketExtra
-	) {
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+    static protected function getTypeMarkerArray (
+        $theCode,
+        &$markerArray,
+        $pskey,
+        $subkey,
+        $pid,
+        $useBackPid,
+        $calculatedArray,
+        $basketExtra
+    ) {
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
-		if ($subkey != '') {
-			$theCalculateArray = $calculatedArray[$pskey][$subkey];
-		} else {
-			$theCalculateArray = $calculatedArray[$pskey];
-		}
-		if (!is_array($theCalculateArray)) {
-			$theCalculateArray = [];
-		}
+        if ($subkey != '') {
+            $theCalculateArray = $calculatedArray[$pskey][$subkey];
+        } else {
+            $theCalculateArray = $calculatedArray[$pskey];
+        }
+        if (!is_array($theCalculateArray)) {
+            $theCalculateArray = [];
+        }
 
-		$markerkey = strtoupper($pskey) . ($subkey != '' ? '_' . $subkey : '');
-		$markerArray['###PRICE_' . $markerkey . '_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceTax']);
-		$markerArray['###PRICE_' . $markerkey . '_NO_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceNoTax']);
-		$markerArray['###PRICE_' . $markerkey . '_ONLY_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceTax'] - $theCalculateArray['priceNoTax']);
-		$markerArray['###' . $markerkey . '_SELECTOR###'] =
-			self::generateRadioSelect(
-				$theCode,
-				$pskey,
-				$subkey,
-				$calculatedArray,
-				$pid,
-				$useBackPid,
-				$basketExtra
-			);
+        $markerkey = strtoupper($pskey) . ($subkey != '' ? '_' . $subkey : '');
+        $markerArray['###PRICE_' . $markerkey . '_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceTax']);
+        $markerArray['###PRICE_' . $markerkey . '_NO_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceNoTax']);
+        $markerArray['###PRICE_' . $markerkey . '_ONLY_TAX###'] = $priceViewObj->priceFormat($theCalculateArray['priceTax'] - $theCalculateArray['priceNoTax']);
+        $markerArray['###' . $markerkey . '_SELECTOR###'] =
+            self::generateRadioSelect(
+                $theCode,
+                $pskey,
+                $subkey,
+                $calculatedArray,
+                $pid,
+                $useBackPid,
+                $basketExtra
+            );
 
         $imageCode = '';
         $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
@@ -347,137 +347,137 @@ class PaymentShippingHandling {
             $markerArray['###' . $markerkey . '_TITLE###'] = $basketExtra[$pskey . '.']['title'];
         }
 
-		$markerArray['###' . $markerkey . '_IMAGE###'] = $imageCode;
-	}
+        $markerArray['###' . $markerkey . '_IMAGE###'] = $imageCode;
+    }
 
 
-	static public function getMarkerArray (
-		$theCode,
-		&$markerArray,
-		$pid,
-		$useBackPid,
-		$calculatedArray,
-		$basketExtra
-	) {
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+    static public function getMarkerArray (
+        $theCode,
+        &$markerArray,
+        $pid,
+        $useBackPid,
+        $calculatedArray,
+        $basketExtra
+    ) {
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
 
-		// payment
-		self::getTypeMarkerArray(
-			$theCode,
-			$markerArray,
-			'payment',
-			'',
-			$pid,
-			$useBackPid,
-			$calculatedArray,
-			$basketExtra
-		);
+        // payment
+        self::getTypeMarkerArray(
+            $theCode,
+            $markerArray,
+            'payment',
+            '',
+            $pid,
+            $useBackPid,
+            $calculatedArray,
+            $basketExtra
+        );
 
-		// shipping
-		self::getTypeMarkerArray(
-			$theCode,
-			$markerArray,
-			'shipping',
-			'',
-			$pid,
-			$useBackPid,
-			$calculatedArray,
-			$basketExtra
-		);
+        // shipping
+        self::getTypeMarkerArray(
+            $theCode,
+            $markerArray,
+            'shipping',
+            '',
+            $pid,
+            $useBackPid,
+            $calculatedArray,
+            $basketExtra
+        );
 
-		$markerArray['###SHIPPING_WEIGHT###'] = doubleval($calculatedArray['weight']);
-		$markerArray['###DELIVERYCOSTS###'] = $priceViewObj->priceFormat(self::getDeliveryCosts($calculatedArray));
+        $markerArray['###SHIPPING_WEIGHT###'] = doubleval($calculatedArray['weight']);
+        $markerArray['###DELIVERYCOSTS###'] = $priceViewObj->priceFormat(self::getDeliveryCosts($calculatedArray));
 
- 		if (isset($basketExtra['handling.'])) {
+        if (isset($basketExtra['handling.'])) {
 
 // 			foreach ($basketExtra['handling.'] as $k => $confArray)	{
 // 				$this->getTypeMarkerArray($markerArray, 'handling', $basketUrl);
 // 			}
 
- 			foreach ($basketExtra['handling.'] as $k => $confArray) {
-				if (strpos($k,'.') == strlen($k) - 1) {
+            foreach ($basketExtra['handling.'] as $k => $confArray) {
+                if (strpos($k,'.') == strlen($k) - 1) {
 
-					$k1 = substr($k,0,strlen($k) - 1);
-					if (
-						MathUtility::canBeInterpretedAsInteger($k1)
-					) {
-						self::getTypeMarkerArray(
-							$theCode,
-							$markerArray,
-							'handling',
-							$k1,
-							$pid,
-							$useBackPid,
-							$calculatedArray,
-							$basketExtra
-						);
-					}
-				}
-			}
- 		}
-	}
-
-
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	array		marker array
-	 * @return	array
-	 * @access private
-	 */
-	static public function getModelMarkerArray (
-		$theCode,
-		$title,
-		$value,
-		$imageCode,
-		$activeArray,
-		&$markerArray
-	) {
-			// Returns a markerArray ready for substitution with information for the tt_producst record, $row
-
-		$markerArray['###VALUE###'] = $value;
-		$markerArray['###CHECKED###'] = ($value == implode('-', $activeArray) ? ' checked="checked"' : '');
-		$markerArray['###TITLE###'] = $title;
-		$markerArray['###IMAGE###'] = $imageCode;
-	}
+                    $k1 = substr($k,0,strlen($k) - 1);
+                    if (
+                        MathUtility::canBeInterpretedAsInteger($k1)
+                    ) {
+                        self::getTypeMarkerArray(
+                            $theCode,
+                            $markerArray,
+                            'handling',
+                            $k1,
+                            $pid,
+                            $useBackPid,
+                            $calculatedArray,
+                            $basketExtra
+                        );
+                    }
+                }
+            }
+        }
+    }
 
 
-	/**
-	 * Generates a radio or selector box for payment shipping
-	 */
-	static public function generateRadioSelect (
-		$theCode,
-		$pskey,
-		$subkey,
-		$calculatedArray,
-		$pid,
-		$useBackPid,
-		&$basketExtra
-	) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	array		marker array
+     * @return	array
+     * @access private
+     */
+    static public function getModelMarkerArray (
+        $theCode,
+        $title,
+        $value,
+        $imageCode,
+        $activeArray,
+        &$markerArray
+    ) {
+            // Returns a markerArray ready for substitution with information for the tt_producst record, $row
+
+        $markerArray['###VALUE###'] = $value;
+        $markerArray['###CHECKED###'] = ($value == implode('-', $activeArray) ? ' checked="checked"' : '');
+        $markerArray['###TITLE###'] = $title;
+        $markerArray['###IMAGE###'] = $imageCode;
+    }
+
+
+    /**
+     * Generates a radio or selector box for payment shipping
+     */
+    static public function generateRadioSelect (
+        $theCode,
+        $pskey,
+        $subkey,
+        $calculatedArray,
+        $pid,
+        $useBackPid,
+        &$basketExtra
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
 
 /*
-			The conf-array for the payment/shipping/handling configuration has numeric keys for the elements
-			But there are also these properties:
-			.radio	  [boolean]	Enables radiobuttons instead of the default, selector-boxes
-			.wrap		[string]	<select>|</select> - wrap for the selectorboxes.  Only if .radio is false. See default value below
-			.template	[string]	Template string for the display of radiobuttons.  Only if .radio is true. See default below
-			*/
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$active = $basketExtra[$pskey] ?? '';
+            The conf-array for the payment/shipping/handling configuration has numeric keys for the elements
+            But there are also these properties:
+            .radio	  [boolean]	Enables radiobuttons instead of the default, selector-boxes
+            .wrap		[string]	<select>|</select> - wrap for the selectorboxes.  Only if .radio is false. See default value below
+            .template	[string]	Template string for the display of radiobuttons.  Only if .radio is true. See default below
+            */
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $active = $basketExtra[$pskey] ?? '';
         $activeArray = is_array($active) ? $active : (empty($active) ? [] : [$active]);
-		$bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-		$selectedText = ($bUseXHTML ? 'selected="selected"' : 'selected');
-		$type = 0;
-		$wrap = '';
-		$confArray = [];
+        $bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $selectedText = ($bUseXHTML ? 'selected="selected"' : 'selected');
+        $type = 0;
+        $wrap = '';
+        $confArray = [];
         $htmlInputAddition = '';
 
         if ($subkey != '') {
@@ -501,13 +501,13 @@ class PaymentShippingHandling {
             }
         }
 
-		if (
-			!MathUtility::canBeInterpretedAsInteger($type)
-		) {
-			$type = 0;
-		}
+        if (
+            !MathUtility::canBeInterpretedAsInteger($type)
+        ) {
+            $type = 0;
+        }
 
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
         $linkConf = [];
         $linkUrl = htmlspecialchars(
             FrontendUtility::getTypoLink_URL(
@@ -523,235 +523,235 @@ class PaymentShippingHandling {
                 $linkConf
             )
         );
-		$out = '';
-		$submitCode = 'this.form.action=\'' . $linkUrl . '\';this.form.submit();';
+        $out = '';
+        $submitCode = 'this.form.action=\'' . $linkUrl . '\';this.form.submit();';
 
-		$template = '';
-		if (
-			isset($confArray['template']) &&
-			$confArray['template'] != ''
-		) {
-			$template =
-				preg_replace(
-					['/###PSKEY###/', '/###INPUTADDITION###/', '/###SUBMIT###/'],
-					[$pskey, $htmlInputAddition, $submitCode],
-					$confArray['template']
-				);
-		} else {
-			$template =
-				'<input type="radio" name="recs[tt_products][' . $pskey . ']' . $htmlInputAddition . '" onClick="' . $submitCode . '" value="###VALUE###"###CHECKED###> ###TITLE### &nbsp;&nbsp;&nbsp; ###IMAGE###<br>';
-		}
+        $template = '';
+        if (
+            isset($confArray['template']) &&
+            $confArray['template'] != ''
+        ) {
+            $template =
+                preg_replace(
+                    ['/###PSKEY###/', '/###INPUTADDITION###/', '/###SUBMIT###/'],
+                    [$pskey, $htmlInputAddition, $submitCode],
+                    $confArray['template']
+                );
+        } else {
+            $template =
+                '<input type="radio" name="recs[tt_products][' . $pskey . ']' . $htmlInputAddition . '" onClick="' . $submitCode . '" value="###VALUE###"###CHECKED###> ###TITLE### &nbsp;&nbsp;&nbsp; ###IMAGE###<br>';
+        }
 
-		$wrap = $wrap ? $wrap : '<select id="' . $pskey . ($subkey != '' ? '-' . $subkey : '') . '-select" name="recs[tt_products][' . $pskey . ']' . $htmlInputAddition . '" onChange="' . $submitCode . '">|</select>';
-		$t = [];
-		$localBasketExtra = [];
-		if ($subkey != '') {
-			$localBasketExtra = $basketExtra[$pskey . '.'][$subkey . '.'] ?? [];
-		} else {
-			$localBasketExtra = $basketExtra[$pskey . '.'] ?? [];
-		}
+        $wrap = $wrap ? $wrap : '<select id="' . $pskey . ($subkey != '' ? '-' . $subkey : '') . '-select" name="recs[tt_products][' . $pskey . ']' . $htmlInputAddition . '" onChange="' . $submitCode . '">|</select>';
+        $t = [];
+        $localBasketExtra = [];
+        if ($subkey != '') {
+            $localBasketExtra = $basketExtra[$pskey . '.'][$subkey . '.'] ?? [];
+        } else {
+            $localBasketExtra = $basketExtra[$pskey . '.'] ?? [];
+        }
 
-		$actTitle = $localBasketExtra['title'] ?? '';
+        $actTitle = $localBasketExtra['title'] ?? '';
         $confArray = \tx_ttproducts_control_basket::cleanConfArr($confArray);
-		$bWrapSelect = (count($confArray) > 1);
+        $bWrapSelect = (count($confArray) > 1);
 
-		if (is_array($confArray)) {
-			foreach($confArray as $key => $item) {
+        if (is_array($confArray)) {
+            foreach($confArray as $key => $item) {
 
                 if (
-					(!isset($item['show']) || $item['show']) &&
-					(
-						!isset($item['showLimit']) ||
-						doubleval($item['showLimit']) >= doubleval($calculatedArray['count']) ||
-						intval($item['showLimit']) == 0
-					)
-				) {
+                    (!isset($item['show']) || $item['show']) &&
+                    (
+                        !isset($item['showLimit']) ||
+                        doubleval($item['showLimit']) >= doubleval($calculatedArray['count']) ||
+                        intval($item['showLimit']) == 0
+                    )
+                ) {
                     if (empty($activeArray)) { 
                     // TODO: Make it configurable if the first item of the payment/shipping setup shall automatically be made active.
                         $activeArray = [$key];
                     }
-					$addItems = [];
-					$itemTable = '';
-					$itemTableView = '';
-					$tableName = '';
+                    $addItems = [];
+                    $itemTable = '';
+                    $itemTableView = '';
+                    $tableName = '';
 
-					if (
+                    if (
                         isset($item['where.']) &&
-						$item['where.'] != '' &&
-						(strpos($item['title'], '###') !== false)
-					) {
-						$tableName = key($item['where.']);
-						$itemTableView = $tablesObj->get($tableName, true);
-						$itemTable = $itemTableView->getModelObj();
+                        $item['where.'] != '' &&
+                        (strpos($item['title'], '###') !== false)
+                    ) {
+                        $tableName = key($item['where.']);
+                        $itemTableView = $tablesObj->get($tableName, true);
+                        $itemTable = $itemTableView->getModelObj();
 
-						if (($tableName == 'static_countries') && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables')) {
-							$viewTagArray = [];
+                        if (($tableName == 'static_countries') && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables')) {
+                            $viewTagArray = [];
 
-							if (is_object($itemTable)) {
-								$markerFieldArray = [];
-								$parentArray = [];
-								$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-								$fieldsArray = $markerObj->getMarkerFields(
-									$item['title'],
-									$itemTable->getTableObj()->tableFieldArray,
-									$itemTable->getTableObj()->requiredFieldArray,
-									$markerFieldArray,
-									$itemTable->marker,
-									$viewTagArray,
-									$parentArray
-								);
+                            if (is_object($itemTable)) {
+                                $markerFieldArray = [];
+                                $parentArray = [];
+                                $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+                                $fieldsArray = $markerObj->getMarkerFields(
+                                    $item['title'],
+                                    $itemTable->getTableObj()->tableFieldArray,
+                                    $itemTable->getTableObj()->requiredFieldArray,
+                                    $markerFieldArray,
+                                    $itemTable->marker,
+                                    $viewTagArray,
+                                    $parentArray
+                                );
 
-								$addItems =
-									$itemTable->get(
-										'',
-										0,
-										false,
-										$item['where.'][$tableName],
-										'',
-										'',
-										'',
-										implode(',', $fieldsArray)
-									);
-							}
-						}
-					}
+                                $addItems =
+                                    $itemTable->get(
+                                        '',
+                                        0,
+                                        false,
+                                        $item['where.'][$tableName],
+                                        '',
+                                        '',
+                                        '',
+                                        implode(',', $fieldsArray)
+                                    );
+                            }
+                        }
+                    }
 
-					if (empty($addItems)) {
-						$addItems = ['0' => ''];
-					}
+                    if (empty($addItems)) {
+                        $addItems = ['0' => ''];
+                    }
 
-					if (
-						isset($addItems) &&
-						is_array($addItems)
-					) {
-						if ($type) {	// radio
+                    if (
+                        isset($addItems) &&
+                        is_array($addItems)
+                    ) {
+                        if ($type) {	// radio
 
-							foreach($addItems as $k1 => $row) {
-								$image = '';
-								if (isset($item['image.'])) {
-									$image = $item['image.'];
-								}
-								$title = $item['title'];
+                            foreach($addItems as $k1 => $row) {
+                                $image = '';
+                                if (isset($item['image.'])) {
+                                    $image = $item['image.'];
+                                }
+                                $title = $item['title'];
 
-								if (is_array($row) && $tableName != '') {
+                                if (is_array($row) && $tableName != '') {
 
-									if (
-										isset($itemTableView) &&
-										is_object($itemTableView)
-									) {
-										$markerArray = [];
-										$itemTableView->getRowMarkerArray(
-											$tableName,
-											$row,
-											$markerArray,
-											$fieldsArray
-										);
-										if (strpos($title, '###') !== false) {
-											$title = $templateService->substituteMarkerArrayCached($title, $markerArray);
-										}
-									}
+                                    if (
+                                        isset($itemTableView) &&
+                                        is_object($itemTableView)
+                                    ) {
+                                        $markerArray = [];
+                                        $itemTableView->getRowMarkerArray(
+                                            $tableName,
+                                            $row,
+                                            $markerArray,
+                                            $fieldsArray
+                                        );
+                                        if (strpos($title, '###') !== false) {
+                                            $title = $templateService->substituteMarkerArrayCached($title, $markerArray);
+                                        }
+                                    }
 
-									$value = $key . '-' . $row['uid'];
-									if ($value == implode('-', $activeArray)) {
-										$actTitle = $title;
-									}
-									if (isset($row['image.'])) {
-										$image = $row['image.'];
-									}
-								} else {
-									$value = $key;
-								}
-								$markerArray = [];
-								$imageCode = '';
+                                    $value = $key . '-' . $row['uid'];
+                                    if ($value == implode('-', $activeArray)) {
+                                        $actTitle = $title;
+                                    }
+                                    if (isset($row['image.'])) {
+                                        $image = $row['image.'];
+                                    }
+                                } else {
+                                    $value = $key;
+                                }
+                                $markerArray = [];
+                                $imageCode = '';
 
-								if ($image != '') {
+                                if ($image != '') {
                                     $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
                                     $imageCode =
                                         $imageObj->getImageCode(
                                             $image,
                                             $theCode
                                         );
-								}
+                                }
 
-								self::getModelMarkerArray(
-									$theCode,
-									$title,
-									$value,
-									$imageCode,
-									$activeArray,
-									$markerArray
-								);
+                                self::getModelMarkerArray(
+                                    $theCode,
+                                    $title,
+                                    $value,
+                                    $imageCode,
+                                    $activeArray,
+                                    $markerArray
+                                );
 
-								$out .= $templateService->substituteMarkerArrayCached($template, $markerArray) . chr(10);
-							}
-						} else {
-							foreach ($addItems as $k1 => $row) {
-								if (is_array($row) && $tableName != '') {
-									$markerArray = [];
-									$itemTableView->getRowMarkerArray(
-										$tableName,
-										$row,
-										$markerArray,
-										$fieldsArray
-									);
-									$title = $templateService->substituteMarkerArrayCached($item['title'], $markerArray);
-									$title = htmlentities($title, ENT_QUOTES, 'UTF-8');
-									$value = $key . '-' . $row['uid'];
-									if ($value == implode('-', $activeArray)) {
-										$actTitle = $item['title'];
-									}
-								} else {
-									$value = $key;
-									$title = $item['title'];
-								}
+                                $out .= $templateService->substituteMarkerArrayCached($template, $markerArray) . chr(10);
+                            }
+                        } else {
+                            foreach ($addItems as $k1 => $row) {
+                                if (is_array($row) && $tableName != '') {
+                                    $markerArray = [];
+                                    $itemTableView->getRowMarkerArray(
+                                        $tableName,
+                                        $row,
+                                        $markerArray,
+                                        $fieldsArray
+                                    );
+                                    $title = $templateService->substituteMarkerArrayCached($item['title'], $markerArray);
+                                    $title = htmlentities($title, ENT_QUOTES, 'UTF-8');
+                                    $value = $key . '-' . $row['uid'];
+                                    if ($value == implode('-', $activeArray)) {
+                                        $actTitle = $item['title'];
+                                    }
+                                } else {
+                                    $value = $key;
+                                    $title = $item['title'];
+                                }
 
-								if ($bWrapSelect) {
-									$out .= '<option value="' . $value . '"' . ($value == implode('-', $activeArray) ? ' ' . $selectedText : '') . '>' . $title . '</option>' . chr(10);
-								} else {
-									$out .= $title;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+                                if ($bWrapSelect) {
+                                    $out .= '<option value="' . $value . '"' . ($value == implode('-', $activeArray) ? ' ' . $selectedText : '') . '>' . $title . '</option>' . chr(10);
+                                } else {
+                                    $out .= $title;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		if (strpos($actTitle, '###')) {
-			$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-			$markerArray = [];
-			$viewTagArray = [];
-			$parentArray = [];
-			$tmp = [];
-			$fieldsArray = $markerObj->getMarkerFields(
-				$actTitle,
-				$tmp,
-				$tmp,
-				$tmp,
-				$itemTable->marker,
-				$viewTagArray,
-				$parentArray
-			);
+        if (strpos($actTitle, '###')) {
+            $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+            $markerArray = [];
+            $viewTagArray = [];
+            $parentArray = [];
+            $tmp = [];
+            $fieldsArray = $markerObj->getMarkerFields(
+                $actTitle,
+                $tmp,
+                $tmp,
+                $tmp,
+                $itemTable->marker,
+                $viewTagArray,
+                $parentArray
+            );
 
-			$markerArray = [];
-			foreach ($viewTagArray as $tag => $v) {
-				$markerArray['###' . $tag . '###'] = '?';
-			}
-			$actTitle = $templateService->substituteMarkerArrayCached($actTitle, $markerArray);
-		}
+            $markerArray = [];
+            foreach ($viewTagArray as $tag => $v) {
+                $markerArray['###' . $tag . '###'] = '?';
+            }
+            $actTitle = $templateService->substituteMarkerArrayCached($actTitle, $markerArray);
+        }
 
-		if ($subkey != '') {
-			$basketExtra[$pskey . '.'][$subkey . '.']['title'] = $actTitle;
-		} else {
-			$basketExtra[$pskey . '.']['title'] = $actTitle;
-		}
+        if ($subkey != '') {
+            $basketExtra[$pskey . '.'][$subkey . '.']['title'] = $actTitle;
+        } else {
+            $basketExtra[$pskey . '.']['title'] = $actTitle;
+        }
 
-		if (!$type && $bWrapSelect) {
-			$out = $cObj->wrap($out, $wrap);
-		}
+        if (!$type && $bWrapSelect) {
+            $out = $cObj->wrap($out, $wrap);
+        }
 
-		return $out;
-	} // generateRadioSelect
+        return $out;
+    } // generateRadioSelect
 
 
     static protected function matchCondition ($confArray, $calculatedArray, $key) {
@@ -771,63 +771,63 @@ class PaymentShippingHandling {
     }
 
 
-	static public function getConfiguredPrice (
-		$pskey,
-		$subkey,
-		$row,
-		$itemArray,
-		$calculatedArray,
-		$basketExtra,
-		$basketRecs,
-		&$confArray,
-		&$countTotal,
-		&$priceTotalTax,
-		&$priceTax,
-		&$priceNoTax,
+    static public function getConfiguredPrice (
+        $pskey,
+        $subkey,
+        $row,
+        $itemArray,
+        $calculatedArray,
+        $basketExtra,
+        $basketRecs,
+        &$confArray,
+        &$countTotal,
+        &$priceTotalTax,
+        &$priceTax,
+        &$priceNoTax,
         &$resetPrice,
-		&$funcParams = ''
-	) {
+        &$funcParams = ''
+    ) {
         $resetPrice = false;
 
-		if (
+        if (
             is_array($confArray) &&
             isset($confArray['type'])
         ) {
-			$minPrice = 0;
-			$priceNew = 0;
-			if (isset($confArray['WherePIDMinPrice.'])) {
-					// compare PIDList with values set in priceTaxWherePIDMinPrice in the SETUP
-					// if they match, get the min. price
-					// if more than one entry for priceTaxWherePIDMinPrice exists, the highest is value will be taken into account
-				foreach ($confArray['WherePIDMinPrice.'] as $minPricePID => $minPriceValue) {
-					foreach ($itemArray as $sort => $actItemArray) {
-						foreach ($actItemArray as $k1 => $actItem) {
-							$tmpRow = $actItem['rec'];
-							$pid = intval($tmpRow['pid']);
-							if ($pid == $minPricePID) {
-								$minPrice = $minPriceValue;
-							}
-						}
-					}
-				}
-			}
-			krsort($confArray);
+            $minPrice = 0;
+            $priceNew = 0;
+            if (isset($confArray['WherePIDMinPrice.'])) {
+                    // compare PIDList with values set in priceTaxWherePIDMinPrice in the SETUP
+                    // if they match, get the min. price
+                    // if more than one entry for priceTaxWherePIDMinPrice exists, the highest is value will be taken into account
+                foreach ($confArray['WherePIDMinPrice.'] as $minPricePID => $minPriceValue) {
+                    foreach ($itemArray as $sort => $actItemArray) {
+                        foreach ($actItemArray as $k1 => $actItem) {
+                            $tmpRow = $actItem['rec'];
+                            $pid = intval($tmpRow['pid']);
+                            if ($pid == $minPricePID) {
+                                $minPrice = $minPriceValue;
+                            }
+                        }
+                    }
+                }
+            }
+            krsort($confArray);
 
-			if (
+            if (
                 $confArray['type'] == 'count'
             ) {
-				foreach ($confArray as $k1 => $price1) {
-					if (
-						MathUtility::canBeInterpretedAsInteger($k1) &&
-						$countTotal >= $k1
-					) {
-						$priceNew = $price1;
-						break;
-					}
-				}
-			} else if ($confArray['type'] == 'weight') {
+                foreach ($confArray as $k1 => $price1) {
+                    if (
+                        MathUtility::canBeInterpretedAsInteger($k1) &&
+                        $countTotal >= $k1
+                    ) {
+                        $priceNew = $price1;
+                        break;
+                    }
+                }
+            } else if ($confArray['type'] == 'weight') {
 
-				foreach ($confArray as $k1 => $price1) {
+                foreach ($confArray as $k1 => $price1) {
                     if (
                         (
                             MathUtility::canBeInterpretedAsInteger($k1)
@@ -835,89 +835,89 @@ class PaymentShippingHandling {
                         self::matchCondition($confArray, $calculatedArray, $k1) &&
                         ($calculatedArray['weight'] * 1000 >= $k1)
                     ) {
-						$priceNew = $price1;
-						break;
-					}
-				}
-			} else if ($confArray['type'] == 'price') {
-				foreach ($confArray as $k1 => $price1) {
-					if (
-						(
-							MathUtility::canBeInterpretedAsInteger($k1)
-						) &&
-						$priceTotalTax >= $k1
-					) {
-						$priceNew = $price1;
-						break;
-					}
-				}
-			} else if (
-				$confArray['type'] == 'objectMethod' &&
-				isset($confArray['class'])
-			) {
-				$obj= GeneralUtility::makeInstance($confArray['class']);
-				if (method_exists($obj, 'getConfiguredPrice')) {
-					$funcParams1 = $confArray['method.'];
-					$priceNew =
-						$obj->getConfiguredPrice(
-							$pskey,
-							$subkey,
-							$row,
-							$itemArray,
-							$calculatedArray,
-							$basketExtra,
-							$basketRecs,
-							$confArray,
-							$countTotal,
-							$priceTotalTax,
-							$priceTax,
-							$priceNoTax,
-							$funcParams1
-						);
-				} else {
-					$priceNew = '0';
-				}
-			}
+                        $priceNew = $price1;
+                        break;
+                    }
+                }
+            } else if ($confArray['type'] == 'price') {
+                foreach ($confArray as $k1 => $price1) {
+                    if (
+                        (
+                            MathUtility::canBeInterpretedAsInteger($k1)
+                        ) &&
+                        $priceTotalTax >= $k1
+                    ) {
+                        $priceNew = $price1;
+                        break;
+                    }
+                }
+            } else if (
+                $confArray['type'] == 'objectMethod' &&
+                isset($confArray['class'])
+            ) {
+                $obj= GeneralUtility::makeInstance($confArray['class']);
+                if (method_exists($obj, 'getConfiguredPrice')) {
+                    $funcParams1 = $confArray['method.'];
+                    $priceNew =
+                        $obj->getConfiguredPrice(
+                            $pskey,
+                            $subkey,
+                            $row,
+                            $itemArray,
+                            $calculatedArray,
+                            $basketExtra,
+                            $basketRecs,
+                            $confArray,
+                            $countTotal,
+                            $priceTotalTax,
+                            $priceTax,
+                            $priceNoTax,
+                            $funcParams1
+                        );
+                } else {
+                    $priceNew = '0';
+                }
+            }
 
-			if(is_array($funcParams)) {
-				$hookObj= GeneralUtility::makeInstance($funcParams['class']);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init();
-				}
+            if(is_array($funcParams)) {
+                $hookObj= GeneralUtility::makeInstance($funcParams['class']);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init();
+                }
 
-				if (method_exists($hookObj, 'getConfiguredPrice')) {
-					$priceNew = $hookObj->getConfiguredPrice(
-						$pskey,
-						$subkey,
-						$row,
-						$itemArray,
-						$calculatedArray,
-						$confArray,
-						$basketExtra,
-						$basketRecs,
-						$countTotal,
-						$priceTotalTax,
-						$priceTax,
-						$priceNoTax,
-						$funcParams
-					);
-				};
-			}
+                if (method_exists($hookObj, 'getConfiguredPrice')) {
+                    $priceNew = $hookObj->getConfiguredPrice(
+                        $pskey,
+                        $subkey,
+                        $row,
+                        $itemArray,
+                        $calculatedArray,
+                        $confArray,
+                        $basketExtra,
+                        $basketRecs,
+                        $countTotal,
+                        $priceTotalTax,
+                        $priceTax,
+                        $priceNoTax,
+                        $funcParams
+                    );
+                };
+            }
 
-			// compare the price to the min. price
-			if ($minPrice > $priceNew) {
-				$priceNew = $minPrice;
-			}
+            // compare the price to the min. price
+            if ($minPrice > $priceNew) {
+                $priceNew = $minPrice;
+            }
 
             $resetPrice = false;
 
-			if (isset($confArray['noCostsAmount'])) {
-			// the total products price as from the payment/shipping is free
-				$noCostsAmount = (double) $confArray['noCostsAmount'];
+            if (isset($confArray['noCostsAmount'])) {
+            // the total products price as from the payment/shipping is free
+                $noCostsAmount = (double) $confArray['noCostsAmount'];
                 if ($priceTotalTax >= $noCostsAmount) {
                     $resetPrice = true;
                 }
-			}
+            }
 
             if (
                 isset($confArr['noCostsVoucher']) &&
@@ -928,153 +928,153 @@ class PaymentShippingHandling {
                 $resetPrice = true;
             }
 
-			if (isset($confArray['noCostsAmount.']) && isset($confArray['noCostsAmount.']['upTo'])) {
-				$noCostsAmount = (double) $confArray['noCostsAmount.']['upTo'];
-				if ($priceTotalTax <= $noCostsAmount) {
-					$resetPrice = true;
-				}
-			}
+            if (isset($confArray['noCostsAmount.']) && isset($confArray['noCostsAmount.']['upTo'])) {
+                $noCostsAmount = (double) $confArray['noCostsAmount.']['upTo'];
+                if ($priceTotalTax <= $noCostsAmount) {
+                    $resetPrice = true;
+                }
+            }
 
-			if ($resetPrice) {
-				$priceNew = 0;
-				$priceTax = $priceNoTax = 0;
-			}
+            if ($resetPrice) {
+                $priceNew = 0;
+                $priceTax = $priceNoTax = 0;
+            }
 
-			if (
-				isset($confArray['maximum']) &&
-				$priceTax > $confArray['maximum']
-			) {
-				$priceNew = 0;
-				$priceTax = $priceNoTax = $confArray['maximum'];
-			}
+            if (
+                isset($confArray['maximum']) &&
+                $priceTax > $confArray['maximum']
+            ) {
+                $priceNew = 0;
+                $priceTax = $priceNoTax = $confArray['maximum'];
+            }
 
-			$taxIncluded = self::$priceObj->getTaxIncluded();
-			$priceTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceNew,
-					1,
-					$row,
-					$taxIncluded,
-					true
-				);
-			$priceNoTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceNew,
-					0,
-					$row,
-					$taxIncluded,
-					true
-				);
-		}
-	}
-
-
-	static public function getDiscountPrices (
-		$pskey,
-		$confArray,
-		$row,
-		&$itemArray,
-		$basketExtra,
-		$basketRecs,
-		$taxIncluded,
-		$priceTotalTax,
-		&$discountArray,
-		&$priceTax,
-		&$priceNoTax
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-
-		if ($pskey == 'shipping') {
-			$calcSetup = 'shippingcalc';
-		} else if ($pskey == 'handling') {
-			$calcSetup = 'handlingcalc';
-		}
-
-		if (
-			$calcSetup != '' &&
-			isset($confArray['price.']) &&
-			is_array($confArray['price.']) &&
-			isset($confArray['price.']['calc.']) &&
-			isset($confArray['price.']['calc.']['use']) &&
-			isset($conf[$calcSetup . '.']) &&
-			is_array($conf[$calcSetup . '.'])
-		) {
-			$useArray = GeneralUtility::trimExplode(',', $confArray['price.']['calc.']['use']);
-			$specialCalc = [];
-
-			foreach ($conf[$calcSetup . '.'] as $k => $v) {
-				$kInt = trim($k, '.'); // substr($k, 0, strlen($k) - 1);
-				if (in_array($kInt, $useArray)) {
-					$specialCalc[$k] = $v;
-				}
-			}
-			$discountPriceObj = GeneralUtility::makeInstance('tx_ttproducts_discountprice');
-			$priceReduction = [];
-			$extMergeArray = ['tt_products_articles'];
-			$discountPriceObj->getCalculatedData(
-				$itemArray,
-				$specialCalc,
-				$pskey,
-				$priceReduction,
-				$discountArray,
-				$priceTotalTax,
-				false,
-				$taxIncluded,
-				true
-			);
-
-			if (is_array($discountArray) && count($discountArray)) {
-				$localPriceTotal = 0;
-				foreach ($discountArray as $uid => $price) {
-					$localPriceTotal += $price;
-				}
-				$priceTax =
-					$priceTax +
-					self::$priceObj->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$localPriceTotal,
-						true,
-						$row,
-						$taxIncluded,
-						true
-					);
-				$priceNoTax =
-					$priceNoTax +
-					self::$priceObj->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$localPriceTotal,
-						false,
-						$row,
-						$taxIncluded,
-						true
-					);
-			}
-		}
-	}
+            $taxIncluded = self::$priceObj->getTaxIncluded();
+            $priceTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceNew,
+                    1,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+            $priceNoTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceNew,
+                    0,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+        }
+    }
 
 
-	static public function addItemShippingPrices (
-		&$priceShippingTax,
-		&$priceShippingNoTax,
-		$row,
-		$basketExtra,
-		$basketRecs,
-		$taxIncluded,
-		$itemArray
-	)	{
+    static public function getDiscountPrices (
+        $pskey,
+        $confArray,
+        $row,
+        &$itemArray,
+        $basketExtra,
+        $basketRecs,
+        $taxIncluded,
+        $priceTotalTax,
+        &$discountArray,
+        &$priceTax,
+        &$priceNoTax
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
 
-		foreach ($itemArray as $sort => $actItemArray) {
+        if ($pskey == 'shipping') {
+            $calcSetup = 'shippingcalc';
+        } else if ($pskey == 'handling') {
+            $calcSetup = 'handlingcalc';
+        }
 
-			// $actItemArray = all items array
-			foreach ($actItemArray as $k2 => $actItem) {
-				$row = $actItem['rec'];
+        if (
+            $calcSetup != '' &&
+            isset($confArray['price.']) &&
+            is_array($confArray['price.']) &&
+            isset($confArray['price.']['calc.']) &&
+            isset($confArray['price.']['calc.']['use']) &&
+            isset($conf[$calcSetup . '.']) &&
+            is_array($conf[$calcSetup . '.'])
+        ) {
+            $useArray = GeneralUtility::trimExplode(',', $confArray['price.']['calc.']['use']);
+            $specialCalc = [];
+
+            foreach ($conf[$calcSetup . '.'] as $k => $v) {
+                $kInt = trim($k, '.'); // substr($k, 0, strlen($k) - 1);
+                if (in_array($kInt, $useArray)) {
+                    $specialCalc[$k] = $v;
+                }
+            }
+            $discountPriceObj = GeneralUtility::makeInstance('tx_ttproducts_discountprice');
+            $priceReduction = [];
+            $extMergeArray = ['tt_products_articles'];
+            $discountPriceObj->getCalculatedData(
+                $itemArray,
+                $specialCalc,
+                $pskey,
+                $priceReduction,
+                $discountArray,
+                $priceTotalTax,
+                false,
+                $taxIncluded,
+                true
+            );
+
+            if (is_array($discountArray) && count($discountArray)) {
+                $localPriceTotal = 0;
+                foreach ($discountArray as $uid => $price) {
+                    $localPriceTotal += $price;
+                }
+                $priceTax =
+                    $priceTax +
+                    self::$priceObj->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $localPriceTotal,
+                        true,
+                        $row,
+                        $taxIncluded,
+                        true
+                    );
+                $priceNoTax =
+                    $priceNoTax +
+                    self::$priceObj->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $localPriceTotal,
+                        false,
+                        $row,
+                        $taxIncluded,
+                        true
+                    );
+            }
+        }
+    }
+
+
+    static public function addItemShippingPrices (
+        &$priceShippingTax,
+        &$priceShippingNoTax,
+        $row,
+        $basketExtra,
+        $basketRecs,
+        $taxIncluded,
+        $itemArray
+    )	{
+
+        foreach ($itemArray as $sort => $actItemArray) {
+
+            // $actItemArray = all items array
+            foreach ($actItemArray as $k2 => $actItem) {
+                $row = $actItem['rec'];
 // 				$shippingPrice = $actItem['shipping'] + $row['shipping'];
 // 				$row['tax'] = $actItem['tax'];
 
@@ -1083,381 +1083,381 @@ class PaymentShippingHandling {
 // 					$priceShippingNoTax += $this->priceObj->getPrice($shippingPrice,false,$row,$taxIncluded,true);
 // 				}
 
-				if (!empty($row['bulkily'])) {
-					$value = floatval($basketExtra['shipping.']['bulkilyAddition'] ?? '') * $actItem['count'];
-					$row['tax'] = floatval($basketExtra['shipping.']['bulkilyFeeTax'] ?? 0);
-					$priceShippingTax +=
-						self::$priceObj->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$value,
-							true,
-							$row,
-							$taxIncluded,
-							true
-						);
+                if (!empty($row['bulkily'])) {
+                    $value = floatval($basketExtra['shipping.']['bulkilyAddition'] ?? '') * $actItem['count'];
+                    $row['tax'] = floatval($basketExtra['shipping.']['bulkilyFeeTax'] ?? 0);
+                    $priceShippingTax +=
+                        self::$priceObj->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $value,
+                            true,
+                            $row,
+                            $taxIncluded,
+                            true
+                        );
 
-					$priceShippingNoTax +=
-						self::$priceObj->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$value,
-							false,
-							$row,
-							$taxIncluded,
-							true
-						);
-				}
-			}
-		}
-	}
+                    $priceShippingNoTax +=
+                        self::$priceObj->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $value,
+                            false,
+                            $row,
+                            $taxIncluded,
+                            true
+                        );
+                }
+            }
+        }
+    }
 
 
-	static public function getPrices (
-		$basketExtra,
-		$basketRecs,
-		$taxIncluded,
-		$iso3Seller,
-		$iso3Buyer,
-		$pskey,
-		$subkey,
-		$row,
-		$pskeyConf,
-		$countTotal,
-		$priceTotalTax,
-		$itemArray,
-		&$calculatedArray,
-		&$priceTax,
-		&$priceNoTax,
+    static public function getPrices (
+        $basketExtra,
+        $basketRecs,
+        $taxIncluded,
+        $iso3Seller,
+        $iso3Buyer,
+        $pskey,
+        $subkey,
+        $row,
+        $pskeyConf,
+        $countTotal,
+        $priceTotalTax,
+        $itemArray,
+        &$calculatedArray,
+        &$priceTax,
+        &$priceNoTax,
         &$resetPrice 
-	) {
-		$cObj = FrontendUtility::getContentObjectRenderer();
+    ) {
+        $cObj = FrontendUtility::getContentObjectRenderer();
 
-		if (!empty($basketExtra[$pskey . '.'])) {
-			if (
-				$subkey != '' &&
-				!empty($basketExtra[$pskey . '.'][$subkey . '.'])
-			) {
-				$basketConf = $basketExtra[$pskey . '.'][$subkey . '.'];
-			} else {
-				$basketConf = $basketExtra[$pskey . '.'];
-			}
-		} else {
-			$basketConf = [];
-		}
+        if (!empty($basketExtra[$pskey . '.'])) {
+            if (
+                $subkey != '' &&
+                !empty($basketExtra[$pskey . '.'][$subkey . '.'])
+            ) {
+                $basketConf = $basketExtra[$pskey . '.'][$subkey . '.'];
+            } else {
+                $basketConf = $basketExtra[$pskey . '.'];
+            }
+        } else {
+            $basketConf = [];
+        }
 
-		if (isset($basketConf['TAXincluded'])) {
-			$taxIncluded = $basketConf['TAXincluded'];
-		}
-		$confArray = [];
-		if (isset($basketConf['price.'])) {
-			$confArray = $basketConf['price.'];
-		}
+        if (isset($basketConf['TAXincluded'])) {
+            $taxIncluded = $basketConf['TAXincluded'];
+        }
+        $confArray = [];
+        if (isset($basketConf['price.'])) {
+            $confArray = $basketConf['price.'];
+        }
 
-		self::$priceObj->init($cObj, $pskeyConf, 0);
-		if ($confArray) {
+        self::$priceObj->init($cObj, $pskeyConf, 0);
+        if ($confArray) {
             $tmp = '';
-			self::getConfiguredPrice(
-				$pskey,
-				$subkey,
-				$row,
-				$itemArray,
-				$calculatedArray,
-				$basketExtra,
-				$basketRecs,
-				$confArray,
-				$countTotal,
-				$priceTotalTax,
-				$priceTax,
-				$priceNoTax,
+            self::getConfiguredPrice(
+                $pskey,
+                $subkey,
+                $row,
+                $itemArray,
+                $calculatedArray,
+                $basketExtra,
+                $basketRecs,
+                $confArray,
+                $countTotal,
+                $priceTotalTax,
+                $priceTax,
+                $priceNoTax,
                 $resetPrice,
-				$tmp
-			);
-		} else if (isset($basketConf['price'])) {
-			$priceAdd = doubleVal($basketConf['price']);
+                $tmp
+            );
+        } else if (isset($basketConf['price'])) {
+            $priceAdd = doubleVal($basketConf['price']);
 
-			if ($priceAdd) {
-				$priceTaxAdd =
-					self::$priceObj->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceAdd,
-						true,
-						$row,
-						$taxIncluded,
-						true
-					);
-			} else {
-				$priceTaxAdd = doubleVal($basketConf['priceTax']);
-			}
-			$priceTax += $priceTaxAdd;
-			$priceNoTaxAdd = doubleVal($basketConf['priceNoTax']);
+            if ($priceAdd) {
+                $priceTaxAdd =
+                    self::$priceObj->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceAdd,
+                        true,
+                        $row,
+                        $taxIncluded,
+                        true
+                    );
+            } else {
+                $priceTaxAdd = doubleVal($basketConf['priceTax']);
+            }
+            $priceTax += $priceTaxAdd;
+            $priceNoTaxAdd = doubleVal($basketConf['priceNoTax']);
 
-			if (!$priceNoTaxAdd) {
-				$priceNoTaxAdd =
-					self::$priceObj->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceTaxAdd,
-						false,
-						$row,
-						true,
-						true
-					);
-			}
-			$priceNoTax += $priceNoTaxAdd;
-		}
+            if (!$priceNoTaxAdd) {
+                $priceNoTaxAdd =
+                    self::$priceObj->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceTaxAdd,
+                        false,
+                        $row,
+                        true,
+                        true
+                    );
+            }
+            $priceNoTax += $priceNoTaxAdd;
+        }
 
-		switch ($pskey) {
-			case 'payment':
-				$handleLib = '';
-				if (
-					!empty($basketConf) &&
-					isset($basketConf['handleLib']) &&
-					isset($basketConf['handleLib.'])
-				) {
-					$handleLib = $basketConf['handleLib'];
-				}
+        switch ($pskey) {
+            case 'payment':
+                $handleLib = '';
+                if (
+                    !empty($basketConf) &&
+                    isset($basketConf['handleLib']) &&
+                    isset($basketConf['handleLib.'])
+                ) {
+                    $handleLib = $basketConf['handleLib'];
+                }
 
-				if (
-					$handleLib &&
-					\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib) &&
-					isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]) &&
-					isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]['api'])
-				) {
-					$callingClassName = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]['api'];
-					$price = $priceTotalTax;
-					if (
-						isset($calculatedArray['handling']) &&
-						is_array($calculatedArray['handling'])
-					) {
-						foreach ($calculatedArray['handling'] as $handling) {
-							$price += $handling['priceTax'];
-						}
-					}
+                if (
+                    $handleLib &&
+                    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib) &&
+                    isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]) &&
+                    isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]['api'])
+                ) {
+                    $callingClassName = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$handleLib]['api'];
+                    $price = $priceTotalTax;
+                    if (
+                        isset($calculatedArray['handling']) &&
+                        is_array($calculatedArray['handling'])
+                    ) {
+                        foreach ($calculatedArray['handling'] as $handling) {
+                            $price += $handling['priceTax'];
+                        }
+                    }
 
-					if (
-						isset($calculatedArray['shipping']) &&
-						is_array($calculatedArray['shipping'])
-					) {
-						$price += $calculatedArray['shipping']['priceTax'];
-					}
+                    if (
+                        isset($calculatedArray['shipping']) &&
+                        is_array($calculatedArray['shipping'])
+                    ) {
+                        $price += $calculatedArray['shipping']['priceTax'];
+                    }
 
-					if (
-						isset($basketConf['handleLib.']['costs']) &&
-						$basketConf['handleLib.']['costs'] == 'auto' &&
-						class_exists($callingClassName) &&
-						method_exists($callingClassName, 'getCosts')
-					) {
-						$priceTax = $priceNoTax = call_user_func(
-							$callingClassName . '::getCosts',
-							$basketConf['handleLib.'],
-							$price,
-							$iso3Seller,
-							$iso3Buyer
-						);
-					}
-				}
-				break;
-			case 'shipping':
-				self::addItemShippingPrices(
-					$priceTax,
-					$priceNoTax,
-					$row,
-					$basketExtra,
-					$basketRecs,
-					$taxIncluded,
-					$itemArray
-				);
-				break;
-		}
-	}
+                    if (
+                        isset($basketConf['handleLib.']['costs']) &&
+                        $basketConf['handleLib.']['costs'] == 'auto' &&
+                        class_exists($callingClassName) &&
+                        method_exists($callingClassName, 'getCosts')
+                    ) {
+                        $priceTax = $priceNoTax = call_user_func(
+                            $callingClassName . '::getCosts',
+                            $basketConf['handleLib.'],
+                            $price,
+                            $iso3Seller,
+                            $iso3Buyer
+                        );
+                    }
+                }
+                break;
+            case 'shipping':
+                self::addItemShippingPrices(
+                    $priceTax,
+                    $priceNoTax,
+                    $row,
+                    $basketExtra,
+                    $basketRecs,
+                    $taxIncluded,
+                    $itemArray
+                );
+                break;
+        }
+    }
 
 
-	static public function getBasketConf (
-		$basketExtra,
-		$pskey,
-		$subkey = ''
-	) {
+    static public function getBasketConf (
+        $basketExtra,
+        $pskey,
+        $subkey = ''
+    ) {
         $basketConf = [];
-		if (isset($basketExtra[$pskey.'.'])) {
-			if ($subkey != '' && !empty($basketExtra[$pskey . '.'][$subkey . '.'])) {
-				$basketConf = $basketExtra[$pskey . '.'][$subkey . '.'];
-			} else if (
+        if (isset($basketExtra[$pskey.'.'])) {
+            if ($subkey != '' && !empty($basketExtra[$pskey . '.'][$subkey . '.'])) {
+                $basketConf = $basketExtra[$pskey . '.'][$subkey . '.'];
+            } else if (
                 isset($basketExtra[$pskey . '.'])
-			) {
-				$basketConf = $basketExtra[$pskey . '.'];
-			}
-		}
-		return $basketConf;
-	}
+            ) {
+                $basketConf = $basketExtra[$pskey . '.'];
+            }
+        }
+        return $basketConf;
+    }
 
 
-	static public function getSpecialPrices (
-		$basketExtra,
-		$basketRecs,
-		$pskey,
-		$subkey,
-		$row,
-		$calculatedArray,
-		&$priceShippingTax,
-		&$priceShippingNoTax
-	) {
-		$basketConf = self::getBasketConf($basketExtra, $pskey, $subkey);
+    static public function getSpecialPrices (
+        $basketExtra,
+        $basketRecs,
+        $pskey,
+        $subkey,
+        $row,
+        $calculatedArray,
+        &$priceShippingTax,
+        &$priceShippingNoTax
+    ) {
+        $basketConf = self::getBasketConf($basketExtra, $pskey, $subkey);
 
-		$perc = doubleVal($basketConf['percentOfGoodstotal'] ?? 0);
-		if ($perc)  {
-			$priceShipping = doubleVal(($calculatedArray['priceTax']['goodstotal']['ALL'] / 100) * $perc);
-			$dum = self::$priceObj->getPrice(
-				$basketExtra,
-				$basketRecs,
-				$priceShipping,
-				true,
-				$row
-			);
-			$taxIncluded = self::$priceObj->getTaxIncluded();
-			$priceShippingTax = $priceShippingTax +
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					true,
-					$row,
-					$taxIncluded,
-					true
-				);
-			$priceShippingNoTax = $priceShippingNoTax +
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					false,
-					$row,
-					$taxIncluded,
-					true
-				);
-		}
+        $perc = doubleVal($basketConf['percentOfGoodstotal'] ?? 0);
+        if ($perc)  {
+            $priceShipping = doubleVal(($calculatedArray['priceTax']['goodstotal']['ALL'] / 100) * $perc);
+            $dum = self::$priceObj->getPrice(
+                $basketExtra,
+                $basketRecs,
+                $priceShipping,
+                true,
+                $row
+            );
+            $taxIncluded = self::$priceObj->getTaxIncluded();
+            $priceShippingTax = $priceShippingTax +
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    true,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+            $priceShippingNoTax = $priceShippingNoTax +
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    false,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+        }
 
-		$calculationScript = $basketConf['calculationScript'] ?? '';
-		if ($calculationScript != '') {
+        $calculationScript = $basketConf['calculationScript'] ?? '';
+        if ($calculationScript != '') {
             $calcScript = '';
             $sanitizer = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class);
             $calcScript = $sanitizer->sanitize($calculationScript);
 
-			if ($calcScript) {
-				$confScript = $basketConf['calculationScript.'];
-				include($calcScript);
-			}
-		}
-	}
+            if ($calcScript) {
+                $confScript = $basketConf['calculationScript.'];
+                include($calcScript);
+            }
+        }
+    }
 
 
-	static public function getPaymentShippingData (
-		$basketExtra,
-		$basketRecs,
-		$conf,
-		$iso3Seller,
-		$iso3Buyer,
-		$countTotal,
-		$priceTotalTax,
-		$shippingRow,
-		$paymentRow,
-		$itemArray,
-		&$calculatedArray,
-		&$priceShippingTax,
-		&$priceShippingNoTax,
-		&$pricePaymentTax,
-		&$pricePaymentNoTax
-	) {
-		$row = $shippingRow;
-		$taxIncluded = self::$priceObj->getTaxIncluded();
+    static public function getPaymentShippingData (
+        $basketExtra,
+        $basketRecs,
+        $conf,
+        $iso3Seller,
+        $iso3Buyer,
+        $countTotal,
+        $priceTotalTax,
+        $shippingRow,
+        $paymentRow,
+        $itemArray,
+        &$calculatedArray,
+        &$priceShippingTax,
+        &$priceShippingNoTax,
+        &$pricePaymentTax,
+        &$pricePaymentNoTax
+    ) {
+        $row = $shippingRow;
+        $taxIncluded = self::$priceObj->getTaxIncluded();
 
-		$weigthFactor = doubleVal($basketExtra['shipping.']['priceFactWeight'] ?? 0);
-		if($weigthFactor > 0) {
-			$priceShipping = $calculatedArray['weight'] * $weigthFactor;
-			$priceShippingTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					true,
-					$row,
-					$taxIncluded,
-					true
-				);
-			$priceShippingNoTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					false,
-					$row,
-					$taxIncluded,
-					true
-				);
-		}
+        $weigthFactor = doubleVal($basketExtra['shipping.']['priceFactWeight'] ?? 0);
+        if($weigthFactor > 0) {
+            $priceShipping = $calculatedArray['weight'] * $weigthFactor;
+            $priceShippingTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    true,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+            $priceShippingNoTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    false,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+        }
 
-		$countFactor = doubleVal($basketExtra['shipping.']['priceFactCount'] ?? 0);
-		if($countFactor > 0) {
-			$priceShipping = $countTotal * $countFactor;
-			$priceShippingTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					true,
-					$row,
-					$taxIncluded,
-					true
-				);
-			$priceShippingNoTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceShipping,
-					false,
-					$row,
-					$taxIncluded,
-					true
-				);
-		}
+        $countFactor = doubleVal($basketExtra['shipping.']['priceFactCount'] ?? 0);
+        if($countFactor > 0) {
+            $priceShipping = $countTotal * $countFactor;
+            $priceShippingTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    true,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+            $priceShippingNoTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceShipping,
+                    false,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+        }
 
-		self::getSpecialPrices(
-			$basketExtra,
-			$basketRecs,
-			'shipping',
-			'',
-			$row,
-			$calculatedArray,
-			$priceShippingTax,
-			$priceShippingNoTax
-		);
+        self::getSpecialPrices(
+            $basketExtra,
+            $basketRecs,
+            'shipping',
+            '',
+            $row,
+            $calculatedArray,
+            $priceShippingTax,
+            $priceShippingNoTax
+        );
 
-		$pskeyConf = [];
-		if (isset($conf['shipping.'])) {
-			$pskeyConf = $conf['shipping.'];
-		}
+        $pskeyConf = [];
+        if (isset($conf['shipping.'])) {
+            $pskeyConf = $conf['shipping.'];
+        }
         $resetPrice = false;
-		self::getPrices(
-			$basketExtra,
-			$basketRecs,
-			$taxIncluded,
-			$iso3Seller,
-			$iso3Buyer,
-			'shipping',
-			'',
-			$row,
-			$pskeyConf,
-			$countTotal,
-			$priceTotalTax,
-			$itemArray,
-			$calculatedArray,
-			$priceShippingTax,
-			$priceShippingNoTax,
+        self::getPrices(
+            $basketExtra,
+            $basketRecs,
+            $taxIncluded,
+            $iso3Seller,
+            $iso3Buyer,
+            'shipping',
+            '',
+            $row,
+            $pskeyConf,
+            $countTotal,
+            $priceTotalTax,
+            $itemArray,
+            $calculatedArray,
+            $priceShippingTax,
+            $priceShippingNoTax,
             $resetPrice
-		);
+        );
 
-		if (!$resetPrice) {
+        if (!$resetPrice) {
 
             $discountArray = [];
             $basketConf = self::getBasketConf($basketExtra, 'shipping');
@@ -1477,384 +1477,384 @@ class PaymentShippingHandling {
             );
         }
 
-			// Payment
-		$pricePayment = $pricePaymentTax = $pricePaymentNoTax = 0;
-		$taxpercentage = '';
-		$row = $paymentRow;
-		$payment = 0;
-		$perc = doubleVal($basketExtra['payment.']['percentOfTotalShipping'] ?? 0);
-		if ($perc) {
-			$payment = ($calculatedArray['priceTax']['goodstotal']['ALL'] + $calculatedArray['shipping']['priceTax'] ) * doubleVal($perc);
-		}
+            // Payment
+        $pricePayment = $pricePaymentTax = $pricePaymentNoTax = 0;
+        $taxpercentage = '';
+        $row = $paymentRow;
+        $payment = 0;
+        $perc = doubleVal($basketExtra['payment.']['percentOfTotalShipping'] ?? 0);
+        if ($perc) {
+            $payment = ($calculatedArray['priceTax']['goodstotal']['ALL'] + $calculatedArray['shipping']['priceTax'] ) * doubleVal($perc);
+        }
 
-		if ($payment) {
-			$pricePaymentTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$payment,
-					true,
-					$row,
-					$taxIncluded,
-					true
-				);
-			$pricePaymentNoTax +=
-				self::$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$payment,
-					false,
-					$row,
-					$taxIncluded,
-					true
-				);
-		}
+        if ($payment) {
+            $pricePaymentTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $payment,
+                    true,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+            $pricePaymentNoTax +=
+                self::$priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $payment,
+                    false,
+                    $row,
+                    $taxIncluded,
+                    true
+                );
+        }
 
-		self::getSpecialPrices(
-			$basketExtra,
-			$basketRecs,
-			'payment',
-			'',
-			$row,
-			$calculatedArray,
-			$pricePaymentTax,
-			$pricePaymentNoTax
-		);
+        self::getSpecialPrices(
+            $basketExtra,
+            $basketRecs,
+            'payment',
+            '',
+            $row,
+            $calculatedArray,
+            $pricePaymentTax,
+            $pricePaymentNoTax
+        );
 
-		$pskeyConf = [];
-		if (!empty($conf['payment.'])) {
-			$pskeyConf = $conf['payment.'];
-		}
-		self::getPrices(
-			$basketExtra,
-			$basketRecs,
-			$taxIncluded,
-			$iso3Seller,
-			$iso3Buyer,
-			'payment',
-			'',
-			$row,
-			$pskeyConf,
-			$countTotal,
-			$priceTotalTax,
-			$itemArray,
-			$calculatedArray,
-			$pricePaymentTax,
-			$pricePaymentNoTax,
+        $pskeyConf = [];
+        if (!empty($conf['payment.'])) {
+            $pskeyConf = $conf['payment.'];
+        }
+        self::getPrices(
+            $basketExtra,
+            $basketRecs,
+            $taxIncluded,
+            $iso3Seller,
+            $iso3Buyer,
+            'payment',
+            '',
+            $row,
+            $pskeyConf,
+            $countTotal,
+            $priceTotalTax,
+            $itemArray,
+            $calculatedArray,
+            $pricePaymentTax,
+            $pricePaymentNoTax,
             $resetPrice
-		);
-	} // getPaymentShippingData
+        );
+    } // getPaymentShippingData
 
 
-	static public function getHandlingData (
-			$basketExtra,
-			$basketRecs,
-			$conf,
-			$iso3Seller,
-			$iso3Buyer,
-			$countTotal,
-			$priceTotalTax,
-			&$calculatedArray,
-			$itemArray
-		) {
-		$taxIncluded = self::$priceObj->getTaxIncluded();
+    static public function getHandlingData (
+            $basketExtra,
+            $basketRecs,
+            $conf,
+            $iso3Seller,
+            $iso3Buyer,
+            $countTotal,
+            $priceTotalTax,
+            &$calculatedArray,
+            $itemArray
+        ) {
+        $taxIncluded = self::$priceObj->getTaxIncluded();
 
-		if (
-			isset($basketExtra['handling.']) &&
-			is_array($basketExtra['handling.'])
-		) {
-			$pskey = 'handling';
-			$pskeyConf = [];
-			if (isset($conf[$pskey . '.'])) {
-				$pskeyConf = $conf[$pskey . '.'];
-			}
+        if (
+            isset($basketExtra['handling.']) &&
+            is_array($basketExtra['handling.'])
+        ) {
+            $pskey = 'handling';
+            $pskeyConf = [];
+            if (isset($conf[$pskey . '.'])) {
+                $pskeyConf = $conf[$pskey . '.'];
+            }
 
-			foreach ($basketExtra[$pskey . '.'] as $k => $handlingRow) {
+            foreach ($basketExtra[$pskey . '.'] as $k => $handlingRow) {
 
-				if (strpos($k, '.') == strlen($k) - 1) {
-					$k1 = substr($k, 0, strlen($k) - 1);
-					if  (
-						MathUtility::canBeInterpretedAsInteger($k1)
-					) {
-						$tax =
-							self::getTaxPercentage($basketExtra, $pskey, $k1);
-						$row = [];
-						if ($tax != '') {
-							$row[] = ['tax' => $tax];
-						}
+                if (strpos($k, '.') == strlen($k) - 1) {
+                    $k1 = substr($k, 0, strlen($k) - 1);
+                    if  (
+                        MathUtility::canBeInterpretedAsInteger($k1)
+                    ) {
+                        $tax =
+                            self::getTaxPercentage($basketExtra, $pskey, $k1);
+                        $row = [];
+                        if ($tax != '') {
+                            $row[] = ['tax' => $tax];
+                        }
 
-						$priceTax = '';
-						$priceNoTax = '';
+                        $priceTax = '';
+                        $priceNoTax = '';
 
-						$discountArray = [];
-						$basketConf =
-							self::getBasketConf($basketExtra, $pskey, $k1);
+                        $discountArray = [];
+                        $basketConf =
+                            self::getBasketConf($basketExtra, $pskey, $k1);
 
-						self::getDiscountPrices(
-							$pskey,
-							$basketConf,
-							$row,
-							$itemArray,
-							$basketExtra,
-							$basketRecs,
-							$taxIncluded,
-							$priceTotalTax,
-							$discountArray,
-							$priceTax,
-							$priceNoTax
-						);
-						self::getSpecialPrices(
-							$basketExtra,
-							$basketRecs,
-							$pskey,
-							$k1,
-							$row,
-							$calculatedArray,
-							$priceTax,
-							$priceNoTax
-						);
-						self::getPrices(
-							$basketExtra,
-							$basketRecs,
-							$taxIncluded,
-							$iso3Seller,
-							$iso3Buyer,
-							$pskey,
-							$k1,
-							$row,
-							$pskeyConf,
-							$countTotal,
-							$priceTotalTax,
-							$itemArray,
-							$calculatedArray,
-							$priceTax,
-							$priceNoTax,
+                        self::getDiscountPrices(
+                            $pskey,
+                            $basketConf,
+                            $row,
+                            $itemArray,
+                            $basketExtra,
+                            $basketRecs,
+                            $taxIncluded,
+                            $priceTotalTax,
+                            $discountArray,
+                            $priceTax,
+                            $priceNoTax
+                        );
+                        self::getSpecialPrices(
+                            $basketExtra,
+                            $basketRecs,
+                            $pskey,
+                            $k1,
+                            $row,
+                            $calculatedArray,
+                            $priceTax,
+                            $priceNoTax
+                        );
+                        self::getPrices(
+                            $basketExtra,
+                            $basketRecs,
+                            $taxIncluded,
+                            $iso3Seller,
+                            $iso3Buyer,
+                            $pskey,
+                            $k1,
+                            $row,
+                            $pskeyConf,
+                            $countTotal,
+                            $priceTotalTax,
+                            $itemArray,
+                            $calculatedArray,
+                            $priceTax,
+                            $priceNoTax,
                             $resetPrice
-						);
-						$calculatedArray[$pskey][$k1]['priceTax'] = $priceTax;
-						$calculatedArray[$pskey][$k1]['priceNoTax'] = $priceNoTax;
-					}
-				}
-			}
-		}
-	} // getHandlingData
+                        );
+                        $calculatedArray[$pskey][$k1]['priceTax'] = $priceTax;
+                        $calculatedArray[$pskey][$k1]['priceNoTax'] = $priceNoTax;
+                    }
+                }
+            }
+        }
+    } // getHandlingData
 
 
-	/**
-	 * Include handle script
-	 */
-	static public function includeHandleScript (
-		$handleScript,
-		$confScript,
-		$activity,
-		&$bFinalize,
-		$pibase,
-		$infoViewObj
-	) {
-		$content = '';
+    /**
+     * Include handle script
+     */
+    static public function includeHandleScript (
+        $handleScript,
+        $confScript,
+        $activity,
+        &$bFinalize,
+        $pibase,
+        $infoViewObj
+    ) {
+        $content = '';
 
-		include($handleScript);
-		return $content;
-	} // includeHandleScript
+        include($handleScript);
+        return $content;
+    } // includeHandleScript
 
 
-	/**
-	 * get the TAXpercentage from the shipping if available
-	 */
-	static public function getTaxPercentage (
-		$basketExtra,
-		$pskey = 'shipping',
-		$subkey = ''
-	) {
-		$result = 0;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
+    /**
+     * get the TAXpercentage from the shipping if available
+     */
+    static public function getTaxPercentage (
+        $basketExtra,
+        $pskey = 'shipping',
+        $subkey = ''
+    ) {
+        $result = 0;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
 
-		if (
-			$subkey == '' &&
-			!empty($basketExtra[$pskey . '.']) &&
-			isset($basketExtra[$pskey . '.']['TAXpercentage'])
-		) {
-			$result = doubleval($basketExtra[$pskey . '.']['TAXpercentage']);
-		} else if (
-			$subkey != '' &&
-			!empty($basketExtra[$pskey . '.']) &&
-			isset($basketExtra[$pskey . '.'][$subkey . '.']) &&
-			is_array($basketExtra[$pskey . '.'][$subkey . '.']) &&
-			isset($basketExtra[$pskey . '.'][$subkey . '.']['TAXpercentage'])
-		) {
-			$result = doubleval($basketExtra[$pskey . '.'][$subkey . '.']['TAXpercentage']);
-		} else {
-			if (
+        if (
+            $subkey == '' &&
+            !empty($basketExtra[$pskey . '.']) &&
+            isset($basketExtra[$pskey . '.']['TAXpercentage'])
+        ) {
+            $result = doubleval($basketExtra[$pskey . '.']['TAXpercentage']);
+        } else if (
+            $subkey != '' &&
+            !empty($basketExtra[$pskey . '.']) &&
+            isset($basketExtra[$pskey . '.'][$subkey . '.']) &&
+            is_array($basketExtra[$pskey . '.'][$subkey . '.']) &&
+            isset($basketExtra[$pskey . '.'][$subkey . '.']['TAXpercentage'])
+        ) {
+            $result = doubleval($basketExtra[$pskey . '.'][$subkey . '.']['TAXpercentage']);
+        } else {
+            if (
                 $subkey == '' &&
                 isset($conf[$pskey . '.']['TAXpercentage'])
             ) {
-				$result = doubleval($conf[$pskey . '.']['TAXpercentage']);
-			} else if (
-				isset($conf[$pskey . '.']) &&
-				isset($conf[$pskey . '.'][$subkey . '.']) &&
-				isset($conf[$pskey . '.'][$subkey . '.']['TAXpercentage'])
-			) {
-				$result = doubleval($conf[$pskey . '.'][$subkey . '.']['TAXpercentage']);
-			}
-		}
-		return $result;
-	}
+                $result = doubleval($conf[$pskey . '.']['TAXpercentage']);
+            } else if (
+                isset($conf[$pskey . '.']) &&
+                isset($conf[$pskey . '.'][$subkey . '.']) &&
+                isset($conf[$pskey . '.'][$subkey . '.']['TAXpercentage'])
+            ) {
+                $result = doubleval($conf[$pskey . '.'][$subkey . '.']['TAXpercentage']);
+            }
+        }
+        return $result;
+    }
 
 
-	/**
-	 * get the replaceTAXpercentage from the shipping if available
-	 */
-	static public function getReplaceTaxPercentage (
-		$basketExtra,
-		$pskey = 'shipping',
-		$itemTax = ''
-	) {
-		$result = '';
+    /**
+     * get the replaceTAXpercentage from the shipping if available
+     */
+    static public function getReplaceTaxPercentage (
+        $basketExtra,
+        $pskey = 'shipping',
+        $itemTax = ''
+    ) {
+        $result = '';
 
-		if (
-			!empty($basketExtra[$pskey . '.']) &&
-			isset($basketExtra[$pskey . '.']['replaceTAXpercentage'])
-		) {
-			$result = doubleval($basketExtra[$pskey . '.']['replaceTAXpercentage']);
-		}
+        if (
+            !empty($basketExtra[$pskey . '.']) &&
+            isset($basketExtra[$pskey . '.']['replaceTAXpercentage'])
+        ) {
+            $result = doubleval($basketExtra[$pskey . '.']['replaceTAXpercentage']);
+        }
 
-		if (
-			$itemTax != '' &&
-			!empty($basketExtra[$pskey . '.']) &&
-			isset($basketExtra[$pskey . '.']['replaceTAXpercentage.']) &&
-			is_array($basketExtra[$pskey . '.']['replaceTAXpercentage.'])
-		) {
-			$itemTax = doubleval($itemTax);
-			if (isset($basketExtra[$pskey . '.']['replaceTAXpercentage.'][$itemTax])) {
-				$result = doubleval($basketExtra[$pskey . '.']['replaceTAXpercentage.'][$itemTax]);
-			}
-		}
-		return $result;
-	}
-
-
-	/**
-	 * get the delivery costs
-	 */
-	static public function getDeliveryCosts ($calculatedArray) {
-		$result = $calculatedArray['shipping']['priceTax'] + $calculatedArray['payment']['priceTax'];
-		return $result;
-	}
+        if (
+            $itemTax != '' &&
+            !empty($basketExtra[$pskey . '.']) &&
+            isset($basketExtra[$pskey . '.']['replaceTAXpercentage.']) &&
+            is_array($basketExtra[$pskey . '.']['replaceTAXpercentage.'])
+        ) {
+            $itemTax = doubleval($itemTax);
+            if (isset($basketExtra[$pskey . '.']['replaceTAXpercentage.'][$itemTax])) {
+                $result = doubleval($basketExtra[$pskey . '.']['replaceTAXpercentage.'][$itemTax]);
+            }
+        }
+        return $result;
+    }
 
 
-	/**
-	 * get the where condition for a shipping entry
-	 * E.g.:  30.where.static_countries = cn_short_local = 'Deutschland'
-	 */
-	static public function getWhere ($basketExtra, $tablename) {
+    /**
+     * get the delivery costs
+     */
+    static public function getDeliveryCosts ($calculatedArray) {
+        $result = $calculatedArray['shipping']['priceTax'] + $calculatedArray['payment']['priceTax'];
+        return $result;
+    }
+
+
+    /**
+     * get the where condition for a shipping entry
+     * E.g.:  30.where.static_countries = cn_short_local = 'Deutschland'
+     */
+    static public function getWhere ($basketExtra, $tablename) {
 
         $result = '';
 
-		if (
-			isset($basketExtra['shipping.']) &&
-			!empty($basketExtra['shipping.']['where.'])
-		) {
-			switch ($tablename) {
-				case 'static_countries':
-					if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables')) {
-						$eInfo = ExtensionUtility::getExtensionInfo('static_info_tables');
-						$sitVersion = $eInfo['version'];
-					}
-					if (version_compare($sitVersion, '2.0.1', '>=')) {
-						$result = $basketExtra['shipping.']['where.'][$tablename];
-					}
-				break;
-			}
-		}
-		return $result;
-	}
+        if (
+            isset($basketExtra['shipping.']) &&
+            !empty($basketExtra['shipping.']['where.'])
+        ) {
+            switch ($tablename) {
+                case 'static_countries':
+                    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables')) {
+                        $eInfo = ExtensionUtility::getExtensionInfo('static_info_tables');
+                        $sitVersion = $eInfo['version'];
+                    }
+                    if (version_compare($sitVersion, '2.0.1', '>=')) {
+                        $result = $basketExtra['shipping.']['where.'][$tablename];
+                    }
+                break;
+            }
+        }
+        return $result;
+    }
 
 
-	static public function getAddRequiredInfoFields ($type, $basketExtra) {
-		$resultArray = [];
-		$pskeyArray = self::getTypeArray();
-		foreach ($pskeyArray as $pskey) {
-			if (
-				isset($basketExtra[$pskey . '.']) &&
-				is_array($basketExtra[$pskey . '.'])
-			) {
-				$tmp = '';
-				if (
-					isset($basketExtra[$pskey . '.']['addRequiredInfoFields.']) &&
-					isset($basketExtra[$pskey . '.']['addRequiredInfoFields.'][$type])
-				) {
-					$tmp = $basketExtra[$pskey . '.']['addRequiredInfoFields.'][$type];
-				} else if (
-					isset($basketExtra[$pskey . '.']['addRequiredInfoFields'])
+    static public function getAddRequiredInfoFields ($type, $basketExtra) {
+        $resultArray = [];
+        $pskeyArray = self::getTypeArray();
+        foreach ($pskeyArray as $pskey) {
+            if (
+                isset($basketExtra[$pskey . '.']) &&
+                is_array($basketExtra[$pskey . '.'])
+            ) {
+                $tmp = '';
+                if (
+                    isset($basketExtra[$pskey . '.']['addRequiredInfoFields.']) &&
+                    isset($basketExtra[$pskey . '.']['addRequiredInfoFields.'][$type])
                 ) {
-					$tmp = $basketExtra[$pskey . '.']['addRequiredInfoFields'];
-				}
+                    $tmp = $basketExtra[$pskey . '.']['addRequiredInfoFields.'][$type];
+                } else if (
+                    isset($basketExtra[$pskey . '.']['addRequiredInfoFields'])
+                ) {
+                    $tmp = $basketExtra[$pskey . '.']['addRequiredInfoFields'];
+                }
 
-				if ($tmp != '') {
-					$resultArray[] = trim($tmp);
-				}
-			}
-		}
-		$result = implode(',', $resultArray);
-		return $result;
-	}
-
-
-	static public function get ($pskey, $setup, $basketExtra) {
-		$result = '';
-		$tmp = $basketExtra[$pskey . '.'][$setup] ?? '';
-		if ($tmp != '') {
-			$result = trim($tmp);
-		}
-		return $result;
-	}
+                if ($tmp != '') {
+                    $resultArray[] = trim($tmp);
+                }
+            }
+        }
+        $result = implode(',', $resultArray);
+        return $result;
+    }
 
 
-	static public function useCreditcard ($basketExtra) {
-		$result = false;
-		$payConf = $basketExtra['payment.'] ?? [];
-		if (is_array($payConf) && !empty($payConf['creditcards'])) {
-			$result = true;
-		}
-		return $result;
-	}
+    static public function get ($pskey, $setup, $basketExtra) {
+        $result = '';
+        $tmp = $basketExtra[$pskey . '.'][$setup] ?? '';
+        if ($tmp != '') {
+            $result = trim($tmp);
+        }
+        return $result;
+    }
 
 
-	static public function useAccount ($basketExtra) {
-		$result = false;
-		$payConf = $basketExtra['payment.'] ?? [];
-		if (is_array($payConf) && !empty($payConf['accounts'])) {
-			$result = true;
-		}
-		return $result;
-	}
+    static public function useCreditcard ($basketExtra) {
+        $result = false;
+        $payConf = $basketExtra['payment.'] ?? [];
+        if (is_array($payConf) && !empty($payConf['creditcards'])) {
+            $result = true;
+        }
+        return $result;
+    }
 
 
-	static public function getHandleLib ($request, $basketExtra) {
+    static public function useAccount ($basketExtra) {
+        $result = false;
+        $payConf = $basketExtra['payment.'] ?? [];
+        if (is_array($payConf) && !empty($payConf['accounts'])) {
+            $result = true;
+        }
+        return $result;
+    }
 
-		$result = false;
-		$payConf = $basketExtra['payment.'] ?? [];
-		$handleLib = '';
 
-		if (is_array($payConf)) {
-			$handleLib = $payConf['handleLib'] ?? '';
-		}
+    static public function getHandleLib ($request, $basketExtra) {
 
-		if (
-			(
-				strpos($handleLib,'transactor') !== false ||
-				strpos($handleLib, 'paymentlib') !== false
-			) &&
-			isset($payConf['handleLib.']) &&
-			is_array($payConf['handleLib.']) &&
-			isset($payConf['handleLib.']['gatewaymode']) &&
-			$payConf['handleLib.']['gatewaymode'] == $request &&
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
-		) {
-			$result = $handleLib;
-		}
+        $result = false;
+        $payConf = $basketExtra['payment.'] ?? [];
+        $handleLib = '';
 
-		return $result;
-	}
+        if (is_array($payConf)) {
+            $handleLib = $payConf['handleLib'] ?? '';
+        }
+
+        if (
+            (
+                strpos($handleLib,'transactor') !== false ||
+                strpos($handleLib, 'paymentlib') !== false
+            ) &&
+            isset($payConf['handleLib.']) &&
+            is_array($payConf['handleLib.']) &&
+            isset($payConf['handleLib.']['gatewaymode']) &&
+            $payConf['handleLib.']['gatewaymode'] == $request &&
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
+        ) {
+            $result = $handleLib;
+        }
+
+        return $result;
+    }
 }

--- a/Classes/Api/PluginApi.php
+++ b/Classes/Api/PluginApi.php
@@ -56,8 +56,8 @@ abstract class RelatedProductsTypes {
 
 class PluginApi {
 
-	static private $bHasBeenInitialised = false;
-	static private $flexformArray = [];
+    static private $bHasBeenInitialised = false;
+    static private $flexformArray = [];
 
     static public function init ($conf) {
         $piVarsDefault = [];
@@ -142,8 +142,8 @@ class PluginApi {
         // ### central initialization ###
 
         if (!$bRunAjax) {
-		    $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
-		    $cObj->start([]);
+            $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
+            $cObj->start([]);
 
             $db = GeneralUtility::makeInstance('tx_ttproducts_db');
             $result =
@@ -173,293 +173,293 @@ class PluginApi {
         }
     }
 
-	static public function getFlexform () {
-		return self::$flexformArray;
-	}
+    static public function getFlexform () {
+        return self::$flexformArray;
+    }
 
-	static public function isRelatedCode ($code) {
-		$result = false;
-		if (
-			substr($code, 0, 11) == 'LISTRELATED'
-		) {
-			$result = true;
-		}
+    static public function isRelatedCode ($code) {
+        $result = false;
+        if (
+            substr($code, 0, 11) == 'LISTRELATED'
+        ) {
+            $result = true;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function initUrl (
-		&$urlObj,
-		$cObj,
-		$conf
-	) {
-		if (!isset($urlObj)) {
-			$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-			$urlObj->init($conf);
-		}
-	}
+    static public function initUrl (
+        &$urlObj,
+        $cObj,
+        $conf
+    ) {
+        if (!isset($urlObj)) {
+            $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+            $urlObj->init($conf);
+        }
+    }
 
-	static public function initAjax (
-		&$ajaxObj,
-		$urlObj,
-		$cObj,
-		$debug
-	) {
-		$result = true;
+    static public function initAjax (
+        &$ajaxObj,
+        $urlObj,
+        $cObj,
+        $debug
+    ) {
+        $result = true;
 
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
-			$ajaxObj = GeneralUtility::makeInstance('tx_ttproducts_ajax');
-			$result = $ajaxObj->init();
-			if (!$result) {
-				return false;
-			}
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+            $ajaxObj = GeneralUtility::makeInstance('tx_ttproducts_ajax');
+            $result = $ajaxObj->init();
+            if (!$result) {
+                return false;
+            }
 
-			$ajaxObj->main(
-				$cObj,
-				$urlObj,
-				$debug,
-				\tx_ttproducts_model_control::getPivar('tt_products'),
-				\tx_ttproducts_model_control::getPivar('tt_products_cat')
-			);
-		}
-		return $result;
-	}
+            $ajaxObj->main(
+                $cObj,
+                $urlObj,
+                $debug,
+                \tx_ttproducts_model_control::getPivar('tt_products'),
+                \tx_ttproducts_model_control::getPivar('tt_products_cat')
+            );
+        }
+        return $result;
+    }
 
-	static public function initConfig (
-		&$config,
-		&$conf,
-		&$pid,
-		&$pageAsCategory,
-		&$errorCode,
-		$backPID
-	) {
-		$eInfo = ExtensionUtility::getExtensionInfo(TT_PRODUCTS_EXT);
-		$config['version'] = $eInfo['version'];
+    static public function initConfig (
+        &$config,
+        &$conf,
+        &$pid,
+        &$pageAsCategory,
+        &$errorCode,
+        $backPID
+    ) {
+        $eInfo = ExtensionUtility::getExtensionInfo(TT_PRODUCTS_EXT);
+        $config['version'] = $eInfo['version'];
 
-		$config['defaultCategoryID'] = \JambageCom\Div2007\Utility\FlexformUtility::get(self::getFlexform(), 'categorySelection');
+        $config['defaultCategoryID'] = \JambageCom\Div2007\Utility\FlexformUtility::get(self::getFlexform(), 'categorySelection');
 
-		// get template suffix string
+        // get template suffix string
 
-		$config['templateSuffix'] = strtoupper($conf['templateSuffix'] ?? '');
+        $config['templateSuffix'] = strtoupper($conf['templateSuffix'] ?? '');
 
-		$templateSuffix = \JambageCom\Div2007\Utility\FlexformUtility::get(self::getFlexform(), 'template_suffix');
-		$templateSuffix = strtoupper($templateSuffix);
-		$config['templateSuffix'] = ($templateSuffix ? $templateSuffix : $config['templateSuffix']);
-		$config['templateSuffix'] = ($config['templateSuffix'] ? '_' . $config['templateSuffix'] : '');
-		$config['limit'] = $conf['limit'] ? $conf['limit'] : 50;
-		$config['limitImage'] = MathUtility::forceIntegerInRange($conf['limitImage'], 0, 50, 1);
-		$config['limitImage'] = $config['limitImage'] ? $config['limitImage'] : 1;
-		$config['limitImageSingle'] = MathUtility::forceIntegerInRange($conf['limitImageSingle'], 0, 50, 1);
-		$config['limitImageSingle'] = $config['limitImageSingle'] ? $config['limitImageSingle'] : 1;
+        $templateSuffix = \JambageCom\Div2007\Utility\FlexformUtility::get(self::getFlexform(), 'template_suffix');
+        $templateSuffix = strtoupper($templateSuffix);
+        $config['templateSuffix'] = ($templateSuffix ? $templateSuffix : $config['templateSuffix']);
+        $config['templateSuffix'] = ($config['templateSuffix'] ? '_' . $config['templateSuffix'] : '');
+        $config['limit'] = $conf['limit'] ? $conf['limit'] : 50;
+        $config['limitImage'] = MathUtility::forceIntegerInRange($conf['limitImage'], 0, 50, 1);
+        $config['limitImage'] = $config['limitImage'] ? $config['limitImage'] : 1;
+        $config['limitImageSingle'] = MathUtility::forceIntegerInRange($conf['limitImageSingle'], 0, 50, 1);
+        $config['limitImageSingle'] = $config['limitImageSingle'] ? $config['limitImageSingle'] : 1;
 
-		if (!empty($conf['priceNoReseller'])) {
-			$config['priceNoReseller'] = MathUtility::forceIntegerInRange($conf['priceNoReseller'], 2, 10);
-		}
+        if (!empty($conf['priceNoReseller'])) {
+            $config['priceNoReseller'] = MathUtility::forceIntegerInRange($conf['priceNoReseller'], 2, 10);
+        }
 
-			// If the current record should be displayed.
-		$config['displayCurrentRecord'] = $conf['displayCurrentRecord'] ?? '';
+            // If the current record should be displayed.
+        $config['displayCurrentRecord'] = $conf['displayCurrentRecord'] ?? '';
 
-		if (
+        if (
             empty($conf['TAXmode']) ||
-			$conf['TAXmode'] == '' ||
-			$conf['TAXmode'] == '{$plugin.tt_products.TAXmode}'
-		) {
-			$conf['TAXmode'] = 1;
-		}
+            $conf['TAXmode'] == '' ||
+            $conf['TAXmode'] == '{$plugin.tt_products.TAXmode}'
+        ) {
+            $conf['TAXmode'] = 1;
+        }
 
-		if ($conf['TAXmode'] < 1 || $conf['TAXmode'] > 2) {
-			$errorCode['0'] = 'error_range';
-			$errorCode['1'] = 'TAXmode';
-			$errorCode['2'] = '1';
-			$errorCode['3'] = '2';
-			$errorCode['4'] = $conf['TAXmode'];
-			return false;
-		}
+        if ($conf['TAXmode'] < 1 || $conf['TAXmode'] > 2) {
+            $errorCode['0'] = 'error_range';
+            $errorCode['1'] = 'TAXmode';
+            $errorCode['2'] = '1';
+            $errorCode['3'] = '2';
+            $errorCode['4'] = $conf['TAXmode'];
+            return false;
+        }
 
-		$backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
+        $backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
 
-		$config['backPID'] = $backPID;
+        $config['backPID'] = $backPID;
 
-		// page where to go usually
-		$pid =
-			(
-				$conf['PIDbasket'] && $conf['clickIntoBasket'] ?
-					$conf['PIDbasket'] :
-						(
-							$backPID ?
-								$backPID :
-								$GLOBALS['TSFE']->id
-						)
-			);
+        // page where to go usually
+        $pid =
+            (
+                $conf['PIDbasket'] && $conf['clickIntoBasket'] ?
+                    $conf['PIDbasket'] :
+                        (
+                            $backPID ?
+                                $backPID :
+                                $GLOBALS['TSFE']->id
+                        )
+            );
 
-		$pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
-		return true;
-	}
+        $pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
+        return true;
+    }
 
-	public function getRelatedProductsBySystemCategory ($content, $pluginConf) {
-		$result = '';
-		$errorCode = [];
+    public function getRelatedProductsBySystemCategory ($content, $pluginConf) {
+        $result = '';
+        $errorCode = [];
 
-		$result =
-			$this->getRelatedProducts(
-				$errorCode,
-				$content,
-				$pluginConf,
-				RelatedProductsTypes::SystemCategory
-			);
+        $result =
+            $this->getRelatedProducts(
+                $errorCode,
+                $content,
+                $pluginConf,
+                RelatedProductsTypes::SystemCategory
+            );
 
-		if ($errorCode[0]) {
+        if ($errorCode[0]) {
             $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-			$result .= ErrorUtility::getMessage($languageObj, $errorCode);
-		}
+            $result .= ErrorUtility::getMessage($languageObj, $errorCode);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	public function getRelatedProducts (
-		&$errorCode,
-		$content,
-		$pluginConf,
-		$type,
-		$bRunAjax = false
-	) {
-		$result = '';
-		$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+    public function getRelatedProducts (
+        &$errorCode,
+        $content,
+        $pluginConf,
+        $type,
+        $bRunAjax = false
+    ) {
+        $result = '';
+        $pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
 
-		if (!self::$bHasBeenInitialised) {
-			$conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
+        if (!self::$bHasBeenInitialised) {
+            $conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
             \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($conf, $pluginConf);
-			$config = [];
-			$cObj = FrontendUtility::getContentObjectRenderer([]);
+            $config = [];
+            $cObj = FrontendUtility::getContentObjectRenderer([]);
 
-			self::init2(
-				$conf,
-				$config,
-				$cObj,
-				$errorCode,
-				$bRunAjax
-			);
-		}
+            self::init2(
+                $conf,
+                $config,
+                $cObj,
+                $errorCode,
+                $bRunAjax
+            );
+        }
 
-		$uid = intval($pluginConf['ref']);
-		$subtype = '';
-		switch ($type) {
-			case RelatedProductsTypes::SystemCategory:
-				$subtype = 'productsbysystemcategory';
-				break;
-			default:
-				$errorCode['0'] = 'wrong_type';
-				$errorCode['1'] = $type;
-				return false;
-				break;
-		}
+        $uid = intval($pluginConf['ref']);
+        $subtype = '';
+        switch ($type) {
+            case RelatedProductsTypes::SystemCategory:
+                $subtype = 'productsbysystemcategory';
+                break;
+            default:
+                $errorCode['0'] = 'wrong_type';
+                $errorCode['1'] = $type;
+                return false;
+                break;
+        }
 
-		$funcTablename = 'tt_products';
+        $funcTablename = 'tt_products';
 
-		$relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
-		$relatedListView->init(
-			$config['pid_list'],
-			$config['recursive']
-		);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemViewObj = $tablesObj->get($funcTablename, true);
-		$itemObj = $itemViewObj->getModelObj();
+        $relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
+        $relatedListView->init(
+            $config['pid_list'],
+            $config['recursive']
+        );
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemViewObj = $tablesObj->get($funcTablename, true);
+        $itemObj = $itemViewObj->getModelObj();
 
-		$addListArray =
-			$relatedListView->getAddListArray(
-				$theCode,
-				$funcTablename,
-				$itemViewObj->getMarker(),
-				$uid,
-				$conf['useArticles']
-			);
-		$funcArray = $addListArray[$subtype] ?? [];
-		$pid = $GLOBALS['TSFE']->id;
-		$paramUidArray['product'] = $uid;
+        $addListArray =
+            $relatedListView->getAddListArray(
+                $theCode,
+                $funcTablename,
+                $itemViewObj->getMarker(),
+                $uid,
+                $conf['useArticles']
+            );
+        $funcArray = $addListArray[$subtype] ?? [];
+        $pid = $GLOBALS['TSFE']->id;
+        $paramUidArray['product'] = $uid;
 
-		$relatedItemObj = $itemObj;
-		$parentFuncTablename = '';
+        $relatedItemObj = $itemObj;
+        $parentFuncTablename = '';
 
-		if (
+        if (
             !empty($funcArray) &&
             $funcTablename != $funcArray['functablename']
         ) {
-			$relatedItemObj = $tablesObj->get($funcArray['functablename'], false);
-			$parentFuncTablename = $funcArray['functablename'];
-		}
-		$tableConf = $relatedItemObj->getTableConf($funcArray['code']);
-		$orderBy = '';
-		if (isset($tableConf['orderBy'])) {
-			$orderBy = $tableConf['orderBy'];
-		}
+            $relatedItemObj = $tablesObj->get($funcArray['functablename'], false);
+            $parentFuncTablename = $funcArray['functablename'];
+        }
+        $tableConf = $relatedItemObj->getTableConf($funcArray['code']);
+        $orderBy = '';
+        if (isset($tableConf['orderBy'])) {
+            $orderBy = $tableConf['orderBy'];
+        }
 
-		$mergeRow = [];
-		$parentRows = [];
-		$relatedIds =
-			$itemObj->getRelated(
-				$parentFuncTablename,
-				$parentRows,
+        $mergeRow = [];
+        $parentRows = [];
+        $relatedIds =
+            $itemObj->getRelated(
+                $parentFuncTablename,
+                $parentRows,
                 $multiOrderArray = [],
-				$uid,
-				$subtype,
-				$orderBy
-			);
+                $uid,
+                $subtype,
+                $orderBy
+            );
 
-		if (!empty($relatedIds)) {
+        if (!empty($relatedIds)) {
 
-			$listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
-			$listView->init(
-				$pid,
-				$paramUidArray,
-				$config['pid_list'],
-				0
-			);
+            $listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
+            $listView->init(
+                $pid,
+                $paramUidArray,
+                $config['pid_list'],
+                0
+            );
 
-			$listPids = $funcArray['additionalPages'];
-			if ($listPids != '') {
-				$pidListObj->applyRecursive($config['recursive'], $listPids);
-			} else {
-				$listPids = $pidListObj->getPidlist();
-			}
+            $listPids = $funcArray['additionalPages'];
+            if ($listPids != '') {
+                $pidListObj->applyRecursive($config['recursive'], $listPids);
+            } else {
+                $listPids = $pidListObj->getPidlist();
+            }
 
-			$templateCode =
-				$templateObj->get(
-					$funcArray['code'],
-					$templateFile,
-					$errorCode
-				);
+            $templateCode =
+                $templateObj->get(
+                    $funcArray['code'],
+                    $templateFile,
+                    $errorCode
+                );
             $notOverwritePriceIfSet = false;
 
-			$tmpContent = $listView->printView(
-				$templateCode,
-				$funcArray['code'],
-				$funcArray['functablename'],
-				implode(',', $relatedIds),
-				$listPids,
-				'',
-				$errorCode,
-				$funcArray['template'] . $config['templateSuffix'],
-				$pageAsCategory,
-				\tx_ttproducts_control_basket::getBasketExtra(),
-				\tx_ttproducts_control_basket::getRecs(),
-				$mergeRow,
-				1,
-				$callFunctableArray,
-				$parentDataArray,
-				$parentProductRow,
-				$parentFuncTablename,
-				$parentRows,
-				$notOverwritePriceIfSet,
-				$multiOrderArray,
-				$productRowArray,
-				$bEditableVariants
-			);
-			$result = $tmpContent;
-		}
+            $tmpContent = $listView->printView(
+                $templateCode,
+                $funcArray['code'],
+                $funcArray['functablename'],
+                implode(',', $relatedIds),
+                $listPids,
+                '',
+                $errorCode,
+                $funcArray['template'] . $config['templateSuffix'],
+                $pageAsCategory,
+                \tx_ttproducts_control_basket::getBasketExtra(),
+                \tx_ttproducts_control_basket::getRecs(),
+                $mergeRow,
+                1,
+                $callFunctableArray,
+                $parentDataArray,
+                $parentProductRow,
+                $parentFuncTablename,
+                $parentRows,
+                $notOverwritePriceIfSet,
+                $multiOrderArray,
+                $productRowArray,
+                $bEditableVariants
+            );
+            $result = $tmpContent;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/Classes/Api/PriceApi.php
+++ b/Classes/Api/PriceApi.php
@@ -41,75 +41,75 @@ namespace JambageCom\TtProducts\Api;
 
 class PriceApi {
 
-	static public function mergeRows (
-		array &$targetRow,
-		array $sourceRow,
-		$field,
-		$bIsAddedPrice,
-		$previouslyAddedPrice, // deprecated
-		$calculationField = '',
-		$bKeepNotEmpty = true,
-		$bUseExt = false
-	) {
-		$calculatedValue = 0;
-		$value = 0;
-		if (isset($sourceRow[$field])) {
+    static public function mergeRows (
+        array &$targetRow,
+        array $sourceRow,
+        $field,
+        $bIsAddedPrice,
+        $previouslyAddedPrice, // deprecated
+        $calculationField = '',
+        $bKeepNotEmpty = true,
+        $bUseExt = false
+    ) {
+        $calculatedValue = 0;
+        $value = 0;
+        if (isset($sourceRow[$field])) {
             $value = $sourceRow[$field];
         }
-		if (
-			$field == 'price' &&
-			$calculationField != ''
-		) { // check for a graduated price
-			if (
-				isset($sourceRow[$calculationField])
-			) {
-				$value = $sourceRow[$calculationField];
-				$calculatedValue = $value;
-			}
-		}
+        if (
+            $field == 'price' &&
+            $calculationField != ''
+        ) { // check for a graduated price
+            if (
+                isset($sourceRow[$calculationField])
+            ) {
+                $value = $sourceRow[$calculationField];
+                $calculatedValue = $value;
+            }
+        }
 
-		$priceNumber = '';
-		if (strpos($field, 'price') === 0) {
-			$priceNumber = str_replace('price', '', $field);
-			if (!isset($targetRow['surcharge' . $priceNumber])) {
-				$targetRow['surcharge' . $priceNumber] = 0;
-			}
-		}
+        $priceNumber = '';
+        if (strpos($field, 'price') === 0) {
+            $priceNumber = str_replace('price', '', $field);
+            if (!isset($targetRow['surcharge' . $priceNumber])) {
+                $targetRow['surcharge' . $priceNumber] = 0;
+            }
+        }
 
-		if ($bIsAddedPrice) {
-			if (strpos($field, 'price') === 0) {
+        if ($bIsAddedPrice) {
+            if (strpos($field, 'price') === 0) {
                 if (!isset($targetRow['surcharge' . $priceNumber])) {
                     $targetRow['surcharge' . $priceNumber] = 0;
                 }
-				$targetRow['surcharge' . $priceNumber] += $value;
-			}
+                $targetRow['surcharge' . $priceNumber] += $value;
+            }
 
-			$value += $targetRow[$field];
+            $value += $targetRow[$field];
 
-			if ($bUseExt) {
-				if (!isset($targetRow['ext'])) {
-					$targetRow['ext'] = [];
-				}
-				if (!isset($targetRow['ext']['addedPrice'])) {
+            if ($bUseExt) {
+                if (!isset($targetRow['ext'])) {
+                    $targetRow['ext'] = [];
+                }
+                if (!isset($targetRow['ext']['addedPrice'])) {
                     $targetRow['ext']['addedPrice'] = 0;
                 }
-				$targetRow['ext']['addedPrice'] += $targetRow[$field];
-			}
+                $targetRow['ext']['addedPrice'] += $targetRow[$field];
+            }
         }
 
-		if($bKeepNotEmpty) {
-			if (
+        if($bKeepNotEmpty) {
+            if (
                 (
                     !isset($targetRow[$field]) ||
                     !round($targetRow[$field], 16)
-				) &&
-				round($value, 16)
-			) {
-				$targetRow[$field] = $value;
-			}
-		} else { // $bKeepNotEmpty == false
-			$targetRow[$field] = $value;
-		}
-	}
+                ) &&
+                round($value, 16)
+            ) {
+                $targetRow[$field] = $value;
+            }
+        } else { // $bKeepNotEmpty == false
+            $targetRow[$field] = $value;
+        }
+    }
 }
 

--- a/Classes/Backend/BackendUserSimulation.php
+++ b/Classes/Backend/BackendUserSimulation.php
@@ -25,352 +25,352 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @internal
  */
 class BackendUserSimulation extends \TYPO3\CMS\Core\Authentication\AbstractUserAuthentication {
-	/**
-	 * User workspace.
-	 * -99 is ERROR (none available)
-	 * -1 is offline
-	 * 0 is online
-	 * >0 is custom workspaces
-	 * @var int
-	 */
-	public $workspace = -99;
+    /**
+     * User workspace.
+     * -99 is ERROR (none available)
+     * -1 is offline
+     * 0 is online
+     * >0 is custom workspaces
+     * @var int
+     */
+    public $workspace = -99;
 
-	/**
-	 * Custom workspace record if any
-	 * @var array
-	 * @todo Define visibility
-	 */
-	public $workspaceRec = [];
+    /**
+     * Custom workspace record if any
+     * @var array
+     * @todo Define visibility
+     */
+    public $workspaceRec = [];
 
-	/**
-	 * Contains last error message
-	 * @var string
-	 * @todo Define visibility
-	 */
-	public $errorMsg = '';
+    /**
+     * Contains last error message
+     * @var string
+     * @todo Define visibility
+     */
+    public $errorMsg = '';
 
-	/**
-	 * @var int
-	 */
-	public $firstMainGroup = 0;
+    /**
+     * @var int
+     */
+    public $firstMainGroup = 0;
 
-	/**
-	 * Constructor
-	 */
-	public function __construct ($userid) {
-		parent::__construct();
-		$this->user['username'] = 'tt_products_user' . $userid;
-		$this->user['uid'] = intval($userid);
-		$this->user['admin'] = '1';
-	}
+    /**
+     * Constructor
+     */
+    public function __construct ($userid) {
+        parent::__construct();
+        $this->user['username'] = 'tt_products_user' . $userid;
+        $this->user['uid'] = intval($userid);
+        $this->user['admin'] = '1';
+    }
 
-	/**
-	 * Returns true if user is admin
-	 *
-	 * @return boolean
-	 */
-	public function isAdmin () {
-		return true;
-	}
+    /**
+     * Returns true if user is admin
+     *
+     * @return boolean
+     */
+    public function isAdmin () {
+        return true;
+    }
 
-	/**
-	 * Checks if the page id, $id, is found within the webmounts set up for the user.
-	 * This should ALWAYS be checked for any page id a user works with, whether it's about reading, writing or whatever.
-	 * The point is that this will add the security that a user can NEVER touch parts outside his mounted
-	 * pages in the page tree. This is otherwise possible if the raw page permissions allows for it.
-	 * So this security check just makes it easier to make safe user configurations.
-	 * If the user is admin OR if this feature is disabled
-	 * (fx. by setting TYPO3_CONF_VARS['BE']['lockBeUserToDBmounts']=0) then it returns "1" right away
-	 * Otherwise the function will return the uid of the webmount which was first found in the rootline of the input page $id
-	 *
-	 * @param integer $id Page ID to check
-	 * @param string $readPerms Content of "->getPagePermsClause(1)" (read-permissions). If not set, they will be internally calculated (but if you have the correct value right away you can save that database lookup!)
-	 * @param bool|int $exitOnError If set, then the function will exit with an error message.
-	 * @throws \RuntimeException
-	 * @return int|null The page UID of a page in the rootline that matched a mount point
-	 * @todo Define visibility
-	 */
-	public function isInWebMount ($id, $readPerms = '', $exitOnError = 0) {
-		return 1;
-	}
+    /**
+     * Checks if the page id, $id, is found within the webmounts set up for the user.
+     * This should ALWAYS be checked for any page id a user works with, whether it's about reading, writing or whatever.
+     * The point is that this will add the security that a user can NEVER touch parts outside his mounted
+     * pages in the page tree. This is otherwise possible if the raw page permissions allows for it.
+     * So this security check just makes it easier to make safe user configurations.
+     * If the user is admin OR if this feature is disabled
+     * (fx. by setting TYPO3_CONF_VARS['BE']['lockBeUserToDBmounts']=0) then it returns "1" right away
+     * Otherwise the function will return the uid of the webmount which was first found in the rootline of the input page $id
+     *
+     * @param integer $id Page ID to check
+     * @param string $readPerms Content of "->getPagePermsClause(1)" (read-permissions). If not set, they will be internally calculated (but if you have the correct value right away you can save that database lookup!)
+     * @param bool|int $exitOnError If set, then the function will exit with an error message.
+     * @throws \RuntimeException
+     * @return int|null The page UID of a page in the rootline that matched a mount point
+     * @todo Define visibility
+     */
+    public function isInWebMount ($id, $readPerms = '', $exitOnError = 0) {
+        return 1;
+    }
 
-	/**
-	 * Returns a WHERE-clause for the pages-table where user permissions according to input argument, $perms, is validated.
-	 * $perms is the "mask" used to select. Fx. if $perms is 1 then you'll get all pages that a user can actually see!
-	 * 2^0 = show (1)
-	 * 2^1 = edit (2)
-	 * 2^2 = delete (4)
-	 * 2^3 = new (8)
-	 * If the user is 'admin' " 1=1" is returned (no effect)
-	 * If the user is not set at all (->user is not an array), then " 1=0" is returned (will cause no selection results at all)
-	 * The 95% use of this function is "->getPagePermsClause(1)" which will
-	 * return WHERE clauses for *selecting* pages in backend listings - in other words this will check read permissions.
-	 *
-	 * @param integer $perms Permission mask to use, see function description
-	 * @return string Part of where clause. Prefix " AND " to this.
-	 * @todo Define visibility
-	 */
-	public function getPagePermsClause ($perms) {
-		return ' 1=1';
-	}
+    /**
+     * Returns a WHERE-clause for the pages-table where user permissions according to input argument, $perms, is validated.
+     * $perms is the "mask" used to select. Fx. if $perms is 1 then you'll get all pages that a user can actually see!
+     * 2^0 = show (1)
+     * 2^1 = edit (2)
+     * 2^2 = delete (4)
+     * 2^3 = new (8)
+     * If the user is 'admin' " 1=1" is returned (no effect)
+     * If the user is not set at all (->user is not an array), then " 1=0" is returned (will cause no selection results at all)
+     * The 95% use of this function is "->getPagePermsClause(1)" which will
+     * return WHERE clauses for *selecting* pages in backend listings - in other words this will check read permissions.
+     *
+     * @param integer $perms Permission mask to use, see function description
+     * @return string Part of where clause. Prefix " AND " to this.
+     * @todo Define visibility
+     */
+    public function getPagePermsClause ($perms) {
+        return ' 1=1';
+    }
 
-	/**
-	 * Checking the authMode of a select field with authMode set
-	 *
-	 * @param string $table Table name
-	 * @param string $field Field name (must be configured in TCA and of type "select" with authMode set!)
-	 * @param string $value Value to evaluation (single value, must not contain any of the chars ":,|")
-	 * @param string $authMode Auth mode keyword (explicitAllow, explicitDeny, individual)
-	 * @return boolean Whether access is granted or not
-	 * @todo Define visibility
-	 */
-	public function checkAuthMode ($table, $field, $value, $authMode) {
-		return true;
-	}
+    /**
+     * Checking the authMode of a select field with authMode set
+     *
+     * @param string $table Table name
+     * @param string $field Field name (must be configured in TCA and of type "select" with authMode set!)
+     * @param string $value Value to evaluation (single value, must not contain any of the chars ":,|")
+     * @param string $authMode Auth mode keyword (explicitAllow, explicitDeny, individual)
+     * @return boolean Whether access is granted or not
+     * @todo Define visibility
+     */
+    public function checkAuthMode ($table, $field, $value, $authMode) {
+        return true;
+    }
 
-	/**
-	 * Checking if a language value (-1, 0 and >0 for sys_language records) is allowed to be edited by the user.
-	 *
-	 * @param integer $langValue Language value to evaluate
-	 * @return boolean Returns true if the language value is allowed, otherwise false.
-	 * @todo Define visibility
-	 */
-	public function checkLanguageAccess($langValue) {
-		return true;
-	}
+    /**
+     * Checking if a language value (-1, 0 and >0 for sys_language records) is allowed to be edited by the user.
+     *
+     * @param integer $langValue Language value to evaluate
+     * @return boolean Returns true if the language value is allowed, otherwise false.
+     * @todo Define visibility
+     */
+    public function checkLanguageAccess($langValue) {
+        return true;
+    }
 
 
-	/**
-	 * Checking if a user has editing access to a record from a $GLOBALS['TCA'] table.
-	 * The checks does not take page permissions and other "environmental" things into account.
-	 * It only deal with record internals; If any values in the record fields disallows it.
-	 * For instance languages settings, authMode selector boxes are evaluated (and maybe more in the future).
-	 * It will check for workspace dependent access.
-	 * The function takes an ID (integer) or row (array) as second argument.
-	 *
-	 * @param string $table Table name
-	 * @param mixed $idOrRow If integer, then this is the ID of the record. If Array this just represents fields in the record.
-	 * @param boolean $newRecord Set, if testing a new (non-existing) record array. Will disable certain checks that doesn't make much sense in that context.
-	 * @param boolean $deletedRecord Set, if testing a deleted record array.
-	 * @param boolean $checkFullLanguageAccess Set, whenever access to all translations of the record is required
-	 * @return boolean true if OK, otherwise false
-	 * @todo Define visibility
-	 */
-	public function recordEditAccessInternals ($table, $idOrRow, $newRecord = false, $deletedRecord = false, $checkFullLanguageAccess = false) {
-		return true; // editing is always allowed
-	}
+    /**
+     * Checking if a user has editing access to a record from a $GLOBALS['TCA'] table.
+     * The checks does not take page permissions and other "environmental" things into account.
+     * It only deal with record internals; If any values in the record fields disallows it.
+     * For instance languages settings, authMode selector boxes are evaluated (and maybe more in the future).
+     * It will check for workspace dependent access.
+     * The function takes an ID (integer) or row (array) as second argument.
+     *
+     * @param string $table Table name
+     * @param mixed $idOrRow If integer, then this is the ID of the record. If Array this just represents fields in the record.
+     * @param boolean $newRecord Set, if testing a new (non-existing) record array. Will disable certain checks that doesn't make much sense in that context.
+     * @param boolean $deletedRecord Set, if testing a deleted record array.
+     * @param boolean $checkFullLanguageAccess Set, whenever access to all translations of the record is required
+     * @return boolean true if OK, otherwise false
+     * @todo Define visibility
+     */
+    public function recordEditAccessInternals ($table, $idOrRow, $newRecord = false, $deletedRecord = false, $checkFullLanguageAccess = false) {
+        return true; // editing is always allowed
+    }
 
-	/**
-	 * Checking if editing of an existing record is allowed in current workspace if that is offline.
-	 * Rules for editing in offline mode:
-	 * - record supports versioning and is an offline version from workspace and has the corrent stage
-	 * - or record (any) is in a branch where there is a page which is a version from the workspace
-	 *   and where the stage is not preventing records
-	 *
-	 * @param string $table Table of record
-	 * @param array $recData Integer (record uid) or array where fields are at least: pid, t3ver_wsid, t3ver_stage (if versioningWS is set)
-	 * @return string String error code, telling the failure state. false=All ok
-	 * @todo Define visibility
-	 */
-	public function workspaceCannotEditRecord ($table, $recData) {
-		return false; // editing is always allowed
-	}
+    /**
+     * Checking if editing of an existing record is allowed in current workspace if that is offline.
+     * Rules for editing in offline mode:
+     * - record supports versioning and is an offline version from workspace and has the corrent stage
+     * - or record (any) is in a branch where there is a page which is a version from the workspace
+     *   and where the stage is not preventing records
+     *
+     * @param string $table Table of record
+     * @param array $recData Integer (record uid) or array where fields are at least: pid, t3ver_wsid, t3ver_stage (if versioningWS is set)
+     * @return string String error code, telling the failure state. false=All ok
+     * @todo Define visibility
+     */
+    public function workspaceCannotEditRecord ($table, $recData) {
+        return false; // editing is always allowed
+    }
 
-	/**
-	 * Check if "live" records from $table may be created or edited in this PID.
-	 * If the answer is false it means the only valid way to create or edit records in the PID is by versioning
-	 * If the answer is 1 or 2 it means it is OK to create a record, if -1 it means that it is OK in terms
-	 * of versioning because the element was within a versionized branch
-	 * but NOT ok in terms of the state the root point had!
-	 *
-	 * @param integer $pid PID value to check for. OBSOLETE!
-	 * @param string $table Table name
-	 * @return mixed Returns false if a live record cannot be created and must be versionized in order to do so. 2 means a) Workspace is "Live" or workspace allows "live edit" of records from non-versionized tables (and the $table is not versionizable). 1 and -1 means the pid is inside a versionized branch where -1 means that the branch-point did NOT allow a new record according to its state.
-	 * @todo Define visibility
-	 */
-	public function workspaceAllowLiveRecordsInPID($pid, $table) {
-		return 2;
-	}
+    /**
+     * Check if "live" records from $table may be created or edited in this PID.
+     * If the answer is false it means the only valid way to create or edit records in the PID is by versioning
+     * If the answer is 1 or 2 it means it is OK to create a record, if -1 it means that it is OK in terms
+     * of versioning because the element was within a versionized branch
+     * but NOT ok in terms of the state the root point had!
+     *
+     * @param integer $pid PID value to check for. OBSOLETE!
+     * @param string $table Table name
+     * @return mixed Returns false if a live record cannot be created and must be versionized in order to do so. 2 means a) Workspace is "Live" or workspace allows "live edit" of records from non-versionized tables (and the $table is not versionizable). 1 and -1 means the pid is inside a versionized branch where -1 means that the branch-point did NOT allow a new record according to its state.
+     * @todo Define visibility
+     */
+    public function workspaceAllowLiveRecordsInPID($pid, $table) {
+        return 2;
+    }
 
-	/**
-	 * Evaluates if auto creation of a version of a record is allowed.
-	 *
-	 * @param string $table Table of the record
-	 * @param integer $id UID of record
-	 * @param integer $recpid PID of record
-	 * @return boolean true if ok.
-	 * @todo Define visibility
-	 */
-	public function workspaceAllowAutoCreation ($table, $id, $recpid) {
-		return false; // no support for workspaces
-	}
+    /**
+     * Evaluates if auto creation of a version of a record is allowed.
+     *
+     * @param string $table Table of the record
+     * @param integer $id UID of record
+     * @param integer $recpid PID of record
+     * @return boolean true if ok.
+     * @todo Define visibility
+     */
+    public function workspaceAllowAutoCreation ($table, $id, $recpid) {
+        return false; // no support for workspaces
+    }
 
-	/**
-	 * Returns the value/properties of a TS-object as given by $objectString, eg. 'options.dontMountAdminMounts'
-	 * Nice (general!) function for returning a part of a TypoScript array!
-	 *
-	 * @param string $objectString Pointer to an "object" in the TypoScript array, fx. 'options.dontMountAdminMounts'
-	 * @param array|string $config Optional TSconfig array: If array, then this is used and not $this->userTS. If not array, $this->userTS is used.
-	 * @return array An array with two keys, "value" and "properties" where "value" is a string with the value of the object string and "properties" is an array with the properties of the object string.
-	 * @todo Define visibility
-	 */
-	public function getTSConfig ($objectString, $config = '') {
-		if (!is_array($config)) {
-			// Getting Root-ts if not sent
-			$config = $this->userTS;
-		}
-		$TSConf = ['value' => null, 'properties' => null];
-		$parts = GeneralUtility::trimExplode('.', $objectString, true, 2);
-		$key = $parts[0];
-		if (strlen($key) > 0) {
-			if (count($parts) > 1 && strlen($parts[1]) > 0) {
-				// Go on, get the next level
-				if (is_array($config[$key . '.'])) {
-					$TSConf = $this->getTSConfig($parts[1], $config[$key . '.']);
-				}
-			} else {
-				$TSConf['value'] = $config[$key];
-				$TSConf['properties'] = $config[$key . '.'];
-			}
-		}
-		return $TSConf;
-	}
+    /**
+     * Returns the value/properties of a TS-object as given by $objectString, eg. 'options.dontMountAdminMounts'
+     * Nice (general!) function for returning a part of a TypoScript array!
+     *
+     * @param string $objectString Pointer to an "object" in the TypoScript array, fx. 'options.dontMountAdminMounts'
+     * @param array|string $config Optional TSconfig array: If array, then this is used and not $this->userTS. If not array, $this->userTS is used.
+     * @return array An array with two keys, "value" and "properties" where "value" is a string with the value of the object string and "properties" is an array with the properties of the object string.
+     * @todo Define visibility
+     */
+    public function getTSConfig ($objectString, $config = '') {
+        if (!is_array($config)) {
+            // Getting Root-ts if not sent
+            $config = $this->userTS;
+        }
+        $TSConf = ['value' => null, 'properties' => null];
+        $parts = GeneralUtility::trimExplode('.', $objectString, true, 2);
+        $key = $parts[0];
+        if (strlen($key) > 0) {
+            if (count($parts) > 1 && strlen($parts[1]) > 0) {
+                // Go on, get the next level
+                if (is_array($config[$key . '.'])) {
+                    $TSConf = $this->getTSConfig($parts[1], $config[$key . '.']);
+                }
+            } else {
+                $TSConf['value'] = $config[$key];
+                $TSConf['properties'] = $config[$key . '.'];
+            }
+        }
+        return $TSConf;
+    }
 
-	/**
-	 * Returns the "value" of the $objectString from the BE_USERS "User TSconfig" array
-	 *
-	 * @param string $objectString Object string, eg. "somestring.someproperty.somesubproperty
-	 * @return string The value for that object string (object path)
-	 * @see 	getTSConfig()
-	 * @todo Define visibility
-	 */
-	public function getTSConfigVal ($objectString) {
-		$TSConf = $this->getTSConfig($objectString);
-		return $TSConf['value'];
-	}
+    /**
+     * Returns the "value" of the $objectString from the BE_USERS "User TSconfig" array
+     *
+     * @param string $objectString Object string, eg. "somestring.someproperty.somesubproperty
+     * @return string The value for that object string (object path)
+     * @see 	getTSConfig()
+     * @todo Define visibility
+     */
+    public function getTSConfigVal ($objectString) {
+        $TSConf = $this->getTSConfig($objectString);
+        return $TSConf['value'];
+    }
 
-	/**
-	 * Returns the "properties" of the $objectString from the BE_USERS "User TSconfig" array
-	 *
-	 * @param string $objectString Object string, eg. "somestring.someproperty.somesubproperty
-	 * @return array The properties for that object string (object path) - if any
-	 * @see 	getTSConfig()
-	 * @todo Define visibility
-	 */
-	public function getTSConfigProp ($objectString) {
-		$TSConf = $this->getTSConfig($objectString);
-		return $TSConf['properties'];
-	}
+    /**
+     * Returns the "properties" of the $objectString from the BE_USERS "User TSconfig" array
+     *
+     * @param string $objectString Object string, eg. "somestring.someproperty.somesubproperty
+     * @return array The properties for that object string (object path) - if any
+     * @see 	getTSConfig()
+     * @todo Define visibility
+     */
+    public function getTSConfigProp ($objectString) {
+        $TSConf = $this->getTSConfig($objectString);
+        return $TSConf['properties'];
+    }
 
-	/**
-	 * Writes an entry in the logfile/table
-	 * Documentation in "TYPO3 Core API"
-	 *
-	 * @param integer $type Denotes which module that has submitted the entry. See "TYPO3 Core API". Use "4" for extensions.
-	 * @param integer $action Denotes which specific operation that wrote the entry. Use "0" when no sub-categorizing applies
-	 * @param integer $error Flag. 0 = message, 1 = error (user problem), 2 = System Error (which should not happen), 3 = security notice (admin)
-	 * @param integer $details_nr The message number. Specific for each $type and $action. This will make it possible to translate errormessages to other languages
-	 * @param string $details Default text that follows the message (in english!). Possibly translated by identification through type/action/details_nr
-	 * @param array $data Data that follows the log. Might be used to carry special information. If an array the first 5 entries (0-4) will be sprintf'ed with the details-text
-	 * @param string $tablename Table name. Special field used by tce_main.php.
-	 * @param int|string $recuid Record UID. Special field used by tce_main.php.
-	 * @param int|string $recpid Record PID. Special field used by tce_main.php. OBSOLETE
-	 * @param integer $event_pid The page_uid (pid) where the event occurred. Used to select log-content for specific pages.
-	 * @param string $NEWid Special field used by tce_main.php. NEWid string of newly created records.
-	 * @param integer $userId Alternative Backend User ID (used for logging login actions where this is not yet known).
-	 * @return integer Log entry ID.
-	 * @todo Define visibility
-	 */
-	public function writelog ($type, $action, $error, $details_nr, $details, $data, $tablename = '', $recuid = '', $recpid = '', $event_pid = -1, $NEWid = '', $userId = 0) {
-		if (!$userId && isset($this->user['uid'])) {
-			$userId = $this->user['uid'];
-		}
+    /**
+     * Writes an entry in the logfile/table
+     * Documentation in "TYPO3 Core API"
+     *
+     * @param integer $type Denotes which module that has submitted the entry. See "TYPO3 Core API". Use "4" for extensions.
+     * @param integer $action Denotes which specific operation that wrote the entry. Use "0" when no sub-categorizing applies
+     * @param integer $error Flag. 0 = message, 1 = error (user problem), 2 = System Error (which should not happen), 3 = security notice (admin)
+     * @param integer $details_nr The message number. Specific for each $type and $action. This will make it possible to translate errormessages to other languages
+     * @param string $details Default text that follows the message (in english!). Possibly translated by identification through type/action/details_nr
+     * @param array $data Data that follows the log. Might be used to carry special information. If an array the first 5 entries (0-4) will be sprintf'ed with the details-text
+     * @param string $tablename Table name. Special field used by tce_main.php.
+     * @param int|string $recuid Record UID. Special field used by tce_main.php.
+     * @param int|string $recpid Record PID. Special field used by tce_main.php. OBSOLETE
+     * @param integer $event_pid The page_uid (pid) where the event occurred. Used to select log-content for specific pages.
+     * @param string $NEWid Special field used by tce_main.php. NEWid string of newly created records.
+     * @param integer $userId Alternative Backend User ID (used for logging login actions where this is not yet known).
+     * @return integer Log entry ID.
+     * @todo Define visibility
+     */
+    public function writelog ($type, $action, $error, $details_nr, $details, $data, $tablename = '', $recuid = '', $recpid = '', $event_pid = -1, $NEWid = '', $userId = 0) {
+        if (!$userId && isset($this->user['uid'])) {
+            $userId = $this->user['uid'];
+        }
 
-		$fields_values = [
-			'userid' => (int)$userId,
-			'type' => (int)$type,
-			'action' => (int)$action,
-			'error' => (int)$error,
-			'details_nr' => (int)$details_nr,
-			'details' => $details,
-			'log_data' => serialize($data),
-			'tablename' => $tablename,
-			'recuid' => (int)$recuid,
-			'IP' => (string)GeneralUtility::getIndpEnv('REMOTE_ADDR'),
-			'tstamp' => time(),
-			'event_pid' => (int)$event_pid,
-			'NEWid' => $NEWid,
-			'workspace' => $this->workspace
-		];
-		$this->db->exec_INSERTquery('sys_log', $fields_values);
-		return $this->db->sql_insert_id();
-	}
+        $fields_values = [
+            'userid' => (int)$userId,
+            'type' => (int)$type,
+            'action' => (int)$action,
+            'error' => (int)$error,
+            'details_nr' => (int)$details_nr,
+            'details' => $details,
+            'log_data' => serialize($data),
+            'tablename' => $tablename,
+            'recuid' => (int)$recuid,
+            'IP' => (string)GeneralUtility::getIndpEnv('REMOTE_ADDR'),
+            'tstamp' => time(),
+            'event_pid' => (int)$event_pid,
+            'NEWid' => $NEWid,
+            'workspace' => $this->workspace
+        ];
+        $this->db->exec_INSERTquery('sys_log', $fields_values);
+        return $this->db->sql_insert_id();
+    }
 
-	/**
-	 * Simple logging function
-	 *
-	 * @param string $message Log message
-	 * @param string $extKey Option extension key / module name
-	 * @param integer $error Error level. 0 = message, 1 = error (user problem), 2 = System Error (which should not happen), 3 = security notice (admin)
-	 * @return integer Log entry UID
-	 * @todo Define visibility
-	 */
-	public function simplelog ($message, $extKey = '', $error = 0) {
-		return $this->writelog(4, 0, $error, 0, ($extKey ? '[' . $extKey . '] ' : '') . $message, []);
-	}
+    /**
+     * Simple logging function
+     *
+     * @param string $message Log message
+     * @param string $extKey Option extension key / module name
+     * @param integer $error Error level. 0 = message, 1 = error (user problem), 2 = System Error (which should not happen), 3 = security notice (admin)
+     * @return integer Log entry UID
+     * @todo Define visibility
+     */
+    public function simplelog ($message, $extKey = '', $error = 0) {
+        return $this->writelog(4, 0, $error, 0, ($extKey ? '[' . $extKey . '] ' : '') . $message, []);
+    }
 
-	/**
-	 * Sends a warning to $email if there has been a certain amount of failed logins during a period.
-	 * If a login fails, this function is called. It will look up the sys_log to see if there
-	 * have been more than $max failed logins the last $secondsBack seconds (default 3600).
-	 * If so, an email with a warning is sent to $email.
-	 *
-	 * @param string $email Email address
-	 * @param integer $secondsBack Number of sections back in time to check. This is a kind of limit for how many failures an hour for instance.
-	 * @param integer $max Max allowed failures before a warning mail is sent
-	 * @return void
-	 * @access private
-	 * @todo Define visibility
-	 */
-	public function checkLogFailures ($email, $secondsBack = 3600, $max = 3) {
-		if ($email) {
-			// Get last flag set in the log for sending
-			$theTimeBack = $GLOBALS['EXEC_TIME'] - $secondsBack;
-			$res = $this->db->exec_SELECTquery('tstamp', 'sys_log', 'type=255 AND action=4 AND tstamp>' . (int)$theTimeBack, '', 'tstamp DESC', '1');
-			if ($testRow = $this->db->sql_fetch_assoc($res)) {
-				$theTimeBack = $testRow['tstamp'];
-			}
-			$this->db->sql_free_result($res);
-			// Check for more than $max number of error failures with the last period.
-			$res = $this->db->exec_SELECTquery('*', 'sys_log', 'type=255 AND action=3 AND error<>0 AND tstamp>' . (int)$theTimeBack, '', 'tstamp');
-			if ($this->db->sql_num_rows($res) > $max) {
-				// OK, so there were more than the max allowed number of login failures - so we will send an email then.
-				$subject = 'TYPO3 Login Failure Warning (at ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] . ')';
-				$email_body = 'There have been some attempts (' . $this->db->sql_num_rows($res) . ') to login at the TYPO3
+    /**
+     * Sends a warning to $email if there has been a certain amount of failed logins during a period.
+     * If a login fails, this function is called. It will look up the sys_log to see if there
+     * have been more than $max failed logins the last $secondsBack seconds (default 3600).
+     * If so, an email with a warning is sent to $email.
+     *
+     * @param string $email Email address
+     * @param integer $secondsBack Number of sections back in time to check. This is a kind of limit for how many failures an hour for instance.
+     * @param integer $max Max allowed failures before a warning mail is sent
+     * @return void
+     * @access private
+     * @todo Define visibility
+     */
+    public function checkLogFailures ($email, $secondsBack = 3600, $max = 3) {
+        if ($email) {
+            // Get last flag set in the log for sending
+            $theTimeBack = $GLOBALS['EXEC_TIME'] - $secondsBack;
+            $res = $this->db->exec_SELECTquery('tstamp', 'sys_log', 'type=255 AND action=4 AND tstamp>' . (int)$theTimeBack, '', 'tstamp DESC', '1');
+            if ($testRow = $this->db->sql_fetch_assoc($res)) {
+                $theTimeBack = $testRow['tstamp'];
+            }
+            $this->db->sql_free_result($res);
+            // Check for more than $max number of error failures with the last period.
+            $res = $this->db->exec_SELECTquery('*', 'sys_log', 'type=255 AND action=3 AND error<>0 AND tstamp>' . (int)$theTimeBack, '', 'tstamp');
+            if ($this->db->sql_num_rows($res) > $max) {
+                // OK, so there were more than the max allowed number of login failures - so we will send an email then.
+                $subject = 'TYPO3 Login Failure Warning (at ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] . ')';
+                $email_body = 'There have been some attempts (' . $this->db->sql_num_rows($res) . ') to login at the TYPO3
 site "' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] . '" (' . GeneralUtility::getIndpEnv('HTTP_HOST') . ').
 
 This is a dump of the failures:
 
 ';
-				while ($testRows = $this->db->sql_fetch_assoc($res)) {
-					$theData = unserialize($testRows['log_data']);
-					$email_body .= date(
-							$GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] . ' ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'],
-							$testRows['tstamp']
-						) . ':  ' . @sprintf($testRows['details'], (string)$theData[0], (string)$theData[1], (string)$theData[2]);
-					$email_body .= LF;
-				}
-				$from = \TYPO3\CMS\Core\Utility\MailUtility::getSystemFrom();
-				/** @var $mail \TYPO3\CMS\Core\Mail\MailMessage */
-				$mail = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Mail\\MailMessage');
-				$mail->setTo($email)->setFrom($from)->setSubject($subject)->setBody($email_body);
-				$mail->send();
-				// Logout written to log
-				$this->writelog(255, 4, 0, 3, 'Failure warning (%s failures within %s seconds) sent by email to %s', [$this->db->sql_num_rows($res), $secondsBack, $email]);
-				$this->db->sql_free_result($res);
-			}
-		}
-	}
+                while ($testRows = $this->db->sql_fetch_assoc($res)) {
+                    $theData = unserialize($testRows['log_data']);
+                    $email_body .= date(
+                            $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] . ' ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'],
+                            $testRows['tstamp']
+                        ) . ':  ' . @sprintf($testRows['details'], (string)$theData[0], (string)$theData[1], (string)$theData[2]);
+                    $email_body .= LF;
+                }
+                $from = \TYPO3\CMS\Core\Utility\MailUtility::getSystemFrom();
+                /** @var $mail \TYPO3\CMS\Core\Mail\MailMessage */
+                $mail = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Mail\\MailMessage');
+                $mail->setTo($email)->setFrom($from)->setSubject($subject)->setBody($email_body);
+                $mail->send();
+                // Logout written to log
+                $this->writelog(255, 4, 0, 3, 'Failure warning (%s failures within %s seconds) sent by email to %s', [$this->db->sql_num_rows($res), $secondsBack, $email]);
+                $this->db->sql_free_result($res);
+            }
+        }
+    }
 
 }
 

--- a/Classes/Hooks/OrderBackend.php
+++ b/Classes/Hooks/OrderBackend.php
@@ -48,40 +48,40 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 class OrderBackend implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function displayCategoryTree ($parameterArray, $fobj) {
-		$result = false;
+    public function displayCategoryTree ($parameterArray, $fobj) {
+        $result = false;
 
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
-			$treeObj = false;
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
+            $treeObj = false;
 
-			if (class_exists('JambageCom\\MbiProductsCategories\\View\\TreeSelector')) {
-				$treeObj = GeneralUtility::makeInstance('JambageCom\\MbiProductsCategories\\View\\TreeSelector');
-			} else if (class_exists('tx_mbiproductscategories_treeview')) {
-				$treeObj = GeneralUtility::makeInstance('tx_mbiproductscategories_treeview');
-			}
+            if (class_exists('JambageCom\\MbiProductsCategories\\View\\TreeSelector')) {
+                $treeObj = GeneralUtility::makeInstance('JambageCom\\MbiProductsCategories\\View\\TreeSelector');
+            } else if (class_exists('tx_mbiproductscategories_treeview')) {
+                $treeObj = GeneralUtility::makeInstance('tx_mbiproductscategories_treeview');
+            }
 
-			if (is_object($treeObj)) {
-				$result = 
+            if (is_object($treeObj)) {
+                $result = 
                     $treeObj->displayCategoryTree(
                         $parameterArray,
                         $fobj
                     );
-			}
-		}
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	// Called from the backend page and list module for a single order record to open the TCE
-	public function tceSingleOrder ($data) {
+    // Called from the backend page and list module for a single order record to open the TCE
+    public function tceSingleOrder ($data) {
 
-		$table = $data['tableName'];
-		$field = $data['fieldName'];
-		$row   = $data['databaseRow'];
-		$parameterArray = $data['parameterArray'];
+        $table = $data['tableName'];
+        $field = $data['fieldName'];
+        $row   = $data['databaseRow'];
+        $parameterArray = $data['parameterArray'];
 
-			// Field configuration from TCA:
-		$config = $parameterArray['fieldConf']['config'];
+            // Field configuration from TCA:
+        $config = $parameterArray['fieldConf']['config'];
         $pageId = $this->getCurrentPageId();
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = false;
@@ -97,34 +97,34 @@ class OrderBackend implements \TYPO3\CMS\Core\SingletonInterface {
             $conf = $setup['plugin.']['tt_products.'];
         }
 
-		// do not use Ajax
-		$ajax = '';
-		$errorCode = '';
+        // do not use Ajax
+        $ajax = '';
+        $errorCode = '';
         $tmp1 = [];
         $tmp2 = '';
         $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
         $cObj->start([]);
 
-		$db = GeneralUtility::makeInstance('tx_ttproducts_db');
-		$result =
-			$db->init(
-				$conf,
-				$tmp1,
-				$ajax,
+        $db = GeneralUtility::makeInstance('tx_ttproducts_db');
+        $result =
+            $db->init(
+                $conf,
+                $tmp1,
+                $ajax,
                 $tmp2,
                 $cObj,
-				$errorCode
-			); // this initializes tx_ttproducts_config inside of creator
+                $errorCode
+            ); // this initializes tx_ttproducts_config inside of creator
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$orderView = $tablesObj->get('sys_products_orders', true);
-		$result = $orderView->getSingleOrder($row);
-		return $result;
-	}
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $orderView = $tablesObj->get('sys_products_orders', true);
+        $result = $orderView->getSingleOrder($row);
+        return $result;
+    }
 
 
-	public function displayOrderHtml ($parameterArray, $fobj) {
-		$result = 'ERROR';
+    public function displayOrderHtml ($parameterArray, $fobj) {
+        $result = 'ERROR';
         $table = '';
         $field = '';
         $row   = [];
@@ -138,20 +138,20 @@ class OrderBackend implements \TYPO3\CMS\Core\SingletonInterface {
         
                 // Field configuration from TCA:
         $config = $parameterArray['fieldConf']['config'];
-		$orderData = unserialize($row['orderData']);
-		if (
-			is_array($orderData) &&
-			isset($orderData['html_output']) &&
-			isset($config['parameters']) &&
-			is_array($config['parameters']) &&
-			isset($config['parameters']['format']) &&
-			$config['parameters']['format'] == 'html'
-		) {
-			$result = $orderData['html_output'];
-		}
+        $orderData = unserialize($row['orderData']);
+        if (
+            is_array($orderData) &&
+            isset($orderData['html_output']) &&
+            isset($config['parameters']) &&
+            is_array($config['parameters']) &&
+            isset($config['parameters']['format']) &&
+            $config['parameters']['format'] == 'html'
+        ) {
+            $result = $orderData['html_output'];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
     /**
      * Gets the current page ID from the GET/POST data.

--- a/Classes/Model/Field/FieldInterface.php
+++ b/Classes/Model/Field/FieldInterface.php
@@ -19,10 +19,10 @@ namespace JambageCom\TtProducts\Model\Field;
  */
 interface FieldInterface
 {
-	const DISCOUNT = 'discount';
-	const DISCOUNT_DISABLE = 'discount_disable';
-	const PRICE_CALCULATED = 'calc';
-	const PRICE_CALCULATED_ADDITION = 'calc_add';
-	const EXTERNAL_FIELD_PREFIX = 'tx_ttproducts_';
+    const DISCOUNT = 'discount';
+    const DISCOUNT_DISABLE = 'discount_disable';
+    const PRICE_CALCULATED = 'calc';
+    const PRICE_CALCULATED_ADDITION = 'calc_add';
+    const EXTERNAL_FIELD_PREFIX = 'tx_ttproducts_';
 }
 

--- a/Classes/Updates/ProductDatasheetUpdater.php
+++ b/Classes/Updates/ProductDatasheetUpdater.php
@@ -146,7 +146,7 @@ class ProductDatasheetUpdater implements UpgradeWizardInterface, ConfirmableInte
             \PDO::PARAM_INT,
             'uploads/tx_ttproducts/datasheet'
         );
-	
+    
         if (!empty($queries)) {
             foreach ($queries as $query) {
                 $databaseQueries[] = $query;
@@ -187,7 +187,7 @@ class ProductDatasheetUpdater implements UpgradeWizardInterface, ConfirmableInte
         $elementCount = $upgradeApi->countOfTableFieldMigrations(self::TABLE, 'datasheet', 'datasheet_uid', ParameterType::STRING, \PDO::PARAM_INT);
         return ($elementCount > 0);
     } 
-	
+    
     /**
      * Returns an array of class names of Prerequisite classes
      * This way a wizard can define dependencies like "database up-to-date" or

--- a/Classes/Updates/ProductImageUpdater.php
+++ b/Classes/Updates/ProductImageUpdater.php
@@ -226,7 +226,7 @@ class ProductImageUpdater implements UpgradeWizardInterface, ConfirmableInterfac
         }
         return ($elementCount > 0);
     } 
-	
+    
     /**
      * Returns an array of class names of Prerequisite classes
      * This way a wizard can define dependencies like "database up-to-date" or

--- a/Configuration/TCA/sys_products_orders.php
+++ b/Configuration/TCA/sys_products_orders.php
@@ -41,7 +41,7 @@ $result = [
                 'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
                 'default' => 0,
-				'readOnly' => 1
+                'readOnly' => 1
             ]
         ],
         'crdate' => [
@@ -53,7 +53,7 @@ $result = [
                 'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
                 'default' => 0,
-				'readOnly' => 1
+                'readOnly' => 1
             ]
         ],
         'sys_language_uid' => [

--- a/Configuration/TCA/tt_products.php
+++ b/Configuration/TCA/tt_products.php
@@ -11,7 +11,7 @@ $whereCategory =
 
 $imageFolder = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['imageFolder'];
 if (!$imageFolder) {
-	$imageFolder = 'uploads/pics';
+    $imageFolder = 'uploads/pics';
 }
 
 $palleteAddition = '';
@@ -20,90 +20,90 @@ $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LG
 
 
 $result = [
-	'ctrl' => [
-		'title' =>'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products',
-		'label' => 'title',
-		'label_alt' => 'subtitle',
-		'default_sortby' => 'ORDER BY title',
-		'tstamp' => 'tstamp',
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
-		'useColumnsForDefaultValues' => 'category',
-		'mainpalette' => 1,
+    'ctrl' => [
+        'title' =>'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products',
+        'label' => 'title',
+        'label_alt' => 'subtitle',
+        'default_sortby' => 'ORDER BY title',
+        'tstamp' => 'tstamp',
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
+        'useColumnsForDefaultValues' => 'category',
+        'mainpalette' => 1,
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products.gif',
-		'dividers2tabs' => '1',
-		'searchFields' => 'uid,title,subtitle,itemnumber,ean,note,note2,www',
-	],
-	'columns' => [
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+        'dividers2tabs' => '1',
+        'searchFields' => 'uid,title,subtitle,itemnumber,ean,note,note2,www',
+    ],
+    'columns' => [
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'checkbox' => '0',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'checkbox' => '0',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'checkbox' => '0',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'checkbox' => '0',
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -133,29 +133,29 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			]
-		],
-		'subtitle' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
-			'config' => [
-				'type' => 'text',
-				'rows' => '3',
-				'cols' => '20',
-				'eval' => null,
-				'max' => '512',
-				'default' => null,
-			]
-		],
+        'title' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
+        'subtitle' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
+            'config' => [
+                'type' => 'text',
+                'rows' => '3',
+                'cols' => '20',
+                'eval' => null,
+                'max' => '512',
+                'default' => null,
+            ]
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -174,163 +174,163 @@ $result = [
                 'default' => null
             ]
         ],
-		'keyword' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
-			'config' => [
-				'type' => 'text',
-				'rows' => '5',
-				'cols' => '20',
-				'max' => '512',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'prod_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.prod_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products',
-				'foreign_table' => 'tt_products',
-				'foreign_table_where' => ' ORDER BY tt_products.uid',
-				'size' => 3,
-				'minitems' => 0,
-				'maxitems' => 3,
-				'default' => 0
-			]
-		],
-		'itemnumber' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.itemnumber',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '120',
-				'default' => null
-			]
-		],
-		'ean' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.ean',
-			'config' => [
-				'type' => 'input',
-				'size' => '48',
-				'eval' => 'trim',
-				'max' => '48',
-				'default' => null
-			]
-		],
-		'shipping_point' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping_point',
-			'config' => [
-				'type' => 'input',
-				'size' => '24',
-				'eval' => 'trim',
-				'max' => '24',
-				'default' => null
-			]
-		],
-		'price' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.price',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim,double2',
-				'max' => '20',
-				'default' => 0
-			]
-		],
-		'price2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.price2',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim,double2',
-				'max' => '20',
-				'default' => 0
-			]
-		],
-		'discount' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.discount',
-			'config' => [
-				'type' => 'input',
-				'size' => '4',
-				'max' => '8',
-				'eval' => 'trim,double2',
-				'range' => [
-					'upper' => '1000',
-					'lower' => '0'
-				],
-				'default' => 0
-			]
-		],
-		'discount_disable' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.discount_disable',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'tax' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.tax',
-			'config' => [
-				'type' => 'input',
-				'size' => '12',
-				'max' => '19',
-				'eval' => 'trim,double2',
-				'default' => 0
-			]
-		],
-		'creditpoints' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.creditpoints',
-			'config' => [
-				'type' => 'input',
-				'size' => '12',
-				'eval' => 'int',
-				'max' => '12',
-				'default' => 0
-			]
-		],
-		'deposit' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.deposit',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim,double2',
-				'max' => '20',
-				'default' => 0
-			]
-		],
-		'graduated_price_enable' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.graduated_price_enable',
-			'config' => [
-				'type' => 'check',
-				'default' => '1'
-			]
-		],
-		'graduated_price_round' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.graduated_price_round',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'max' => '20',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
+        'keyword' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
+            'config' => [
+                'type' => 'text',
+                'rows' => '5',
+                'cols' => '20',
+                'max' => '512',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'prod_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.prod_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products',
+                'foreign_table' => 'tt_products',
+                'foreign_table_where' => ' ORDER BY tt_products.uid',
+                'size' => 3,
+                'minitems' => 0,
+                'maxitems' => 3,
+                'default' => 0
+            ]
+        ],
+        'itemnumber' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.itemnumber',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '120',
+                'default' => null
+            ]
+        ],
+        'ean' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.ean',
+            'config' => [
+                'type' => 'input',
+                'size' => '48',
+                'eval' => 'trim',
+                'max' => '48',
+                'default' => null
+            ]
+        ],
+        'shipping_point' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping_point',
+            'config' => [
+                'type' => 'input',
+                'size' => '24',
+                'eval' => 'trim',
+                'max' => '24',
+                'default' => null
+            ]
+        ],
+        'price' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.price',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim,double2',
+                'max' => '20',
+                'default' => 0
+            ]
+        ],
+        'price2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.price2',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim,double2',
+                'max' => '20',
+                'default' => 0
+            ]
+        ],
+        'discount' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.discount',
+            'config' => [
+                'type' => 'input',
+                'size' => '4',
+                'max' => '8',
+                'eval' => 'trim,double2',
+                'range' => [
+                    'upper' => '1000',
+                    'lower' => '0'
+                ],
+                'default' => 0
+            ]
+        ],
+        'discount_disable' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.discount_disable',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'tax' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.tax',
+            'config' => [
+                'type' => 'input',
+                'size' => '12',
+                'max' => '19',
+                'eval' => 'trim,double2',
+                'default' => 0
+            ]
+        ],
+        'creditpoints' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.creditpoints',
+            'config' => [
+                'type' => 'input',
+                'size' => '12',
+                'eval' => 'int',
+                'max' => '12',
+                'default' => 0
+            ]
+        ],
+        'deposit' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.deposit',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim,double2',
+                'max' => '20',
+                'default' => 0
+            ]
+        ],
+        'graduated_price_enable' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.graduated_price_enable',
+            'config' => [
+                'type' => 'check',
+                'default' => '1'
+            ]
+        ],
+        'graduated_price_round' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.graduated_price_round',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'max' => '20',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
         'graduated_price_uid' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.graduated_price_uid',
@@ -349,94 +349,94 @@ $result = [
                 'default' => 0
             ],
         ],
-		'article_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.article_uid',
-			'config' => [
-				'type' => 'inline',
-				'appearance' =>
-					[
-						'collapseAll' => true,
-						'newRecordLinkAddTitle' => true,
-						'useCombination' => true
-					],
-				'foreign_table' => 'tt_products_products_mm_articles',
-				'foreign_field' => 'uid_local',
-				'foreign_sortby' => 'sorting',
-				'foreign_label' => 'uid_foreign',
-				'foreign_selector' => 'uid_foreign',
-				'foreign_unique' => 'uid_foreign',
-				'maxitems' => 1000,
-				'default' => 0
-			],
-		],
-		'note' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			]
-		],
-		'note2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '2',
-				'default' => null,
-			]
-		],
-		'note_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'pages',
-				'MM' => 'tt_products_products_note_pages_mm',
-				'size' => '2',
-				'autoSizeMax' => '12',
-				'minitems' => '0',
-				'maxitems' => '30',
-				'default' => 0
-			],
-		],
-		'text_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.text_uid',
-			'config' => [
-				'type' => 'inline',
-				'foreign_table' => 'tt_products_texts',
-				'foreign_field' => 'parentid',
-				'foreign_table_field' => 'parenttable',
-				'maxitems' => 20,
-				'default' => 0
-			],
-		],
-		'download_type' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_type',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['', '']
-				],
-				'default' => null,
-				'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'],
-			]
-		],
-		'download_info' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_info',
-			'config' => [
-				'type' => 'flex',
-				'ds_pointerField' => 'download_type',
-				'ds' => [
-					'default' => '
+        'article_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.article_uid',
+            'config' => [
+                'type' => 'inline',
+                'appearance' =>
+                    [
+                        'collapseAll' => true,
+                        'newRecordLinkAddTitle' => true,
+                        'useCombination' => true
+                    ],
+                'foreign_table' => 'tt_products_products_mm_articles',
+                'foreign_field' => 'uid_local',
+                'foreign_sortby' => 'sorting',
+                'foreign_label' => 'uid_foreign',
+                'foreign_selector' => 'uid_foreign',
+                'foreign_unique' => 'uid_foreign',
+                'maxitems' => 1000,
+                'default' => 0
+            ],
+        ],
+        'note' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ]
+        ],
+        'note2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '2',
+                'default' => null,
+            ]
+        ],
+        'note_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'pages',
+                'MM' => 'tt_products_products_note_pages_mm',
+                'size' => '2',
+                'autoSizeMax' => '12',
+                'minitems' => '0',
+                'maxitems' => '30',
+                'default' => 0
+            ],
+        ],
+        'text_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.text_uid',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tt_products_texts',
+                'foreign_field' => 'parentid',
+                'foreign_table_field' => 'parenttable',
+                'maxitems' => 20,
+                'default' => 0
+            ],
+        ],
+        'download_type' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_type',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', '']
+                ],
+                'default' => null,
+                'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'],
+            ]
+        ],
+        'download_info' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_info',
+            'config' => [
+                'type' => 'flex',
+                'ds_pointerField' => 'download_type',
+                'ds' => [
+                    'default' => '
 						<T3DataStructure>
 							<ROOT>
 								<type>array</type>
@@ -456,106 +456,106 @@ $result = [
 							</meta>
 						</T3DataStructure>
 						',
-				],
-				'eval' => 'null',
-			]
-		],
-		'download_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products_downloads',
-				'MM' => 'tt_products_products_mm_downloads',
-				'foreign_table' => 'tt_products_downloads',
-				'foreign_table_where' => ' ORDER BY tt_products_downloads.title',
-				'size' => 10,
-				'minitems' => 0,
-				'maxitems' => 1000,
-				'default' => 0
-			],
-		],
-		'unit_factor' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit_factor',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'eval' => 'double',
-				'default' => 1,
-				'max' => '6'
-			]
-		],
-		'unit' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim',
-				'max' => '20',
-				'default' => null
-			]
-		],
-		'www' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'www',
-			'config' => [
-				'type' => 'input',
-				'eval' => 'trim',
-				'size' => '30',
-				'max' => '160',
-				'default' => null
-			]
-		],
-		'category' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'category',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['', 0]
-				],
-				'foreign_table' => 'tt_products_cat',
-				'foreign_table_where' => $whereCategory,
-				'default' => 0
-			]
-		],
-		'inStock' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.inStock',
-			'config' => [
-				'type' => 'input',
-				'size' => '6',
-				'max' => '6',
-				'eval' => 'int',
-				'default' => 1
-			]
-		],
-		'basketminquantity' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.basketminquantity',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'eval' => 'trim,double2',
-				'max' => '10',
-				'default' => 0
-			]
-		],
-		'basketmaxquantity' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.basketmaxquantity',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'eval' => 'trim,double2',
-				'max' => '10',
-				'default' => 0
-			]
-		],
+                ],
+                'eval' => 'null',
+            ]
+        ],
+        'download_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.download_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products_downloads',
+                'MM' => 'tt_products_products_mm_downloads',
+                'foreign_table' => 'tt_products_downloads',
+                'foreign_table_where' => ' ORDER BY tt_products_downloads.title',
+                'size' => 10,
+                'minitems' => 0,
+                'maxitems' => 1000,
+                'default' => 0
+            ],
+        ],
+        'unit_factor' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit_factor',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'eval' => 'double',
+                'default' => 1,
+                'max' => '6'
+            ]
+        ],
+        'unit' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim',
+                'max' => '20',
+                'default' => null
+            ]
+        ],
+        'www' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'www',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+                'size' => '30',
+                'max' => '160',
+                'default' => null
+            ]
+        ],
+        'category' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'category',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0]
+                ],
+                'foreign_table' => 'tt_products_cat',
+                'foreign_table_where' => $whereCategory,
+                'default' => 0
+            ]
+        ],
+        'inStock' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.inStock',
+            'config' => [
+                'type' => 'input',
+                'size' => '6',
+                'max' => '6',
+                'eval' => 'int',
+                'default' => 1
+            ]
+        ],
+        'basketminquantity' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.basketminquantity',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'eval' => 'trim,double2',
+                'max' => '10',
+                'default' => 0
+            ]
+        ],
+        'basketmaxquantity' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.basketmaxquantity',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'eval' => 'trim,double2',
+                'max' => '10',
+                'default' => 0
+            ]
+        ],
         'image_uid' => [
             'exclude' => 1,
             'label' => $languageLglPath . 'image',
@@ -634,233 +634,233 @@ $result = [
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
             )
         ],
-		'weight' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.weight',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'max' => '20',
+        'weight' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.weight',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'max' => '20',
                 'eval' => 'trim,JambageCom\\Div2007\\Hooks\\Evaluation\\Double6',
                 'default' => 0
-			]
-		],
-		'usebydate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.usebydate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+            ]
+        ],
+        'usebydate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.usebydate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'bulkily' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.bulkily',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'offer' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.offer',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'highlight' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.highlight',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'bargain' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.bargain',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'directcost' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.directcost',
-			'config' => [
-				'type' => 'input',
-				'size' => '12',
-				'eval' => 'trim,double2',
-				'max' => '20',
-				'default' => 0
-			]
-		],
-		'accessory_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.accessory_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products',
-				'MM' => 'tt_products_accessory_products_products_mm',
-				'foreign_table' => 'tt_products',
-				'foreign_table_where' => ' ORDER BY tt_products.uid',
-				'size' => 10,
-				'minitems' => 0,
-				'maxitems' => 12,
-				'default' => 0
-			],
-		],
-		'related_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.related_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products',
-				'MM' => 'tt_products_related_products_products_mm',
-				'foreign_table' => 'tt_products',
-				'foreign_table_where' => ' ORDER BY tt_products.uid',
-				'size' => 10,
-				'minitems' => 0,
-				'maxitems' => 50,
-				'default' => 0
-			],
-		],
-		'color' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'color2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'color3' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color3',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'size' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'size2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'size3' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size3',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'description' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.description',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'gradings' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.gradings',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'material' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.material',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'quality' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.quality',
-			'config' => [
-				'type' => 'text',
-				'cols' => '46',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'additional_type' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.additional_type',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['', '']
-				],
-				'default' => null,
-				'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'],
-			]
-		],
-		'additional' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.additional',
-			'config' => [
-				'type' => 'flex',
-				'ds_pointerField' => 'additional_type',
-				'ds' => [
-					'default' => '
+                'default' => 0
+            ]
+        ],
+        'bulkily' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.bulkily',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'offer' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.offer',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'highlight' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.highlight',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'bargain' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.bargain',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'directcost' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.directcost',
+            'config' => [
+                'type' => 'input',
+                'size' => '12',
+                'eval' => 'trim,double2',
+                'max' => '20',
+                'default' => 0
+            ]
+        ],
+        'accessory_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.accessory_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products',
+                'MM' => 'tt_products_accessory_products_products_mm',
+                'foreign_table' => 'tt_products',
+                'foreign_table_where' => ' ORDER BY tt_products.uid',
+                'size' => 10,
+                'minitems' => 0,
+                'maxitems' => 12,
+                'default' => 0
+            ],
+        ],
+        'related_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.related_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products',
+                'MM' => 'tt_products_related_products_products_mm',
+                'foreign_table' => 'tt_products',
+                'foreign_table_where' => ' ORDER BY tt_products.uid',
+                'size' => 10,
+                'minitems' => 0,
+                'maxitems' => 50,
+                'default' => 0
+            ],
+        ],
+        'color' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'color2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'color3' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.color3',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'size' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'size2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'size3' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.size3',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'description' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.description',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'gradings' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.gradings',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'material' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.material',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'quality' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.quality',
+            'config' => [
+                'type' => 'text',
+                'cols' => '46',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'additional_type' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.additional_type',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', '']
+                ],
+                'default' => null,
+                'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'],
+            ]
+        ],
+        'additional' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.additional',
+            'config' => [
+                'type' => 'flex',
+                'ds_pointerField' => 'additional_type',
+                'ds' => [
+                    'default' => '
 						<T3DataStructure>
 							<ROOT>
 								<type>array</type>
@@ -920,98 +920,98 @@ $result = [
 							</meta>
 						</T3DataStructure>
 						',
-				],
-				'eval' => 'null',
-			]
-		],
-		'special_preparation' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.special_preparation',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'shipping' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'max' => '20',
-				'eval' => 'trim,double2',
-				'default' => 0
-			]
-		],
-		'shipping2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping2',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'max' => '20',
-				'eval' => 'trim,double2',
-				'default' => 0
-			]
-		],
-		'handling' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.handling',
-			'config' => [
-				'type' => 'input',
-				'size' => '10',
-				'max' => '20',
-				'eval' => 'trim,double2',
-				'default' => 0
-			]
-		],
-		'delivery' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableNot', '-1'],
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableDemand', '0'],
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableImmediate', '1'],
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableShort', '2']
-				],
-				'size' => '6',
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'sellstarttime' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.sellstarttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                ],
+                'eval' => 'null',
+            ]
+        ],
+        'special_preparation' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.special_preparation',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'shipping' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'max' => '20',
+                'eval' => 'trim,double2',
+                'default' => 0
+            ]
+        ],
+        'shipping2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shipping2',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'max' => '20',
+                'eval' => 'trim,double2',
+                'default' => 0
+            ]
+        ],
+        'handling' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.handling',
+            'config' => [
+                'type' => 'input',
+                'size' => '10',
+                'max' => '20',
+                'eval' => 'trim,double2',
+                'default' => 0
+            ]
+        ],
+        'delivery' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableNot', '-1'],
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableDemand', '0'],
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableImmediate', '1'],
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.delivery.availableShort', '2']
+                ],
+                'size' => '6',
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'sellstarttime' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.sellstarttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'sellendtime' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.sellendtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'sellendtime' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.sellendtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, 2300),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
-	],
-	'types' => [
-		'0' =>
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, 2300),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
+    ],
+    'types' => [
+        '0' =>
             [
                 'columnsOverrides' => [
                     'note' => [
@@ -1038,35 +1038,35 @@ $result = [
                     '--div--;LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.shippingdiv,shipping_point,shipping,shipping2,handling,delivery,'
 
             ]
-	],
-	'palettes' => [
-		'1' =>
-			['showitem' => 'sellstarttime,sellendtime'],
-		'2' =>
-			['showitem' => 'inStock,basketminquantity,basketmaxquantity,ean'],
-		'3' =>
-			['showitem' => 'price2,discount,discount_disable,directcost'],
-		'4' =>
-			['showitem' => 'tax_dummy'],
-		'5' =>
-			['showitem' => 'creditpoints'],
-		'6' =>
-			['showitem' => 'highlight,bargain'],
-		'7' =>
-			['showitem' => 'subtitle,keyword,www'],
-		'8' =>
-			['showitem' => 'bulkily,special_preparation,unit,unit_factor'],
-		'9' =>
-			['showitem' => 'color3'],
-		'10' =>
-			['showitem' => 'size3'],
-		'11' =>
-			['showitem' => 'usebydate'],
+    ],
+    'palettes' => [
+        '1' =>
+            ['showitem' => 'sellstarttime,sellendtime'],
+        '2' =>
+            ['showitem' => 'inStock,basketminquantity,basketmaxquantity,ean'],
+        '3' =>
+            ['showitem' => 'price2,discount,discount_disable,directcost'],
+        '4' =>
+            ['showitem' => 'tax_dummy'],
+        '5' =>
+            ['showitem' => 'creditpoints'],
+        '6' =>
+            ['showitem' => 'highlight,bargain'],
+        '7' =>
+            ['showitem' => 'subtitle,keyword,www'],
+        '8' =>
+            ['showitem' => 'bulkily,special_preparation,unit,unit_factor'],
+        '9' =>
+            ['showitem' => 'color3'],
+        '10' =>
+            ['showitem' => 'size3'],
+        '11' =>
+            ['showitem' => 'usebydate'],
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.access',
             'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.endtime_formlabel, --linebreak--, fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.fe_group_formlabel, --linebreak--',
         ],
-	]
+    ]
 ];
 
 

--- a/Configuration/TCA/tt_products_articles.php
+++ b/Configuration/TCA/tt_products_articles.php
@@ -131,7 +131,7 @@ $result = [
             'config' => [
                 'type' => 'input',
                 'size' => '40',
-				'eval' => 'trim',
+                'eval' => 'trim',
                 'max' => '80',
                 'default' => null
             ]
@@ -143,7 +143,7 @@ $result = [
                 'type' => 'text',
                 'rows' => '3',
                 'cols' => '20',
-				'eval' => null,
+                'eval' => null,
                 'max' => '512',
                 'default' => null
             ]

--- a/Configuration/TCA/tt_products_articles_language.php
+++ b/Configuration/TCA/tt_products_articles_language.php
@@ -150,7 +150,7 @@ $result = [
             'config' => [
                 'type' => 'input',
                 'size' => '40',
-				'eval' => 'trim',
+                'eval' => 'trim',
                 'max' => '256',
                 'default' => null
             ],
@@ -163,7 +163,7 @@ $result = [
                 'type' => 'text',
                 'rows' => '3',
                 'cols' => '20',
-				'eval' => null,
+                'eval' => null,
                 'max' => '512',
                 'default' => null
             ],

--- a/Configuration/TCA/tt_products_attribute_mm_graduated_price.php
+++ b/Configuration/TCA/tt_products_attribute_mm_graduated_price.php
@@ -10,64 +10,64 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price',
-		'label' => 'title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden'
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden'
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_cat.gif',
         'hideTable' => true,
-	],
-	'columns' => [
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'uid_local' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price.uid_local',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'foreign_table' => 'tt_products',
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'uid_foreign' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price.uid_foreign',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'foreign_table' => 'tt_products_graduated_price',
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'sorting' => [
-			'config' => [
-				'type' => 'passthrough',
-				'default' => 0
-			]
-		],
-		'sorting_foreign' => [
-			'config' => [
-				'type' => 'passthrough',
-				'default' => 0
-			]
-		],
-	],
-	'types' => [
-		'0' => ['showitem' => 'hidden,--palette--;;1, uid_local, uid_foreign']
-	]
+    ],
+    'columns' => [
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'uid_local' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price.uid_local',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tt_products',
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'uid_foreign' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_attribute_mm_graduated_price.uid_foreign',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tt_products_graduated_price',
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'sorting' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => 0
+            ]
+        ],
+        'sorting_foreign' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => 0
+            ]
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'hidden,--palette--;;1, uid_local, uid_foreign']
+    ]
 ];
 
 

--- a/Configuration/TCA/tt_products_cat.php
+++ b/Configuration/TCA/tt_products_cat.php
@@ -4,7 +4,7 @@ defined('TYPO3') || die('Access denied.');
 $extensionKey = 'tt_products';
 $imageFolder = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['imageFolder'];
 if (!$imageFolder) {
-	$imageFolder = 'uploads/pics';
+    $imageFolder = 'uploads/pics';
 }
 
 // ******************************************************************
@@ -15,85 +15,85 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat',
-		'label' => 'title',
-		'label_alt' => 'subtitle',
-		'default_sortby' =>' ORDER BY title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat',
+        'label' => 'title',
+        'label_alt' => 'subtitle',
+        'default_sortby' =>' ORDER BY title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_cat.gif',
-		'searchFields' => 'uid,title,subtitle,catid,keyword,note,note2',
-	],
-	'columns' => [
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'searchFields' => 'uid,title,subtitle,catid,keyword,note,note2',
+    ],
+    'columns' => [
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -123,28 +123,28 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			]
-		],
-		'subtitle' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
-			'config' => [
-				'type' => 'text',
-				'rows' => '3',
-				'cols' => '20',
-				'max' => '512',
-				'default' => null,
-			]
-		],
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
+        'subtitle' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
+            'config' => [
+                'type' => 'text',
+                'rows' => '3',
+                'cols' => '20',
+                'max' => '512',
+                'default' => null,
+            ]
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -163,155 +163,155 @@ $result = [
                 'default' => null
             ]
         ],
-		'parent_category' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.parent_category',
-			'config' => [
-				'minitems' => 0,
-				'maxitems' => 1,
-				'type' => 'select',
+        'parent_category' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.parent_category',
+            'config' => [
+                'minitems' => 0,
+                'maxitems' => 1,
+                'type' => 'select',
                 'renderType' => 'selectTree',
-				'foreign_table' => 'tt_products_cat',
-				'foreign_table_where' => ' ORDER BY tt_products_cat.title',
-				'treeConfig' => [
-					'parentField' => 'parent_category',
-					'appearance' => [
-						'expandAll' => 1,
-						'showHeader' => true,
-						'maxLevels' => 99,
-						'width' => 500,
-					]
-				],
-				'exclude' => 1,
-				'default' => 0
-			]
-		],
-		'catid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.catid',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim',
-				'max' => '40',
-				'default' => null
-			]
-		],
-		'keyword' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
-			'config' => [
-				'type' => 'text',
-				'rows' => '5',
-				'cols' => '20',
-				'max' => '512',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'note' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			]
-		],
-		'note2' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			]
-		],
-		'image' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'image',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'file',
-				'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
+                'foreign_table' => 'tt_products_cat',
+                'foreign_table_where' => ' ORDER BY tt_products_cat.title',
+                'treeConfig' => [
+                    'parentField' => 'parent_category',
+                    'appearance' => [
+                        'expandAll' => 1,
+                        'showHeader' => true,
+                        'maxLevels' => 99,
+                        'width' => 500,
+                    ]
+                ],
+                'exclude' => 1,
+                'default' => 0
+            ]
+        ],
+        'catid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.catid',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim',
+                'max' => '40',
+                'default' => null
+            ]
+        ],
+        'keyword' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
+            'config' => [
+                'type' => 'text',
+                'rows' => '5',
+                'cols' => '20',
+                'max' => '512',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'note' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ]
+        ],
+        'note2' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ]
+        ],
+        'image' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'image',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'max_size' => 
                 isset($GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize']) ? $GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize'] : 0,
-				'uploadfolder' => $imageFolder,
-				'size' => '3',
-				'maxitems' => '10',
-				'minitems' => '0',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'sliderimage' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.sliderimage',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'file',
-				'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
+                'uploadfolder' => $imageFolder,
+                'size' => '3',
+                'maxitems' => '10',
+                'minitems' => '0',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'sliderimage' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.sliderimage',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'max_size' => 
                 isset($GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize']) ? $GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize'] : 0,
-				'uploadfolder' => $imageFolder,
-				'size' => '3',
-				'maxitems' => '10',
-				'minitems' => '0',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'discount' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.discount',
-			'config' => [
-				'type' => 'input',
-				'size' => '4',
-				'max' => '8',
-				'eval' => 'trim,double2',
-				'range' => [
-					'upper' => '1000',
-					'lower' => '0'
-				],
-				'default' => 0
-			]
-		],
-		'discount_disable' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.discount_disable',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'email_uid' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.email_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products_emails',
-				'foreign_table' => 'tt_products_emails',
-				'foreign_table_where' => ' ORDER BY tt_products_emails.name',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'highlight' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.highlight',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-	],
-	'types' => [
-		'0' =>
+                'uploadfolder' => $imageFolder,
+                'size' => '3',
+                'maxitems' => '10',
+                'minitems' => '0',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'discount' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.discount',
+            'config' => [
+                'type' => 'input',
+                'size' => '4',
+                'max' => '8',
+                'eval' => 'trim,double2',
+                'range' => [
+                    'upper' => '1000',
+                    'lower' => '0'
+                ],
+                'default' => 0
+            ]
+        ],
+        'discount_disable' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.discount_disable',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'email_uid' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.email_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products_emails',
+                'foreign_table' => 'tt_products_emails',
+                'foreign_table_where' => ' ORDER BY tt_products_emails.name',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'highlight' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat.highlight',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+    ],
+    'types' => [
+        '0' =>
             [
                 'columnsOverrides' => [
                     'note' => [

--- a/Configuration/TCA/tt_products_cat_language.php
+++ b/Configuration/TCA/tt_products_cat_language.php
@@ -10,94 +10,94 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat_language',
-		'label' => 'title',
-		'label_alt'=>  'subtitle',
-		'default_sortby' => 'ORDER BY title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat_language',
+        'label' => 'title',
+        'label_alt'=>  'subtitle',
+        'default_sortby' => 'ORDER BY title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_cat_language.gif',
-		'languageField' => 'sys_language_uid',
-		'mainpalette' => 1,
-		'searchFields' => 'title,subtitle,catid,keyword,note,note2',
-	],
-	'columns' => [
-		'sys_language_uid' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'language',
-			'config' => [
+        'languageField' => 'sys_language_uid',
+        'mainpalette' => 1,
+        'searchFields' => 'title,subtitle,catid,keyword,note,note2',
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'language',
+            'config' => [
                 'type' => 'language',
                 'default' => 0
-			]
-		],
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+            ]
+        ],
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -127,30 +127,30 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'subtitle' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
-			'config' => [
-				'type' => 'text',
-				'rows' => '3',
-				'cols' => '20',
-				'max' => '512',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'subtitle' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
+            'config' => [
+                'type' => 'text',
+                'rows' => '3',
+                'cols' => '20',
+                'max' => '512',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -169,56 +169,56 @@ $result = [
                 'default' => null
             ]
         ],
-		'keyword' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
-			'config' => [
-				'type' => 'text',
-				'rows' => '5',
-				'cols' => '20',
-				'max' => '512',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'note' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'note2' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'cat_uid' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat_language.cat_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products_cat',
-				'foreign_table' => 'tt_products_cat',
-				'foreign_table_where' => 'AND tt_products_cat.pid IN (###CURRENT_PID###) ORDER BY tt_products_cat.uid',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			],
-		],
-	],
+        'keyword' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
+            'config' => [
+                'type' => 'text',
+                'rows' => '5',
+                'cols' => '20',
+                'max' => '512',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'note' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'note2' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'cat_uid' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_cat_language.cat_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products_cat',
+                'foreign_table' => 'tt_products_cat',
+                'foreign_table_where' => 'AND tt_products_cat.pid IN (###CURRENT_PID###) ORDER BY tt_products_cat.uid',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ],
+        ],
+    ],
     'types' => [
         '0' =>
             [
@@ -238,13 +238,13 @@ $result = [
                     --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access,
                 --palette--;;access'
             ]
-	],
-	'palettes' => [
+    ],
+    'palettes' => [
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.access',
             'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.endtime_formlabel, --linebreak--, fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.fe_group_formlabel, --linebreak--',
         ],
-	]
+    ]
 ];
 
 return $result;

--- a/Configuration/TCA/tt_products_downloads.php
+++ b/Configuration/TCA/tt_products_downloads.php
@@ -10,83 +10,83 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads',
-		'label' => 'title',
-		'default_sortby' => 'ORDER BY title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads',
+        'label' => 'title',
+        'default_sortby' => 'ORDER BY title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_downloads.gif',
-		'searchFields' => 'title,marker,note',
-	],
-	'columns' => [
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'searchFields' => 'title,marker,note',
+    ],
+    'columns' => [
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -116,17 +116,17 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			]
-		],
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -145,88 +145,88 @@ $result = [
                 'default' => null
             ]
         ],
-		'author' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.author',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'max' => '256',
-				'default' => null,
-			]
-		],
-		'edition' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition.complete', '0'],
-					['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition.partial', '1'],
-				],
-				'size' => '2',
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0,
-			]
-		],
-		'marker' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.marker',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'max' => '256',
+        'author' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.author',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'max' => '256',
                 'default' => null,
-			]
-		],
-		'note' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			]
-		],
-		'path' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.path',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'max' => '256',
-				'default' => null,
-			]
-		],
-		'price_enable' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.price_enable',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'price' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.price',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim,double2',
-				'max' => '20',
-				'default' => 0
-			]
-		],
+            ]
+        ],
+        'edition' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition.complete', '0'],
+                    ['LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.edition.partial', '1'],
+                ],
+                'size' => '2',
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0,
+            ]
+        ],
+        'marker' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.marker',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
+        'note' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ]
+        ],
+        'path' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.path',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
+        'price_enable' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.price_enable',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'price' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.price',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim,double2',
+                'max' => '20',
+                'default' => 0
+            ]
+        ],
         'file_uid' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads.file_uid',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('file_uid')
             
         ],
-	],
+    ],
     'types' => [
         '0' =>
             [

--- a/Configuration/TCA/tt_products_downloads_language.php
+++ b/Configuration/TCA/tt_products_downloads_language.php
@@ -2,7 +2,7 @@
 defined('TYPO3') || die('Access denied.');
 
 // ******************************************************************
-	// This is the language overlay for products downloads table, tt_products_downloads
+    // This is the language overlay for products downloads table, tt_products_downloads
 // ******************************************************************
 
 $extensionKey = 'tt_products';
@@ -10,92 +10,92 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads_language',
-		'label' => 'title',
-		'default_sortby' => 'ORDER BY title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads_language',
+        'label' => 'title',
+        'default_sortby' => 'ORDER BY title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_downloads_language.gif',
-		'languageField' => 'sys_language_uid',
-		'searchFields' => 'title,note',
-	],
-	'columns' => [
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'languageField' => 'sys_language_uid',
+        'searchFields' => 'title,note',
+    ],
+    'columns' => [
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'sys_language_uid' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'language',
-			'config' => [
+                'default' => 0
+            ]
+        ],
+        'sys_language_uid' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'language',
+            'config' => [
                 'type' => 'language',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -125,18 +125,18 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -155,34 +155,34 @@ $result = [
                 'default' => null
             ]
         ],
-		'note' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'eval' => 'null',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'parent_uid' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads_language.parent_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products_downloads',
-				'foreign_table' => 'tt_products_downloads',
-				'foreign_table_where' => 'AND tt_products_downloads.pid IN (###CURRENT_PID###) ORDER BY tt_products_downloads.uid',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			],
-		],
-	],
-	'types' => [
+        'note' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'eval' => 'null',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'parent_uid' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_downloads_language.parent_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products_downloads',
+                'foreign_table' => 'tt_products_downloads',
+                'foreign_table_where' => 'AND tt_products_downloads.pid IN (###CURRENT_PID###) ORDER BY tt_products_downloads.uid',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ],
+        ],
+    ],
+    'types' => [
        '0' =>
             [
                 'columnsOverrides' => [

--- a/Configuration/TCA/tt_products_emails.php
+++ b/Configuration/TCA/tt_products_emails.php
@@ -6,84 +6,84 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_emails',
-		'label' => 'name',
-		'default_sortby' => 'ORDER BY name',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
-		'mainpalette' => 1,
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_emails',
+        'label' => 'name',
+        'default_sortby' => 'ORDER BY name',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'mainpalette' => 1,
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_emails.gif',
-		'searchFields' => 'name,email',
-	],
-	'columns' => [
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'searchFields' => 'name,email',
+    ],
+    'columns' => [
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -113,49 +113,49 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'name' => [
-			'label' => $languageLglPath . 'name',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '80',
-				'default' => null,
-			]
-		],
-		'email' => [
-			'label' => $languageLglPath . 'email',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '80',
-				'default' => null,
-			]
-		],
-		'suffix' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_emails.suffix',
-			'config' => [
-				'type' => 'input',
-				'size' => '24',
-				'eval' => 'trim',
-				'max' => '24',
-				'default' => null,
-			]
-		],
-	],
-	'types' => [
-		'1' => ['showitem' => 'name, email, suffix, hidden,
+        'name' => [
+            'label' => $languageLglPath . 'name',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '80',
+                'default' => null,
+            ]
+        ],
+        'email' => [
+            'label' => $languageLglPath . 'email',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '80',
+                'default' => null,
+            ]
+        ],
+        'suffix' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_emails.suffix',
+            'config' => [
+                'type' => 'input',
+                'size' => '24',
+                'eval' => 'trim',
+                'max' => '24',
+                'default' => null,
+            ]
+        ],
+    ],
+    'types' => [
+        '1' => ['showitem' => 'name, email, suffix, hidden,
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access,
                 --palette--;;access'
             ]
-	],
-	'palettes' => [
+    ],
+    'palettes' => [
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.access',
             'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.endtime_formlabel, --linebreak--, fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.fe_group_formlabel, --linebreak--',
         ],
-	]
+    ]
 ];
 
 return $result;

--- a/Configuration/TCA/tt_products_graduated_price.php
+++ b/Configuration/TCA/tt_products_graduated_price.php
@@ -119,7 +119,7 @@ $result = [
             'config' => [
                 'type' => 'input',
                 'size' => '40',
-				'eval' => 'trim',
+                'eval' => 'trim',
                 'max' => '256',
                 'default' => null,
             ]
@@ -130,7 +130,7 @@ $result = [
             'config' => [
                 'type' => 'text',
                 'cols' => '48',
-				'eval' => 'trim',
+                'eval' => 'trim',
                 'rows' => '1',
                 'default' => null
             ]

--- a/Configuration/TCA/tt_products_language.php
+++ b/Configuration/TCA/tt_products_language.php
@@ -4,7 +4,7 @@ defined('TYPO3') || die('Access denied.');
 $extensionKey = 'tt_products';
 $imageFolder = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['imageFolder'];
 if (!$imageFolder) {
-	$imageFolder = 'uploads/pics';
+    $imageFolder = 'uploads/pics';
 }
 
 // ******************************************************************
@@ -14,95 +14,95 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language',
-		'label' => 'title',
-		'label_alt' => 'subtitle',
-		'default_sortby' => 'ORDER BY title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language',
+        'label' => 'title',
+        'label_alt' => 'subtitle',
+        'default_sortby' => 'ORDER BY title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'thumbnail' => 'image_uid', // supported until TYPO3 10: breaking #92118
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_language.gif',
-		'languageField' => 'sys_language_uid',
-		'mainpalette' => 1,
-		'searchFields' => 'title,subtitle,itemnumber,ean,note,note2,www',
-	],
-	'columns' => [
-		'sys_language_uid' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'language',
-			'config' => [
+        'languageField' => 'sys_language_uid',
+        'mainpalette' => 1,
+        'searchFields' => 'title,subtitle,itemnumber,ean,note,note2,www',
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'language',
+            'config' => [
                 'type' => 'language',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -132,46 +132,46 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'prod_uid' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language.prod_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products',
-				'foreign_table' => 'tt_products',
-				'foreign_table_where' => 'AND tt_products.pid IN (###CURRENT_PID###) ORDER BY tt_products.uid',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			],
-		],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'subtitle' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
-			'config' => [
-				'type' => 'text',
-				'rows' => '3',
-				'cols' => '20',
-				'eval' => null,
-				'max' => '512',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
+        'prod_uid' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language.prod_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products',
+                'foreign_table' => 'tt_products',
+                'foreign_table_where' => 'AND tt_products.pid IN (###CURRENT_PID###) ORDER BY tt_products.uid',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ],
+        ],
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'subtitle' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.subtitle',
+            'config' => [
+                'type' => 'text',
+                'rows' => '3',
+                'cols' => '20',
+                'eval' => null,
+                'max' => '512',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
         'slug' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.slug',
@@ -190,125 +190,125 @@ $result = [
                 'default' => null
             ]
         ],
-		'keyword' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
-			'config' => [
-				'type' => 'text',
-				'rows' => '5',
-				'cols' => '20',
-				'max' => '512',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'itemnumber' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.itemnumber',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '120',
-				'default' => null,
-			]
-		],
-		'unit' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit',
-			'config' => [
-				'type' => 'input',
-				'size' => '20',
-				'eval' => 'trim',
-				'max' => '20',
-				'default' => null,
-			]
-		],
-		'note' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'note2' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '2',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'datasheet' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language.datasheet',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'file',
-				'allowed' => 'doc,htm,html,pdf,sxw,txt,xls,gif,jpg,png',
+        'keyword' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.keyword',
+            'config' => [
+                'type' => 'text',
+                'rows' => '5',
+                'cols' => '20',
+                'max' => '512',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'itemnumber' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.itemnumber',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '120',
+                'default' => null,
+            ]
+        ],
+        'unit' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.unit',
+            'config' => [
+                'type' => 'input',
+                'size' => '20',
+                'eval' => 'trim',
+                'max' => '20',
+                'default' => null,
+            ]
+        ],
+        'note' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'note2' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note2',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '2',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'datasheet' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_language.datasheet',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'allowed' => 'doc,htm,html,pdf,sxw,txt,xls,gif,jpg,png',
                 'max_size' => 
                 isset($GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize']) ? $GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize'] : 0,
-				'uploadfolder' => 'uploads/tx_ttproducts/datasheet',
-				'size' => '5',
-				'maxitems' => '20',
-				'minitems' => '0',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'www' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'www',
-			'config' => [
-				'type' => 'input',
-				'eval' => 'trim',
-				'size' => '30',
-				'max' => '160',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'image' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'image',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'file',
-				'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
+                'uploadfolder' => 'uploads/tx_ttproducts/datasheet',
+                'size' => '5',
+                'maxitems' => '20',
+                'minitems' => '0',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'www' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'www',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+                'size' => '30',
+                'max' => '160',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'image' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'image',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'max_size' => 
                 isset($GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize']) ? $GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize'] : 0,
-				'uploadfolder' => $imageFolder,
-				'size' => '3',
-				'maxitems' => '10',
-				'minitems' => '0',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-		'smallimage' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.smallimage',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'file',
-				'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
+                'uploadfolder' => $imageFolder,
+                'size' => '3',
+                'maxitems' => '10',
+                'minitems' => '0',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+        'smallimage' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.smallimage',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'max_size' => 
                 isset($GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize']) ? $GLOBALS['TYPO3_CONF_VARS']['BE']['maxFileSize'] : 0,
-				'uploadfolder' => $imageFolder,
-				'size' => '5',
-				'maxitems' => '10',
-				'minitems' => '0',
-				'eval' => 'null',
-				'default' => null,
-			]
-		],
-	],
-	'types' => [
-		'0' =>
+                'uploadfolder' => $imageFolder,
+                'size' => '5',
+                'maxitems' => '10',
+                'minitems' => '0',
+                'eval' => 'null',
+                'default' => null,
+            ]
+        ],
+    ],
+    'types' => [
+        '0' =>
             [
                 'columnsOverrides' => [
                     'note' => [
@@ -326,14 +326,14 @@ $result = [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access,
                     --palette--;;access'
             ]
-	],
-	'palettes' => [
-		'2' => ['showitem' => 'subtitle, keyword, itemnumber, www'],
+    ],
+    'palettes' => [
+        '2' => ['showitem' => 'subtitle, keyword, itemnumber, www'],
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.access',
             'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.endtime_formlabel, --linebreak--, fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.fe_group_formlabel, --linebreak--',
         ],
-	]
+    ]
 ];
 
 return $result;

--- a/Configuration/TCA/tt_products_products_mm_downloads.php
+++ b/Configuration/TCA/tt_products_products_mm_downloads.php
@@ -10,58 +10,58 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads',
-		'label' => 'uid_local',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden'
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads',
+        'label' => 'uid_local',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden'
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_relations.gif',
-		'hideTable' => true,
-	],
-	'columns' => [
-		'uid_local' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads.uid_local',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'foreign_table' => 'tt_products',
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'uid_foreign' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads.uid_foreign',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'foreign_table' => 'tt_products_downloads',
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'localsort' => [
-			'config' => [
-				'type' => 'passthrough',
-				'default' => 0
-			]
-		],
-		'foreignsort' => [
-			'config' => [
-				'type' => 'passthrough',
-				'default' => 0
-			]
-		],
-	],
-	'types' => [
-		'0' => [
-			'showitem' => ''
-		]
-	]
+        'hideTable' => true,
+    ],
+    'columns' => [
+        'uid_local' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads.uid_local',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tt_products',
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'uid_foreign' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_products_mm_downloads.uid_foreign',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tt_products_downloads',
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'localsort' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => 0
+            ]
+        ],
+        'foreignsort' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => 0
+            ]
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => ''
+        ]
+    ]
 ];
 
 return $result;

--- a/Configuration/TCA/tt_products_texts.php
+++ b/Configuration/TCA/tt_products_texts.php
@@ -1,90 +1,90 @@
 <?php
 defined('TYPO3') || die('Access denied.');
 
-	// ******************************************************************
-	// This is the standard TypoScript products texts table, tt_products_texts
-	// ******************************************************************
+    // ******************************************************************
+    // This is the standard TypoScript products texts table, tt_products_texts
+    // ******************************************************************
 $extensionKey = 'tt_products';
 $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts',
-		'label' => 'title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_texts.gif',
-		'searchFields' => 'title,marker,note',
-	],
-	'columns' => [
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'searchFields' => 'title,marker,note',
+    ],
+    'columns' => [
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+                'default' => 0
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
-				'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -114,68 +114,68 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null,
-			]
-		],
-		'marker' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.marker',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'eval' => 'trim',
-				'max' => '256',
-				'default' => null
-			]
-		],
-		'note' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			]
-		],
-		'parentid' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.parentid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products',
-				'prepend_tname' => false,
-				'foreign_table_where' => 'AND tt_products.pid IN (###CURRENT_PID###) ORDER BY tt_products.title',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			]
-		],
-		'parenttable' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.parenttable',
-			'config' => [
-				'type' => 'select',
-				'renderType' => 'selectSingle',
-				'items' => [
-					['tt_products', 'tt_products']
-				],
-				'default' => 'tt_products'
-			]
-		],
-	],
-	'types' => [
-		'0' =>
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null,
+            ]
+        ],
+        'marker' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.marker',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'eval' => 'trim',
+                'max' => '256',
+                'default' => null
+            ]
+        ],
+        'note' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ]
+        ],
+        'parentid' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.parentid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products',
+                'prepend_tname' => false,
+                'foreign_table_where' => 'AND tt_products.pid IN (###CURRENT_PID###) ORDER BY tt_products.title',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ]
+        ],
+        'parenttable' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts.parenttable',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['tt_products', 'tt_products']
+                ],
+                'default' => 'tt_products'
+            ]
+        ],
+    ],
+    'types' => [
+        '0' =>
             [
                 'columnsOverrides' => [
                     'note' => [
@@ -188,13 +188,13 @@ $result = [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access,
                     --palette--;;access'
             ]
-	],
-	'palettes' => [
+    ],
+    'palettes' => [
         'access' => [
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.access',
             'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.endtime_formlabel, --linebreak--, fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.fe_group_formlabel, --linebreak--',
         ],
-	]
+    ]
 ];
 
 return $result;

--- a/Configuration/TCA/tt_products_texts_language.php
+++ b/Configuration/TCA/tt_products_texts_language.php
@@ -9,91 +9,91 @@ $languageSubpath = '/Resources/Private/Language/';
 $languageLglPath = 'LLL:EXT:core' . $languageSubpath . 'locallang_general.xlf:LGL.';
 
 $result = [
-	'ctrl' => [
-		'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts_language',
-		'label' => 'title',
-		'tstamp' => 'tstamp',
-		'delete' => 'deleted',
-		'enablecolumns' => [
-			'disabled' => 'hidden',
-			'starttime' => 'starttime',
-			'endtime' => 'endtime',
-			'fe_group' => 'fe_group',
-		],
-		'prependAtCopy' => $languageLglPath . 'prependAtCopy',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'versioningWS' => true,
-		'origUid' => 't3_origuid',
+    'ctrl' => [
+        'title' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts_language',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
+        ],
+        'prependAtCopy' => $languageLglPath . 'prependAtCopy',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
         'iconfile' => 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . 'tt_products_texts_language.gif',
-		'languageField' => 'sys_language_uid',
-		'searchFields' => 'title,note',
-	],
-	'columns' => [
-		'tstamp' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
+        'languageField' => 'sys_language_uid',
+        'searchFields' => 'title,note',
+    ],
+    'columns' => [
+        'tstamp' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tstamp',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'crdate' => [
-			'exclude' => 1,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'datetime,int',
-                'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'sys_language_uid' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'language',
-			'config' => [
-                'type' => 'language',
-				'default' => 0
-			]
-		],
-		'hidden' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'hidden',
-			'config' => [
-				'type' => 'check',
                 'default' => 0
-			]
-		],
-		'starttime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'starttime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+            ]
+        ],
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:crdate',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'datetime,int',
                 'renderType' => 'inputDateTime',
-				'default' => 0
-			]
-		],
-		'endtime' => [
-			'exclude' => 1,
-			'label' => $languageLglPath . 'endtime',
-			'config' => [
-				'type' => 'input',
-				'size' => '8',
-				'eval' => 'date',
+                'default' => 0
+            ]
+        ],
+        'sys_language_uid' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'language',
+            'config' => [
+                'type' => 'language',
+                'default' => 0
+            ]
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0
+            ]
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
                 'renderType' => 'inputDateTime',
-				'default' => 0,
-				'range' => [
-					'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
-					'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
-				]
-			]
-		],
+                'default' => 0
+            ]
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => $languageLglPath . 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => '8',
+                'eval' => 'date',
+                'renderType' => 'inputDateTime',
+                'default' => 0,
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$extensionKey]['endtimeYear']),
+                    'lower' => mktime(0, 0, 0, date('n') - 1, date('d'), date('Y'))
+                ]
+            ]
+        ],
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
@@ -123,45 +123,45 @@ $result = [
                 'default' => 0,
             ]
         ],
-		'title' => [
-			'exclude' => 0,
-			'label' => $languageLglPath . 'title',
-			'config' => [
-				'type' => 'input',
-				'size' => '40',
-				'max' => '256',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'note' => [
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
-			'config' => [
-				'type' => 'text',
-				'cols' => '48',
-				'rows' => '5',
-				'default' => null,
-			],
-			'l10n_mode' => 'prefixLangTitle',
-		],
-		'text_uid' => [
-			'exclude' => 0,
-			'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts_language.text_uid',
-			'config' => [
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'tt_products_texts',
-				'foreign_table' => 'tt_products_texts',
-				'foreign_table_where' => 'AND tt_products_texts.pid IN (###CURRENT_PID###) ORDER BY tt_products_texts.uid',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-				'default' => 0
-			],
-		],
-	],
-	'types' => [
-		'0' => [
+        'title' => [
+            'exclude' => 0,
+            'label' => $languageLglPath . 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => '40',
+                'max' => '256',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'note' => [
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products.note',
+            'config' => [
+                'type' => 'text',
+                'cols' => '48',
+                'rows' => '5',
+                'default' => null,
+            ],
+            'l10n_mode' => 'prefixLangTitle',
+        ],
+        'text_uid' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:' . $extensionKey . $languageSubpath . 'locallang_db.xlf:tt_products_texts_language.text_uid',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tt_products_texts',
+                'foreign_table' => 'tt_products_texts',
+                'foreign_table_where' => 'AND tt_products_texts.pid IN (###CURRENT_PID###) ORDER BY tt_products_texts.uid',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                'default' => 0
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
             'columnsOverrides' => [
                 'note' => [
                     'config' => [

--- a/api/class.tx_ttproducts_api.php
+++ b/api/class.tx_ttproducts_api.php
@@ -43,805 +43,805 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class tx_ttproducts_api {
 
-	static public function roundPrice ($value, $format) {
+    static public function roundPrice ($value, $format) {
 
-		$result = $oldValue = $value;
-		$priceRoundFormatArray = [];
-		$dotPos = strpos($value, '.');
-		$floatLen = strlen($value) - $dotPos - 1;
+        $result = $oldValue = $value;
+        $priceRoundFormatArray = [];
+        $dotPos = strpos($value, '.');
+        $floatLen = strlen($value) - $dotPos - 1;
 
-		if (strpos($format, '.') !== false) {
-			$priceRoundFormatArray = GeneralUtility::trimExplode('.', $format);
-		} else {
-			$priceRoundFormatArray['0'] = $format;
-		}
+        if (strpos($format, '.') !== false) {
+            $priceRoundFormatArray = GeneralUtility::trimExplode('.', $format);
+        } else {
+            $priceRoundFormatArray['0'] = $format;
+        }
 
-		if ($priceRoundFormatArray['0'] != '') {
-			$integerPart = intval($priceRoundFormatArray['0']);
-			$floatPart = $oldValue - intval($oldValue);
-			$faktor = pow(10, strlen($integerPart));
-			$result = (intval($oldValue / $faktor) * $faktor) + $integerPart + $floatPart;
+        if ($priceRoundFormatArray['0'] != '') {
+            $integerPart = intval($priceRoundFormatArray['0']);
+            $floatPart = $oldValue - intval($oldValue);
+            $faktor = pow(10, strlen($integerPart));
+            $result = (intval($oldValue / $faktor) * $faktor) + $integerPart + $floatPart;
 
-			if ($result < $oldValue) {
-				$result += $faktor;
-			}
+            if ($result < $oldValue) {
+                $result += $faktor;
+            }
 
-			$oldValue = $result;
-		}
+            $oldValue = $result;
+        }
 
-		if (isset($priceRoundFormatArray['1'])) {
+        if (isset($priceRoundFormatArray['1'])) {
 
-			$formatText = $priceRoundFormatArray['1'];
-			$digits = 0;
-			while(substr($formatText, $digits, 1) == 'X') {
-				$digits++;
-			}
-			$floatValue = substr($formatText, $digits);
-			$faktor = pow(10, $digits);
+            $formatText = $priceRoundFormatArray['1'];
+            $digits = 0;
+            while(substr($formatText, $digits, 1) == 'X') {
+                $digits++;
+            }
+            $floatValue = substr($formatText, $digits);
+            $faktor = pow(10, $digits);
 
-			if ($floatValue == '') {
-				$result = round($oldValue, $digits);
-			} else {
-				$allowedChars = '';
-				$lowestValuePart = 0;
-				$length = strlen($floatValue);
+            if ($floatValue == '') {
+                $result = round($oldValue, $digits);
+            } else {
+                $allowedChars = '';
+                $lowestValuePart = 0;
+                $length = strlen($floatValue);
 
-				if (
-					$length > 3 &&
-					strpos($floatValue, '[') === 0 &&
-					strpos($floatValue, ']') === ($length - 1)
-				) {
-					$allowedChars = substr($floatValue, 1, $length - 2);
+                if (
+                    $length > 3 &&
+                    strpos($floatValue, '[') === 0 &&
+                    strpos($floatValue, ']') === ($length - 1)
+                ) {
+                    $allowedChars = substr($floatValue, 1, $length - 2);
 
-					if ($allowedChars != '') {
-						$digitValue = intval(round($value * $faktor * 10)) % 10;
-						$countAllowedChars = strlen($allowedChars);
-						$step = intval(10 / $countAllowedChars);
-						$allowedPos = 0;
-						$finalAddition = $digitValue;
-						$lowChar = '';
-						$lowValue = -20;
-						$highChar = '';
-						$highValue = 20;
-						$bKeepChar = false;
+                    if ($allowedChars != '') {
+                        $digitValue = intval(round($value * $faktor * 10)) % 10;
+                        $countAllowedChars = strlen($allowedChars);
+                        $step = intval(10 / $countAllowedChars);
+                        $allowedPos = 0;
+                        $finalAddition = $digitValue;
+                        $lowChar = '';
+                        $lowValue = -20;
+                        $highChar = '';
+                        $highValue = 20;
+                        $bKeepChar = false;
 
-						for ($allowedPos = 0; $allowedPos < $countAllowedChars; $allowedPos++) {
+                        for ($allowedPos = 0; $allowedPos < $countAllowedChars; $allowedPos++) {
 
-							$currentChar = substr($allowedChars, $allowedPos, 1);
-							$currentValue = intval($currentChar);
+                            $currentChar = substr($allowedChars, $allowedPos, 1);
+                            $currentValue = intval($currentChar);
 
-							if ($lowChar == '') {
-								$lowChar = $currentChar;
-								$lowValue = $currentValue;
-							}
+                            if ($lowChar == '') {
+                                $lowChar = $currentChar;
+                                $lowValue = $currentValue;
+                            }
 
-							if ($highChar == '') {
-								$highChar = $currentChar;
-								$highValue = $currentValue;
-							}
+                            if ($highChar == '') {
+                                $highChar = $currentChar;
+                                $highValue = $currentValue;
+                            }
 
-							if (
-								$digitValue == $currentChar &&
-								$floatLen == ($length - 2)
-							) { // '0' means '10'
-								$bKeepChar = true;
-								break;
-							} else {
-								$comparatorLow1 = $digitValue - $currentValue;
-								if ($comparatorLow1 < 0) {
-									$comparatorLow1 += 10;
-								}
+                            if (
+                                $digitValue == $currentChar &&
+                                $floatLen == ($length - 2)
+                            ) { // '0' means '10'
+                                $bKeepChar = true;
+                                break;
+                            } else {
+                                $comparatorLow1 = $digitValue - $currentValue;
+                                if ($comparatorLow1 < 0) {
+                                    $comparatorLow1 += 10;
+                                }
 
-								$comparatorLow2 = $digitValue - $lowValue;
+                                $comparatorLow2 = $digitValue - $lowValue;
 
-								if ($comparatorLow2 < 0) {
-									$comparatorLow2 += 10;
-								}
+                                if ($comparatorLow2 < 0) {
+                                    $comparatorLow2 += 10;
+                                }
 
-								if (
-									$comparatorLow1 < $comparatorLow2
-								) {
-									$lowChar = $currentChar;
-									$lowValue = $currentValue;
-								}
+                                if (
+                                    $comparatorLow1 < $comparatorLow2
+                                ) {
+                                    $lowChar = $currentChar;
+                                    $lowValue = $currentValue;
+                                }
 
-								$comparatorHigh1 = $currentValue - $digitValue;
+                                $comparatorHigh1 = $currentValue - $digitValue;
 
-								if ($comparatorHigh1 < 0) {
-									$comparatorHigh1 += 10;
-								}
+                                if ($comparatorHigh1 < 0) {
+                                    $comparatorHigh1 += 10;
+                                }
 
-								$comparatorHigh2 = $highValue - $digitValue;
+                                $comparatorHigh2 = $highValue - $digitValue;
 
-								if ($comparatorHigh2 < 0) {
-									$comparatorHigh2 += 10;
-								}
+                                if ($comparatorHigh2 < 0) {
+                                    $comparatorHigh2 += 10;
+                                }
 
-								if ($comparatorHigh1 < $comparatorHigh2) {
-									$highChar = $currentChar;
-									$highValue = $currentValue;
-								}
-							}
+                                if ($comparatorHigh1 < $comparatorHigh2) {
+                                    $highChar = $currentChar;
+                                    $highValue = $currentValue;
+                                }
+                            }
 
-							if (
-								!$bKeepChar &&
-								$lowValue != $highValue
-							) {
-								$comparator2 = $highValue - $digitValue;
-								$highAddition = 0;
-								if ($comparator2 < 0) {
-									$comparator2 += 10;
-									$highAddition = 10;
-								}
+                            if (
+                                !$bKeepChar &&
+                                $lowValue != $highValue
+                            ) {
+                                $comparator2 = $highValue - $digitValue;
+                                $highAddition = 0;
+                                if ($comparator2 < 0) {
+                                    $comparator2 += 10;
+                                    $highAddition = 10;
+                                }
 
-								if ($digitValue - $lowValue < $comparator2) {
-									$finalAddition = $lowValue;
-								} else {
-									$finalAddition = $highValue + $highAddition;
-								}
-							}
-						}
-						$lowestValuePart = (intval($finalAddition) / ($faktor * 10));
-					}
-				} else if (
-					MathUtility::canBeInterpretedAsInteger($floatValue)
-				) {
-					$floatPart =  $floatValue * $faktor * 10;
-					$lowestValuePart = (intval($floatPart) / ($faktor * 10));
-				}
+                                if ($digitValue - $lowValue < $comparator2) {
+                                    $finalAddition = $lowValue;
+                                } else {
+                                    $finalAddition = $highValue + $highAddition;
+                                }
+                            }
+                        }
+                        $lowestValuePart = (intval($finalAddition) / ($faktor * 10));
+                    }
+                } else if (
+                    MathUtility::canBeInterpretedAsInteger($floatValue)
+                ) {
+                    $floatPart =  $floatValue * $faktor * 10;
+                    $lowestValuePart = (intval($floatPart) / ($faktor * 10));
+                }
 
-				if (!$bKeepChar) {
-					$result = intval($oldValue * $faktor) / $faktor + $lowestValuePart;
-				}
-			}
-		}
+                if (!$bKeepChar) {
+                    $result = intval($oldValue * $faktor) / $faktor + $lowestValuePart;
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/* get the templateCode for an error message  */
-	static public function getErrorOut (
-		$theCode,
-		$templateCode,
-		$subpartMarker,
-		$alternativeSubpartMarker,
-		&$errorCode
-	) {
+    /* get the templateCode for an error message  */
+    static public function getErrorOut (
+        $theCode,
+        $templateCode,
+        $subpartMarker,
+        $alternativeSubpartMarker,
+        &$errorCode
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$result = false;
+        $result = false;
 
-		if (
-			$subpartMarker != '' &&
-			strpos($templateCode, $subpartMarker) !== false
-				||
-			$alternativeSubpartMarker != '' &&
-			strpos($templateCode, $alternativeSubpartMarker) !== false
-		) {
-			$errorTemplateCode = $templateCode;
-		} else {
-			$templateFile = '';
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$errorTemplateCode = $templateObj->get(
-				$theCode,
-				$templateFile,
-				$errorCode
-			);
-			if (
-				$errorTemplateCode == '' ||
-				strpos($errorTemplateCode, $subpartMarker) === false &&
-				strpos($errorTemplateCode, $alternativeSubpartMarker) === false
-			) {
-				$errorTemplateCode = $templateObj->get(
-					'ERROR',
-					$templateFile,
-					$errorCode
-				);
-			}
-		}
+        if (
+            $subpartMarker != '' &&
+            strpos($templateCode, $subpartMarker) !== false
+                ||
+            $alternativeSubpartMarker != '' &&
+            strpos($templateCode, $alternativeSubpartMarker) !== false
+        ) {
+            $errorTemplateCode = $templateCode;
+        } else {
+            $templateFile = '';
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $errorTemplateCode = $templateObj->get(
+                $theCode,
+                $templateFile,
+                $errorCode
+            );
+            if (
+                $errorTemplateCode == '' ||
+                strpos($errorTemplateCode, $subpartMarker) === false &&
+                strpos($errorTemplateCode, $alternativeSubpartMarker) === false
+            ) {
+                $errorTemplateCode = $templateObj->get(
+                    'ERROR',
+                    $templateFile,
+                    $errorCode
+                );
+            }
+        }
 
-		if ($errorTemplateCode != '') {
-			$errorOut = false;
+        if ($errorTemplateCode != '') {
+            $errorOut = false;
 
-			if ($subpartMarker != '' || $alternativeSubpartMarker != '') {
-				if (
-					$subpartMarker != '' &&
-					strpos($errorTemplateCode, $subpartMarker) !== false
-				) {
-					$errorOut =
-						$templateService->getSubpart(
-							$errorTemplateCode,
-							$subpartMarker
-						);
-				} else if (
-					$alternativeSubpartMarker != '' &&
-					strpos($errorTemplateCode, $alternativeSubpartMarker) !== false
-				) {
-					$errorOut =
-						$templateService->getSubpart(
-							$errorTemplateCode,
-							$alternativeSubpartMarker
-						);
-				}
-			} else {
-				$errorOut = $errorTemplateCode;
-			}
-			$result = $errorOut;
+            if ($subpartMarker != '' || $alternativeSubpartMarker != '') {
+                if (
+                    $subpartMarker != '' &&
+                    strpos($errorTemplateCode, $subpartMarker) !== false
+                ) {
+                    $errorOut =
+                        $templateService->getSubpart(
+                            $errorTemplateCode,
+                            $subpartMarker
+                        );
+                } else if (
+                    $alternativeSubpartMarker != '' &&
+                    strpos($errorTemplateCode, $alternativeSubpartMarker) !== false
+                ) {
+                    $errorOut =
+                        $templateService->getSubpart(
+                            $errorTemplateCode,
+                            $alternativeSubpartMarker
+                        );
+                }
+            } else {
+                $errorOut = $errorTemplateCode;
+            }
+            $result = $errorOut;
 
-			if ($result == '') {
-				$errorCode[0] = 'no_subtemplate';
-				$errorCode[1] = $subpartMarker;
-				$errorCode[2] = $templateFile;
-			}
-		}
+            if ($result == '') {
+                $errorCode[0] = 'no_subtemplate';
+                $errorCode[1] = $subpartMarker;
+                $errorCode[2] = $templateFile;
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	static public function createFeuser (
-		$bAllowCreation,
-		$templateCode,
-		$conf,
-		$infoObj,
-		$basketView,
-		$calculatedArray,
-		$fromArray
-	) {
-		$result = false;
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$infoArray = $infoObj->infoArray;
-		$apostrophe = $conf['orderEmail_apostrophe'];
+    static public function createFeuser (
+        $bAllowCreation,
+        $templateCode,
+        $conf,
+        $infoObj,
+        $basketView,
+        $calculatedArray,
+        $fromArray
+    ) {
+        $result = false;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $infoArray = $infoObj->infoArray;
+        $apostrophe = $conf['orderEmail_apostrophe'];
 
-		$pid = ($conf['PIDuserFolder'] ? $conf['PIDuserFolder'] : ($conf['PIDbasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id));
-		$pid = intval($pid);
-		$username = strtolower(trim($infoArray['billing']['email']));
-		$rowArray =
-			$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-				'uid,username', 'fe_users', 'username=' .
-					$GLOBALS['TYPO3_DB']->fullQuoteStr(
-						$username, 'fe_users'
-					) . ' AND pid=' . $pid . ' AND deleted=0'
-			);
-		$num_rows = count($rowArray);
+        $pid = ($conf['PIDuserFolder'] ? $conf['PIDuserFolder'] : ($conf['PIDbasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id));
+        $pid = intval($pid);
+        $username = strtolower(trim($infoArray['billing']['email']));
+        $rowArray =
+            $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                'uid,username', 'fe_users', 'username=' .
+                    $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                        $username, 'fe_users'
+                    ) . ' AND pid=' . $pid . ' AND deleted=0'
+            );
+        $num_rows = count($rowArray);
 
-		if ($num_rows) {
-			if (isset($rowArray['0']) && is_array($rowArray['0']) && isset($rowArray['0']['uid'])) {
-				$result = intval($rowArray['0']['uid']);
-			}
-		} else if ($bAllowCreation) {
-			$password = substr(md5(rand()), 0, 12);
-			$infoObj->password = $password;
+        if ($num_rows) {
+            if (isset($rowArray['0']) && is_array($rowArray['0']) && isset($rowArray['0']['uid'])) {
+                $result = intval($rowArray['0']['uid']);
+            }
+        } else if ($bAllowCreation) {
+            $password = substr(md5(rand()), 0, 12);
+            $infoObj->password = $password;
             try {
                 $hashInstance = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory::class)->getDefaultHashInstance('FE');
                 $password = $hashInstance->getHashedPassword($password);
             } catch (TYPO3\CMS\Core\Crypto\PasswordHashing\InvalidPasswordHashException $e) {
                 debug ($tmp, 'no FE user could be generated!'); // keep this
             }
-			$tableFieldArray = $tablesObj->get('fe_users')->getTableObj()->tableFieldArray;
-			$insertFields = [	// TODO: check with TCA
-				'pid' => intval($pid),
-				'tstamp' => time(),
-				'crdate' => time(),
-				'username' => $username,
-				'password' => $password,
-				'usergroup' => $conf['memberOfGroup']
-			];
+            $tableFieldArray = $tablesObj->get('fe_users')->getTableObj()->tableFieldArray;
+            $insertFields = [	// TODO: check with TCA
+                'pid' => intval($pid),
+                'tstamp' => time(),
+                'crdate' => time(),
+                'username' => $username,
+                'password' => $password,
+                'usergroup' => $conf['memberOfGroup']
+            ];
 
-			foreach ($tableFieldArray as $fieldname => $value) {
-				$fieldvalue = $infoArray['billing'][$fieldname] ?? null;
-				if (isset($fieldvalue)) {
-					$insertFields[$fieldname] = $fieldvalue;
-				}
-			}
+            foreach ($tableFieldArray as $fieldname => $value) {
+                $fieldvalue = $infoArray['billing'][$fieldname] ?? null;
+                if (isset($fieldvalue)) {
+                    $insertFields[$fieldname] = $fieldvalue;
+                }
+            }
 
-			if (
-				\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('agency') ||
-				\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('femanager') ||
-				\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('sr_feuser_register')
-			) {
-				if ($conf['useStaticInfoCountry'] && isset($infoArray['billing']['country_code'])) {
-					$insertFields['static_info_country'] = $infoArray['billing']['country_code'];
-				} else {
-					$insertFields['static_info_country'] = '';
-				}
-			}
+            if (
+                \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('agency') ||
+                \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('femanager') ||
+                \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('sr_feuser_register')
+            ) {
+                if ($conf['useStaticInfoCountry'] && isset($infoArray['billing']['country_code'])) {
+                    $insertFields['static_info_country'] = $infoArray['billing']['country_code'];
+                } else {
+                    $insertFields['static_info_country'] = '';
+                }
+            }
 
-			if(!empty($infoArray['billing']['date_of_birth'])) {
-				$date = str_replace('-', '/', $infoArray['billing']['date_of_birth']);
-				$insertFields['date_of_birth'] = strtotime($date);
-			}
+            if(!empty($infoArray['billing']['date_of_birth'])) {
+                $date = str_replace('-', '/', $infoArray['billing']['date_of_birth']);
+                $insertFields['date_of_birth'] = strtotime($date);
+            }
 
-			$res = $GLOBALS['TYPO3_DB']->exec_INSERTquery('fe_users', $insertFields);
-			// send new user mail
-			if (!empty($infoArray['billing']['email'])) {
-				$empty = '';
-				$emailContent = trim(
-					$basketView->getView(
-						$errorCode,
-						$templateCode,
-						'EMAIL',
-						$infoObj,
-						false,
-						false,
-						$calculatedArray,
-						false,
-						'EMAIL_NEWUSER_TEMPLATE',
-						[],
-						'',
-						[],
+            $res = $GLOBALS['TYPO3_DB']->exec_INSERTquery('fe_users', $insertFields);
+            // send new user mail
+            if (!empty($infoArray['billing']['email'])) {
+                $empty = '';
+                $emailContent = trim(
+                    $basketView->getView(
+                        $errorCode,
+                        $templateCode,
+                        'EMAIL',
+                        $infoObj,
+                        false,
+                        false,
+                        $calculatedArray,
+                        false,
+                        'EMAIL_NEWUSER_TEMPLATE',
+                        [],
+                        '',
+                        [],
                         $notOverwritePriceIfSet = true,
-						[],
-						[],
-						[],
-						[]
-					)
-				);
+                        [],
+                        [],
+                        [],
+                        []
+                    )
+                );
 
-				if ($emailContent != '') {
-					$parts = explode(chr(10), $emailContent, 2);
-					$subject = trim($parts[0]);
-					$plain_message = trim($parts[1]);
-					$tmp = '';
+                if ($emailContent != '') {
+                    $parts = explode(chr(10), $emailContent, 2);
+                    $subject = trim($parts[0]);
+                    $plain_message = trim($parts[1]);
+                    $tmp = '';
 
-					\JambageCom\Div2007\Utility\MailUtility::send(
-						$infoArray['billing']['email'],
-						$apostrophe . $subject . $apostrophe,
-						$plain_message,
-						$tmp,
-						$fromArray['shop']['email'],
-						$fromArray['shop']['name'],
-						'',
-						'',
-						'',
-						'',
-						'',
-						TT_PRODUCTS_EXT,
-						'sendMail'
-					);
-				}
-			}
+                    \JambageCom\Div2007\Utility\MailUtility::send(
+                        $infoArray['billing']['email'],
+                        $apostrophe . $subject . $apostrophe,
+                        $plain_message,
+                        $tmp,
+                        $fromArray['shop']['email'],
+                        $fromArray['shop']['name'],
+                        '',
+                        '',
+                        '',
+                        '',
+                        '',
+                        TT_PRODUCTS_EXT,
+                        'sendMail'
+                    );
+                }
+            }
 
-			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'uid',
-				'fe_users',
-				'username=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($username, 'fe_users') .
-					' AND pid=' . $pid . ' AND deleted=0');
+            $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                'uid',
+                'fe_users',
+                'username=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($username, 'fe_users') .
+                    ' AND pid=' . $pid . ' AND deleted=0');
 
-			while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-				$result = intval($row['uid']);
-				break;
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		}
+            while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                $result = intval($row['uid']);
+                break;
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	static public function splitSubjectAndText (
-		$templateCode,
-		$defaultSubject,
-		$markerArray,
-		&$subject,
-		&$text
-	) {
+    static public function splitSubjectAndText (
+        $templateCode,
+        $defaultSubject,
+        $markerArray,
+        &$subject,
+        &$text
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$parts = preg_split('/[\n\r]+/', $templateCode, 2);	// First line is subject
-		$subject = trim($parts[0]);
-		$text = trim($parts[1]);
+        $parts = preg_split('/[\n\r]+/', $templateCode, 2);	// First line is subject
+        $subject = trim($parts[0]);
+        $text = trim($parts[1]);
 
-		if (empty($text)) {	// the user did not use the subject field
-			$text = $subject;
-		}
-		$text = $templateService->substituteMarkerArrayCached($text, $markerArray);
-		if (empty($subject)) {
-			$subject = $defaultSubject;
-		}
-	}
+        if (empty($text)) {	// the user did not use the subject field
+            $text = $subject;
+        }
+        $text = $templateService->substituteMarkerArrayCached($text, $markerArray);
+        if (empty($subject)) {
+            $subject = $defaultSubject;
+        }
+    }
 
 
 
-	static public function generateBillNo (
-		$orderUid,
-		$orderPrefix
-	) {
-		$newNumber = 1;
-		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-			'uid,bill_no',
-			'sys_products_orders',
-			'bill_no > \'\'',
-			'',
-			'uid DESC',
-			'1'
-		);
+    static public function generateBillNo (
+        $orderUid,
+        $orderPrefix
+    ) {
+        $newNumber = 1;
+        $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+            'uid,bill_no',
+            'sys_products_orders',
+            'bill_no > \'\'',
+            '',
+            'uid DESC',
+            '1'
+        );
 
-		if (
-			is_array($rows) &&
-			isset($rows['0']) &&
-			!empty($rows['0']['bill_no'])
-		) {
-			$billNo = $rows['0']['bill_no'];
-			$found = preg_match_all('/([\d]+)/', $billNo, $match);
+        if (
+            is_array($rows) &&
+            isset($rows['0']) &&
+            !empty($rows['0']['bill_no'])
+        ) {
+            $billNo = $rows['0']['bill_no'];
+            $found = preg_match_all('/([\d]+)/', $billNo, $match);
 
-			if (
-				$found &&
-				isset($match) &&
-				is_array($match) &&
-				isset($match[0]) &&
-				is_array($match[0])
-			) {
-				$newNumber = $match[0][0] + 1;
-			}
-		}
-		$newNumber = $orderPrefix . $newNumber;
+            if (
+                $found &&
+                isset($match) &&
+                is_array($match) &&
+                isset($match[0]) &&
+                is_array($match[0])
+            ) {
+                $newNumber = $match[0][0] + 1;
+            }
+        }
+        $newNumber = $orderPrefix . $newNumber;
 
-		return $newNumber;
-	}
+        return $newNumber;
+    }
 
-	/**
-	 * Finalize an order
-	 *
-	 * This finalizes an order. The basket info has already been saved before on the payment page, if
-	 * a payment gateway is called afterwards.
-	 * A finalized order is then marked 'not hidden' and with status=1
-	 * The basket is also emptied, but address info is preserved for any new orders.
-	 * $orderUid is the order-uid to finalize
-	 * $mainMarkerArray is optional and may be pre-prepared fields for substitutiong in the template.
-	 *
-	 */
-	static public function finalizeOrder (
-		$pObj,
-		$templateCode,
-		$mainMarkerArray,
-		$functablename,
-		$orderUid,
-		&$orderArray,
-		$itemArray,
-		$calculatedArray,
-		$addressArray,
-		$basketExtra,
-		$basketRecs,
-		$basketExtGift,
-		$usedCreditpoints,
-		$bDebug,
-		&$errorMessage
-	) {
+    /**
+     * Finalize an order
+     *
+     * This finalizes an order. The basket info has already been saved before on the payment page, if
+     * a payment gateway is called afterwards.
+     * A finalized order is then marked 'not hidden' and with status=1
+     * The basket is also emptied, but address info is preserved for any new orders.
+     * $orderUid is the order-uid to finalize
+     * $mainMarkerArray is optional and may be pre-prepared fields for substitutiong in the template.
+     *
+     */
+    static public function finalizeOrder (
+        $pObj,
+        $templateCode,
+        $mainMarkerArray,
+        $functablename,
+        $orderUid,
+        &$orderArray,
+        $itemArray,
+        $calculatedArray,
+        $addressArray,
+        $basketExtra,
+        $basketRecs,
+        $basketExtGift,
+        $usedCreditpoints,
+        $bDebug,
+        &$errorMessage
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
         $result = true;
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config'); // init ok
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config'); // init ok
 // $markerObj  init ok
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables'); // init ok
-		$billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
-		$fileArray = []; // bill or delivery
-		$voucherCount = 0;
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables'); // init ok
+        $billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
+        $fileArray = []; // bill or delivery
+        $voucherCount = 0;
 
-		$activityFinalize = GeneralUtility::makeInstance('tx_ttproducts_activity_finalize');
+        $activityFinalize = GeneralUtility::makeInstance('tx_ttproducts_activity_finalize');
 
-		$emailObj = $tablesObj->get('tt_products_emails');
-		$orderObj = $tablesObj->get('sys_products_orders');
-		$cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-		$conf = $cnfObj->getConf();
-		$customerEmailHTML = '';
+        $emailObj = $tablesObj->get('tt_products_emails');
+        $orderObj = $tablesObj->get('sys_products_orders');
+        $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $conf = $cnfObj->getConf();
+        $customerEmailHTML = '';
 
-		$orderRow =
-			$orderObj->get(
-				$orderUid,
-				0,
-				false,
-				'',
-				'',
-				'',
-				'',
-				'uid,hidden,feusers_uid,status,bill_no',
-				false,
-				'',
-				false
-			);
+        $orderRow =
+            $orderObj->get(
+                $orderUid,
+                0,
+                false,
+                '',
+                '',
+                '',
+                '',
+                'uid,hidden,feusers_uid,status,bill_no',
+                false,
+                '',
+                false
+            );
 
-		if (
-			!empty($orderRow) &&
-			is_array($orderRow) &&
-			$orderRow['hidden'] == '0' &&
-			$orderRow['status'] != '0'
-		) {
-			return false; // the order has already been processed before
-		}
-		$orderObj->updateRecord($orderUid, ['hidden' =>  0]); // mark this order immediately as unhidden in order to let no instant message from the gateway execute the following PHP code twice
+        if (
+            !empty($orderRow) &&
+            is_array($orderRow) &&
+            $orderRow['hidden'] == '0' &&
+            $orderRow['status'] != '0'
+        ) {
+            return false; // the order has already been processed before
+        }
+        $orderObj->updateRecord($orderUid, ['hidden' =>  0]); // mark this order immediately as unhidden in order to let no instant message from the gateway execute the following PHP code twice
 
-		$instockTableArray = '';
-		$customerEmail = $infoViewObj->getCustomerEmail();
-		$defaultFromArray = $infoViewObj->getFromArray($customerEmail);
+        $instockTableArray = '';
+        $customerEmail = $infoViewObj->getCustomerEmail();
+        $defaultFromArray = $infoViewObj->getFromArray($customerEmail);
 
-		$emailControlArray =
-			$activityFinalize->getEmailControlArray(
-				$templateCode,
-				$conf,
-				$defaultFromArray
-			);
+        $emailControlArray =
+            $activityFinalize->getEmailControlArray(
+                $templateCode,
+                $conf,
+                $defaultFromArray
+            );
 
-		if (isset($emailControlArray['customer'])) {
-			$markerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = implode(',', $emailControlArray['customer']['none']['recipient']);
+        if (isset($emailControlArray['customer'])) {
+            $markerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = implode(',', $emailControlArray['customer']['none']['recipient']);
 
-			$customerEmailHTML =
-				$basketView->getView(
-					$errorCode,
-					$templateCode,
-					'EMAIL',
-					$infoViewObj,
-					false,
-					false,
-					$calculatedArray,
-					true,
-					$emailControlArray['customer']['none']['htmltemplate'],
-					$markerArray,
-					'',
-					$itemArray,
+            $customerEmailHTML =
+                $basketView->getView(
+                    $errorCode,
+                    $templateCode,
+                    'EMAIL',
+                    $infoViewObj,
+                    false,
+                    false,
+                    $calculatedArray,
+                    true,
+                    $emailControlArray['customer']['none']['htmltemplate'],
+                    $markerArray,
+                    '',
+                    $itemArray,
                     $notOverwritePriceIfSet = true,
-					['0' => $orderArray],
-					[],
-					$basketExtra,
-					$basketRecs
-				);
-		}
+                    ['0' => $orderArray],
+                    [],
+                    $basketExtra,
+                    $basketRecs
+                );
+        }
 
-		if ($GLOBALS['TSFE']->absRefPrefix == '') {
-			$absRefPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
-			$markerArray['"index.php'] = '"' . $absRefPrefix . 'index.php';
-		}
+        if ($GLOBALS['TSFE']->absRefPrefix == '') {
+            $absRefPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
+            $markerArray['"index.php'] = '"' . $absRefPrefix . 'index.php';
+        }
 
-		$apostrophe = $conf['orderEmail_apostrophe'];
-		$bdArray = $billdeliveryObj->getTypeArray();
+        $apostrophe = $conf['orderEmail_apostrophe'];
+        $bdArray = $billdeliveryObj->getTypeArray();
 
-		foreach ($bdArray as $type) {
-			if (
-				isset($conf[$type . '.']) &&
-				is_array($conf[$type . '.']) &&
-				$conf[$type . '.']['generation'] == 'auto'
-			) {
-				if (
+        foreach ($bdArray as $type) {
+            if (
+                isset($conf[$type . '.']) &&
+                is_array($conf[$type . '.']) &&
+                $conf[$type . '.']['generation'] == 'auto'
+            ) {
+                if (
                     $type == 'bill' &&
                     !$orderRow['bill_no']
-				) {
-					$newBillNumber = self::generateBillNo(
-						$orderUid,
-						substr($conf['orderBillNumberPrefix'] ?? '', 0, 30)
-					);
-					$orderArray['bill_no'] = $newBillNumber;
-				}
+                ) {
+                    $newBillNumber = self::generateBillNo(
+                        $orderUid,
+                        substr($conf['orderBillNumberPrefix'] ?? '', 0, 30)
+                    );
+                    $orderArray['bill_no'] = $newBillNumber;
+                }
 
-				$absFilename =
-					$billdeliveryObj->generateBill(
-						$cObj,
-						$templateCode,
-						$mainMarkerArray,
-						$itemArray,
-						$calculatedArray,
-						$orderArray,
-						$basketExtra,
-						$basketRecs,
-						$type,
-						$conf[$type . '.']
-					);
+                $absFilename =
+                    $billdeliveryObj->generateBill(
+                        $cObj,
+                        $templateCode,
+                        $mainMarkerArray,
+                        $itemArray,
+                        $calculatedArray,
+                        $orderArray,
+                        $basketExtra,
+                        $basketRecs,
+                        $type,
+                        $conf[$type . '.']
+                    );
 
                 if ($absFilename) {
-					$fileArray[$type] = $absFilename;
-				}
-			}
-		}
+                    $fileArray[$type] = $absFilename;
+                }
+            }
+        }
 
-		if (
-			isset($conf['gift.']) &&
-			isset($conf['gift.']['type']) &&
-			$conf['gift.']['type'] == 'voucher' &&
-			isset($conf['whereGift']) &&
-			$conf['whereGift'] != ''
-		) {
-			$voucherCount = 0;
-			$codeArray = [];
-			tx_ttproducts_voucher::generate($voucherCount, $codeArray, $orderUid, $itemArray, $conf['whereGift']);
-		}
+        if (
+            isset($conf['gift.']) &&
+            isset($conf['gift.']['type']) &&
+            $conf['gift.']['type'] == 'voucher' &&
+            isset($conf['whereGift']) &&
+            $conf['whereGift'] != ''
+        ) {
+            $voucherCount = 0;
+            $codeArray = [];
+            tx_ttproducts_voucher::generate($voucherCount, $codeArray, $orderUid, $itemArray, $conf['whereGift']);
+        }
 
-		$orderObj->putData(
-			$orderUid,
-			$orderArray,
-			$itemArray,
-			$customerEmailHTML,
-			1,
-			$basketExtra,
-			$calculatedArray,
-			'',
-			[], // TODO: $giftServiceArticleArray,
-			'', // TODO: $vouchercode
-			$usedCreditpoints,
-			$voucherCount,
-			!$bDebug // if true, then the order record must already be existing
-		);
+        $orderObj->putData(
+            $orderUid,
+            $orderArray,
+            $itemArray,
+            $customerEmailHTML,
+            1,
+            $basketExtra,
+            $calculatedArray,
+            '',
+            [], // TODO: $giftServiceArticleArray,
+            '', // TODO: $vouchercode
+            $usedCreditpoints,
+            $voucherCount,
+            !$bDebug // if true, then the order record must already be existing
+        );
 
-		$creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
-		$creditpointsObj->pay();
+        $creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
+        $creditpointsObj->pay();
 
-		// any gift orders in the extended basket?
-		if ($basketExtGift) {
-			$pid = intval($conf['PIDGiftsTable']);
+        // any gift orders in the extended basket?
+        if ($basketExtGift) {
+            $pid = intval($conf['PIDGiftsTable']);
 
-			if (!$pid) {
-				$pid = intval($GLOBALS['TSFE']->id);
-			}
+            if (!$pid) {
+                $pid = intval($GLOBALS['TSFE']->id);
+            }
 
-			$rc = tx_ttproducts_gifts_div::saveOrderRecord(
-				$orderUid,
-				$pid,
-				$basketExtGift
-			);
-		}
-		$theCode = 'FINALIZE';
-		$orderObj->createMM($orderUid, $itemArray, $theCode);
-		$addcsv = '';
+            $rc = tx_ttproducts_gifts_div::saveOrderRecord(
+                $orderUid,
+                $pid,
+                $basketExtGift
+            );
+        }
+        $theCode = 'FINALIZE';
+        $orderObj->createMM($orderUid, $itemArray, $theCode);
+        $addcsv = '';
 
-		// Generate CSV for each order
-		if ($conf['generateCSV']) {
-			// get bank account info
-			$account = $tablesObj->get('sys_products_accounts');
-			$accountUid = $account->getUid();
+        // Generate CSV for each order
+        if ($conf['generateCSV']) {
+            // get bank account info
+            $account = $tablesObj->get('sys_products_accounts');
+            $accountUid = $account->getUid();
 
-			$csv = GeneralUtility::makeInstance('tx_ttproducts_csv');
+            $csv = GeneralUtility::makeInstance('tx_ttproducts_csv');
             
             $csvfilepath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/' . $conf['CSVdestination'];
 
-			$csv->create(
-				$functablename,
-				$conf,
-				$itemArray,
-				$calculatedArray,
-				$accountUid,
-				$infoViewObj,
-				$orderUid,
-				$basketExtra,
-				$csvfilepath,
-				$errorMessage
-			);
-			if (!$conf['CSVnotInEmail']) {
-				$addcsv = $csvfilepath;
-			}
-		}
+            $csv->create(
+                $functablename,
+                $conf,
+                $itemArray,
+                $calculatedArray,
+                $accountUid,
+                $infoViewObj,
+                $orderUid,
+                $basketExtra,
+                $csvfilepath,
+                $errorMessage
+            );
+            if (!$conf['CSVnotInEmail']) {
+                $addcsv = $csvfilepath;
+            }
+        }
 
-		// Generate XML for each order
-		if ($conf['generateXML']) {
-			$orderXML =
-				trim (
-					$basketView->getView(
-						$errorCode,
-						$templateCode,
-						'EMAIL',
-						$infoViewObj,
-						false,
-						true,
-						$calculatedArray,
-						true,
-						'BASKET_ORDERXML_TEMPLATE',
-						$mainMarkerArray,
-						'',
-						$itemArray,
+        // Generate XML for each order
+        if ($conf['generateXML']) {
+            $orderXML =
+                trim (
+                    $basketView->getView(
+                        $errorCode,
+                        $templateCode,
+                        'EMAIL',
+                        $infoViewObj,
+                        false,
+                        true,
+                        $calculatedArray,
+                        true,
+                        'BASKET_ORDERXML_TEMPLATE',
+                        $mainMarkerArray,
+                        '',
+                        $itemArray,
                         $notOverwritePriceIfSet = true,
-						['0' => $orderArray],
-						[],
-						$basketExtra,
-						$basketRecs
-					)
-				);
+                        ['0' => $orderArray],
+                        [],
+                        $basketExtra,
+                        $basketRecs
+                    )
+                );
 
             if ($orderXML) {
                 $csvfilepath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/' . $conf['XMLdestination'];
 
-				if (substr($xmlFilepath, strlen($xmlFilepath) - 1, 1) != '/') {
-					$xmlFilepath .= '/';
-				}
-				$xmlFilepath .= $orderObj->getNumber($orderUid) . '.xml';
-				$xmlFile = fopen($xmlFilepath, 'w');
-				fwrite($xmlFile, $orderXML);
-				fclose($xmlFile);
-			}
-		}
+                if (substr($xmlFilepath, strlen($xmlFilepath) - 1, 1) != '/') {
+                    $xmlFilepath .= '/';
+                }
+                $xmlFilepath .= $orderObj->getNumber($orderUid) . '.xml';
+                $xmlFile = fopen($xmlFilepath, 'w');
+                fwrite($xmlFile, $orderXML);
+                fclose($xmlFile);
+            }
+        }
 
 // #################################
 
-		$markerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
-		$empty = '';
+        $markerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
+        $empty = '';
 
-		if ($conf['orderEmail_toAddress']) {
-			$infoViewObjArray = $addressArray;
-			if (is_array($infoViewObjArray) && count($infoViewObjArray)) {
-				foreach ($infoViewObjArray as $infoViewObjUid => $infoViewObjRow) {
-					if (
-						!isset($emailControlArray['shop']['none']['recipient']) ||
-						!in_array($infoViewObjRow['email'], $emailControlArray['shop']['none']['recipient'])
-					) {
-						$emailControlArray['shop']['none']['recipient'][] = $infoViewObjRow['email'];
-					}
-				}
-			}
-		}
+        if ($conf['orderEmail_toAddress']) {
+            $infoViewObjArray = $addressArray;
+            if (is_array($infoViewObjArray) && count($infoViewObjArray)) {
+                foreach ($infoViewObjArray as $infoViewObjUid => $infoViewObjRow) {
+                    if (
+                        !isset($emailControlArray['shop']['none']['recipient']) ||
+                        !in_array($infoViewObjRow['email'], $emailControlArray['shop']['none']['recipient'])
+                    ) {
+                        $emailControlArray['shop']['none']['recipient'][] = $infoViewObjRow['email'];
+                    }
+                }
+            }
+        }
 
-		if (
-			isset($conf['orderEmail.']) && is_array($conf['orderEmail.'])
-		) {
-			foreach ($conf['orderEmail.'] as $k => $emailConfig) {
+        if (
+            isset($conf['orderEmail.']) && is_array($conf['orderEmail.'])
+        ) {
+            foreach ($conf['orderEmail.'] as $k => $emailConfig) {
 
-				$suffix = strtolower($emailConfig['suffix']);
-				if (!isset($suffix)) {
-					$suffix = 'shop';
-				}
+                $suffix = strtolower($emailConfig['suffix']);
+                if (!isset($suffix)) {
+                    $suffix = 'shop';
+                }
 
-				if (
-					!empty($emailConfig['to'])  ||
-					!empty($emailConfig['to.']) ||
-					$suffix == 'shop' ||
-					$suffix == 'customer'
-				) {
-					if (!empty($emailConfig['shipping_point'])) {
-						$shippingPoint = strtolower($emailConfig['shipping_point']);
-					} else {
-						$shippingPoint = 'none';
-					}
+                if (
+                    !empty($emailConfig['to'])  ||
+                    !empty($emailConfig['to.']) ||
+                    $suffix == 'shop' ||
+                    $suffix == 'customer'
+                ) {
+                    if (!empty($emailConfig['shipping_point'])) {
+                        $shippingPoint = strtolower($emailConfig['shipping_point']);
+                    } else {
+                        $shippingPoint = 'none';
+                    }
 
-					if (!empty($emailConfig['to.'])) {
-						$toConfig = $emailConfig['to.'];
-						if (
+                    if (!empty($emailConfig['to.'])) {
+                        $toConfig = $emailConfig['to.'];
+                        if (
                             \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
                             !empty($GLOBALS['TSFE']->fe_user->user) &&
-							!empty($GLOBALS['TSFE']->fe_user->user['username']) &&
-							$toConfig['table'] == 'fe_users' &&
-							!empty($toConfig['field']) &&
-							!empty($toConfig['foreign_table']) &&
-							!empty($toConfig['foreign_field']) &&
-							!empty($toConfig['foreign_email_field']) &&
-							!empty($GLOBALS['TSFE']->fe_user->user[$toConfig['field']])
-						) {
-							$where_clause =
-								$toConfig['foreign_table'] . '.' .
-									$toConfig['foreign_field'] . '=' .
-									$GLOBALS['TYPO3_DB']->fullQuoteStr(
-										$GLOBALS['TSFE']->fe_user->user[$toConfig['field']],
-										$toConfig['foreign_table']
-									);
-							$recordArray =
-								$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-									$toConfig['foreign_email_field'],
-									$toConfig['foreign_table'],
-									$where_clause
-								);
+                            !empty($GLOBALS['TSFE']->fe_user->user['username']) &&
+                            $toConfig['table'] == 'fe_users' &&
+                            !empty($toConfig['field']) &&
+                            !empty($toConfig['foreign_table']) &&
+                            !empty($toConfig['foreign_field']) &&
+                            !empty($toConfig['foreign_email_field']) &&
+                            !empty($GLOBALS['TSFE']->fe_user->user[$toConfig['field']])
+                        ) {
+                            $where_clause =
+                                $toConfig['foreign_table'] . '.' .
+                                    $toConfig['foreign_field'] . '=' .
+                                    $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                                        $GLOBALS['TSFE']->fe_user->user[$toConfig['field']],
+                                        $toConfig['foreign_table']
+                                    );
+                            $recordArray =
+                                $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                                    $toConfig['foreign_email_field'],
+                                    $toConfig['foreign_table'],
+                                    $where_clause
+                                );
 
-							if (isset($recordArray) && is_array($recordArray)) {
-								foreach ($recordArray as $record) {
-									if (!empty($record[$toConfig['foreign_email_field']])) {
-										$emailControlArray[$suffix][$shippingPoint]['recipient'][] = $record[$toConfig['foreign_email_field']];
-									}
-								}
-							}
-						}
-					}
+                            if (isset($recordArray) && is_array($recordArray)) {
+                                foreach ($recordArray as $record) {
+                                    if (!empty($record[$toConfig['foreign_email_field']])) {
+                                        $emailControlArray[$suffix][$shippingPoint]['recipient'][] = $record[$toConfig['foreign_email_field']];
+                                    }
+                                }
+                            }
+                        }
+                    }
 
-					$emailControlArray[$suffix][$shippingPoint]['attachmentFile'] = [];
+                    $emailControlArray[$suffix][$shippingPoint]['attachmentFile'] = [];
 
-					if (!empty($emailConfig['to'])) {
-						$emailArray = GeneralUtility::trimExplode(',', $emailConfig['to']);
+                    if (!empty($emailConfig['to'])) {
+                        $emailArray = GeneralUtility::trimExplode(',', $emailConfig['to']);
 
-						foreach ($emailArray as $email) {
-							if (
-								!isset($emailControlArray[$suffix][$shippingPoint]['recipient']) ||
-								is_array($emailControlArray[$suffix][$shippingPoint]['recipient']) &&
-								!in_array($email, $emailControlArray[$suffix][$shippingPoint]['recipient'])
-							) {
-								$emailControlArray[$suffix][$shippingPoint]['recipient'][] = $email;
-							}
-						}
-					}
+                        foreach ($emailArray as $email) {
+                            if (
+                                !isset($emailControlArray[$suffix][$shippingPoint]['recipient']) ||
+                                is_array($emailControlArray[$suffix][$shippingPoint]['recipient']) &&
+                                !in_array($email, $emailControlArray[$suffix][$shippingPoint]['recipient'])
+                            ) {
+                                $emailControlArray[$suffix][$shippingPoint]['recipient'][] = $email;
+                            }
+                        }
+                    }
 
-					if (!empty($emailConfig['attachment'])) {
-						$emailControlArray[$suffix][$shippingPoint]['attachment'] = GeneralUtility::trimExplode(',', $emailConfig['attachment']);
+                    if (!empty($emailConfig['attachment'])) {
+                        $emailControlArray[$suffix][$shippingPoint]['attachment'] = GeneralUtility::trimExplode(',', $emailConfig['attachment']);
 
                         foreach($emailControlArray[$suffix][$shippingPoint]['attachment'] as $attachmentType) {
                             if (isset($fileArray[$attachmentType])) {
@@ -850,282 +850,282 @@ class tx_ttproducts_api {
                         }
                     }
 
-					if ($suffix != 'customer') {
+                    if ($suffix != 'customer') {
 
-						$templateSubpart = 'EMAIL_PLAINTEXT_TEMPLATE_' . strtoupper($suffix);
-						$htmlTemplateSubpart = 'EMAIL_HTML_TEMPLATE_' . strtoupper($suffix);
-						if (
-							$suffix == 'shop'
-						) {
-							if (strpos($templateCode, $templateSubpart) === false) {
-								$templateSubpart = $emailControlArray['customer']['none']['template'];
-							}
-							if (strpos($templateCode, $htmlTemplateSubpart) === false) {
-								$htmlTemplateSubpart = $emailControlArray['customer']['none']['htmltemplate'];
-							}
-						}
+                        $templateSubpart = 'EMAIL_PLAINTEXT_TEMPLATE_' . strtoupper($suffix);
+                        $htmlTemplateSubpart = 'EMAIL_HTML_TEMPLATE_' . strtoupper($suffix);
+                        if (
+                            $suffix == 'shop'
+                        ) {
+                            if (strpos($templateCode, $templateSubpart) === false) {
+                                $templateSubpart = $emailControlArray['customer']['none']['template'];
+                            }
+                            if (strpos($templateCode, $htmlTemplateSubpart) === false) {
+                                $htmlTemplateSubpart = $emailControlArray['customer']['none']['htmltemplate'];
+                            }
+                        }
 
-						$emailControlArray[$suffix][$shippingPoint]['template'] = $templateSubpart;
-						$emailControlArray[$suffix][$shippingPoint]['htmltemplate'] = $htmlTemplateSubpart;
+                        $emailControlArray[$suffix][$shippingPoint]['template'] = $templateSubpart;
+                        $emailControlArray[$suffix][$shippingPoint]['htmltemplate'] = $htmlTemplateSubpart;
 
-						if ($addcsv != '') {
-							$emailControlArray[$suffix][$shippingPoint]['attachmentFile'][] = $addcsv;
-						}
-					}
+                        if ($addcsv != '') {
+                            $emailControlArray[$suffix][$shippingPoint]['attachmentFile'][] = $addcsv;
+                        }
+                    }
 
-					if ($suffix == 'shop' && isset($conf['orderEmail_bcc'])) {
-						$emailControlArray[$suffix][$shippingPoint]['bcc'] = $conf['orderEmail_bcc'];
-					}
+                    if ($suffix == 'shop' && isset($conf['orderEmail_bcc'])) {
+                        $emailControlArray[$suffix][$shippingPoint]['bcc'] = $conf['orderEmail_bcc'];
+                    }
 
-					if (!$emailConfig['from'] || $emailConfig['from'] == 'shop') {
-						$emailControlArray[$suffix][$shippingPoint]['from'] = $defaultFromArray['shop'];
-					} else if ($emailConfig['from'] == 'customer') {
-						$emailControlArray[$suffix][$shippingPoint]['from'] = $defaultFromArray['customer'];
-					} else if (isset($emailConfig['from.'])) {
-						$emailControlArray[$suffix][$shippingPoint]['from'] = [
-							'email' => $emailConfig['from.']['email'],
-							'name' => $emailConfig['from.']['name']
-						];
-					}
+                    if (!$emailConfig['from'] || $emailConfig['from'] == 'shop') {
+                        $emailControlArray[$suffix][$shippingPoint]['from'] = $defaultFromArray['shop'];
+                    } else if ($emailConfig['from'] == 'customer') {
+                        $emailControlArray[$suffix][$shippingPoint]['from'] = $defaultFromArray['customer'];
+                    } else if (isset($emailConfig['from.'])) {
+                        $emailControlArray[$suffix][$shippingPoint]['from'] = [
+                            'email' => $emailConfig['from.']['email'],
+                            'name' => $emailConfig['from.']['name']
+                        ];
+                    }
 
-					if ($shippingPoint != 'none') {
-						$emailControlArray[$suffix][$shippingPoint]['recipient'] = array_unique(GeneralUtility::trimExplode(',', $emailConfig['to']));
-						if (!empty($emailConfig['subject'])) {
-							$emailControlArray[$suffix][$shippingPoint]['subject'] = $emailConfig['subject'];
-						}
-					}
+                    if ($shippingPoint != 'none') {
+                        $emailControlArray[$suffix][$shippingPoint]['recipient'] = array_unique(GeneralUtility::trimExplode(',', $emailConfig['to']));
+                        if (!empty($emailConfig['subject'])) {
+                            $emailControlArray[$suffix][$shippingPoint]['subject'] = $emailConfig['subject'];
+                        }
+                    }
 
-					if (isset($emailConfig['returnPath'])) {
-						$emailControlArray[$suffix][$shippingPoint]['returnPath'] = $emailConfig['returnPath'];
-					}
-				}
-			}
-		}
+                    if (isset($emailConfig['returnPath'])) {
+                        $emailControlArray[$suffix][$shippingPoint]['returnPath'] = $emailConfig['returnPath'];
+                    }
+                }
+            }
+        }
 
-		if (
-			isset($conf['orderEmail_radio.']) &&
-			is_array($conf['orderEmail_radio.']) &&
-			isset($conf['orderEmail_radio.']['1.']) &&
-			is_array($conf['orderEmail_radio.']) &&
-			isset($conf['orderEmail_radio.']['1.'][$infoViewObj->infoArray['delivery']['radio1']])
-		) {
-			$emailControlArray['radio1']['none']['recipient'][] = $conf['orderEmail_radio.']['1.'][$infoViewObj->infoArray['delivery']['radio1']];
-		}
+        if (
+            isset($conf['orderEmail_radio.']) &&
+            is_array($conf['orderEmail_radio.']) &&
+            isset($conf['orderEmail_radio.']['1.']) &&
+            is_array($conf['orderEmail_radio.']) &&
+            isset($conf['orderEmail_radio.']['1.'][$infoViewObj->infoArray['delivery']['radio1']])
+        ) {
+            $emailControlArray['radio1']['none']['recipient'][] = $conf['orderEmail_radio.']['1.'][$infoViewObj->infoArray['delivery']['radio1']];
+        }
 
-		if (isset($emailControlArray['radio1']['none']['recipient'])) {
-			$emailControlArray['radio1']['none']['template'] = 'EMAIL_PLAINTEXT_TEMPLATE_RADIO1';
-			$emailControlArray['radio1']['none']['htmltemplate'] = 'EMAIL_HTML_TEMPLATE_RADIO1';
-		}
+        if (isset($emailControlArray['radio1']['none']['recipient'])) {
+            $emailControlArray['radio1']['none']['template'] = 'EMAIL_PLAINTEXT_TEMPLATE_RADIO1';
+            $emailControlArray['radio1']['none']['htmltemplate'] = 'EMAIL_HTML_TEMPLATE_RADIO1';
+        }
 
-		if ($conf['orderEmail_order2']) {
-			$emailControlArray['customer']['none']['recipient'] = array_merge($emailControlArray['customer']['none']['recipient'], $emailControlArray['shop']['none']['recipient']);
-			$emailControlArray['customer']['none']['recipient'] = array_unique($emailControlArray['customer']['none']['recipient']);
-		}
-		$customerHTMLmailContent = '';
-		$posEmailPlaintext = strpos($templateCode, $emailControlArray['customer']['none']['template']);
+        if ($conf['orderEmail_order2']) {
+            $emailControlArray['customer']['none']['recipient'] = array_merge($emailControlArray['customer']['none']['recipient'], $emailControlArray['shop']['none']['recipient']);
+            $emailControlArray['customer']['none']['recipient'] = array_unique($emailControlArray['customer']['none']['recipient']);
+        }
+        $customerHTMLmailContent = '';
+        $posEmailPlaintext = strpos($templateCode, $emailControlArray['customer']['none']['template']);
 
-		if (
-			$templateCode != '' &&
-			($posEmailPlaintext !== false || $conf['orderEmail_htmlmail'])
-		) {
-			if ($conf['orderEmail_htmlmail']) {	// If htmlmail lib is included, then generate a nice HTML-email
-				$HTMLmailShell = $templateService->getSubpart($templateCode, '###EMAIL_HTML_SHELL###');
+        if (
+            $templateCode != '' &&
+            ($posEmailPlaintext !== false || $conf['orderEmail_htmlmail'])
+        ) {
+            if ($conf['orderEmail_htmlmail']) {	// If htmlmail lib is included, then generate a nice HTML-email
+                $HTMLmailShell = $templateService->getSubpart($templateCode, '###EMAIL_HTML_SHELL###');
 
-				$customerHTMLmailContent =
-					$templateService->substituteMarker(
-						$HTMLmailShell,
-						'###HTML_BODY###',
-						$customerEmailHTML
-					);
-				$customerHTMLmailContent =
-					$templateService->substituteMarkerArray(
-						$customerHTMLmailContent,
-						$markerArray
-					);
+                $customerHTMLmailContent =
+                    $templateService->substituteMarker(
+                        $HTMLmailShell,
+                        '###HTML_BODY###',
+                        $customerEmailHTML
+                    );
+                $customerHTMLmailContent =
+                    $templateService->substituteMarkerArray(
+                        $customerHTMLmailContent,
+                        $markerArray
+                    );
 
-					// Remove image tags to the products:
-				if (!empty($conf['orderEmail_htmlmail.']['removeImagesWithPrefix'])) {
+                    // Remove image tags to the products:
+                if (!empty($conf['orderEmail_htmlmail.']['removeImagesWithPrefix'])) {
                     $htmlParser = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Html\HtmlParser::class);
-					$htmlMailParts = $htmlParser->splitTags('img', $customerHTMLmailContent);
+                    $htmlMailParts = $htmlParser->splitTags('img', $customerHTMLmailContent);
 
-					foreach($htmlMailParts as $kkk => $vvv) {
-						if ($kkk%2) {
-							list($attrib) = $htmlParser->get_tag_attributes($vvv);
-							if (GeneralUtility::isFirstPartOfStr($attrib['src'], $conf['orderEmail_htmlmail.']['removeImagesWithPrefix'])) {
-								$htmlMailParts[$kkk] = '';
-							}
-						}
-					}
-					$customerHTMLmailContent = implode('', $htmlMailParts);
-				}
-			} else {	// ... else just plain text...
-				// nothing to initialize
-			}
+                    foreach($htmlMailParts as $kkk => $vvv) {
+                        if ($kkk%2) {
+                            list($attrib) = $htmlParser->get_tag_attributes($vvv);
+                            if (GeneralUtility::isFirstPartOfStr($attrib['src'], $conf['orderEmail_htmlmail.']['removeImagesWithPrefix'])) {
+                                $htmlMailParts[$kkk] = '';
+                            }
+                        }
+                    }
+                    $customerHTMLmailContent = implode('', $htmlMailParts);
+                }
+            } else {	// ... else just plain text...
+                // nothing to initialize
+            }
 
-			$agbAttachment = ($conf['AGBattachment'] ? GeneralUtility::getFileAbsFileName($conf['AGBattachment']) : '');
+            $agbAttachment = ($conf['AGBattachment'] ? GeneralUtility::getFileAbsFileName($conf['AGBattachment']) : '');
 
-			if ($agbAttachment != '') {
-				$emailControlArray['customer']['none']['attachmentFile'][] = $agbAttachment;
+            if ($agbAttachment != '') {
+                $emailControlArray['customer']['none']['attachmentFile'][] = $agbAttachment;
 
-				if (isset($emailControlArray['radio1']['none']['recipient'])) {
+                if (isset($emailControlArray['radio1']['none']['recipient'])) {
 
-					$emailControlArray['radio1']['none']['attachmentFile'][] = $agbAttachment;
-				}
-			}
+                    $emailControlArray['radio1']['none']['attachmentFile'][] = $agbAttachment;
+                }
+            }
 
-			$categoryInserted = [];
-			$shippingPointInserted = [];
+            $categoryInserted = [];
+            $shippingPointInserted = [];
 
-			// send distributor emails from email entered at the category level
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					$extArray = $row['ext'];
-					$category = $row['category'];
-					$shipping_point = strtolower($row['shipping_point'] ?? '');
-					$suffix = 'shop';
+            // send distributor emails from email entered at the category level
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    $extArray = $row['ext'];
+                    $category = $row['category'];
+                    $shipping_point = strtolower($row['shipping_point'] ?? '');
+                    $suffix = 'shop';
 
-					if (!empty($categoryInserted[$category])) {
-						$suffix = $categoryInserted[$category];
-					} else if ($category) {
+                    if (!empty($categoryInserted[$category])) {
+                        $suffix = $categoryInserted[$category];
+                    } else if ($category) {
                         $emailRow = null;
-						$categoryArray = $tablesObj->get('tt_products_cat')->get($category);
-						if (!empty(($categoryArray['email_uid']))) {
+                        $categoryArray = $tablesObj->get('tt_products_cat')->get($category);
+                        if (!empty(($categoryArray['email_uid']))) {
                             $emailRow = $emailObj->getEmail($categoryArray['email_uid']);
                         }
 
-						if (isset($emailRow) && is_array($emailRow)) {
-							$email = $emailRow['email'];
-							$emailArray = [];
-							if (!empty($emailRow['name'])) {
-								$emailArray = [$email => $emailArray['name']];
-							} else {
-								$emailArray = [$email];
-							}
+                        if (isset($emailRow) && is_array($emailRow)) {
+                            $email = $emailRow['email'];
+                            $emailArray = [];
+                            if (!empty($emailRow['name'])) {
+                                $emailArray = [$email => $emailArray['name']];
+                            } else {
+                                $emailArray = [$email];
+                            }
 
-							if (!empty($emailRow['suffix'])) {
-								$suffix = strtolower($emailRow['suffix']);
-							}
+                            if (!empty($emailRow['suffix'])) {
+                                $suffix = strtolower($emailRow['suffix']);
+                            }
 
-							if (
-								!isset($emailControlArray[$suffix]['none']['recipient']) ||
-								is_array($emailControlArray[$suffix]['none']['recipient']) &&
-								!in_array($email, $emailControlArray[$suffix]['none']['recipient'])
-							) {
-								$emailControlArray[$suffix]['none']['recipient'][] = $emailArray;
-							}
-						}
-						$categoryInserted[$category] = $suffix;
-					}
+                            if (
+                                !isset($emailControlArray[$suffix]['none']['recipient']) ||
+                                is_array($emailControlArray[$suffix]['none']['recipient']) &&
+                                !in_array($email, $emailControlArray[$suffix]['none']['recipient'])
+                            ) {
+                                $emailControlArray[$suffix]['none']['recipient'][] = $emailArray;
+                            }
+                        }
+                        $categoryInserted[$category] = $suffix;
+                    }
 
 // TODO hier die FAL Bedingung eintragen. Und hier die Rechnung erzeugen.
-					if (
-						$suffix == 'shop' // not for category specific suffix
-					) {
-						$addItem = false;
-						if (
-							isset($extArray['records']) &&
-							is_array($extArray['records'])
-						) {
-							if (
-								isset($emailControlArray['download'])
-							) {
-								$externalRowArray = $extArray['records'];
-								foreach ($externalRowArray as $tablename => $externalRow) {
-									if ($tablename == 'sys_file_reference') {
-										$suffix = 'download';
-										$addItem = true;
-										break;
-									}
-								}
-							}
-						} else {
-							if (
-								isset($emailControlArray['product'])
-							) {
-								$suffix = 'product';
-								$addItem = true;
-							}
-						}
+                    if (
+                        $suffix == 'shop' // not for category specific suffix
+                    ) {
+                        $addItem = false;
+                        if (
+                            isset($extArray['records']) &&
+                            is_array($extArray['records'])
+                        ) {
+                            if (
+                                isset($emailControlArray['download'])
+                            ) {
+                                $externalRowArray = $extArray['records'];
+                                foreach ($externalRowArray as $tablename => $externalRow) {
+                                    if ($tablename == 'sys_file_reference') {
+                                        $suffix = 'download';
+                                        $addItem = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            if (
+                                isset($emailControlArray['product'])
+                            ) {
+                                $suffix = 'product';
+                                $addItem = true;
+                            }
+                        }
 
-						if ($addItem) {
-							$emailControlArray[$suffix]['none']['itemArray'][$sort][] = $actItem;
-						}
-						$suffix = 'shop';
-					}
+                        if ($addItem) {
+                            $emailControlArray[$suffix]['none']['itemArray'][$sort][] = $actItem;
+                        }
+                        $suffix = 'shop';
+                    }
 
-					$emailControlArray[$suffix]['none']['itemArray'][$sort][] = $actItem;
+                    $emailControlArray[$suffix]['none']['itemArray'][$sort][] = $actItem;
 
-					if ($shipping_point) {
-						foreach ($emailControlArray as $suffix => $shippingControl) {
-							foreach ($shippingControl as $shippingKey => $shippingPointControl) {
-								// the shippingKey can be comma separated multiple value
-								$shippingKeyArray = GeneralUtility::trimExplode(',', $shippingKey);
-								foreach ($shippingKeyArray as $key) {
-									if (
-										$key == $shipping_point &&
-										isset($shippingControl[$shippingKey]) &&
-										is_array($shippingControl[$shippingKey]) &&
-										(
-											!isset($emailControlArray[$suffix][$shippingKey]) ||
-											!isset($emailControlArray[$suffix][$shippingKey]['itemArray']) ||
-											!isset($emailControlArray[$suffix][$shippingKey]['itemArray'][$sort]) ||
-											!in_array($actItem, $emailControlArray[$suffix][$shippingKey]['itemArray'][$sort])
-										)
-									) {
-										$emailControlArray[$suffix][$shippingKey]['itemArray'][$sort][] =
-											$actItem;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+                    if ($shipping_point) {
+                        foreach ($emailControlArray as $suffix => $shippingControl) {
+                            foreach ($shippingControl as $shippingKey => $shippingPointControl) {
+                                // the shippingKey can be comma separated multiple value
+                                $shippingKeyArray = GeneralUtility::trimExplode(',', $shippingKey);
+                                foreach ($shippingKeyArray as $key) {
+                                    if (
+                                        $key == $shipping_point &&
+                                        isset($shippingControl[$shippingKey]) &&
+                                        is_array($shippingControl[$shippingKey]) &&
+                                        (
+                                            !isset($emailControlArray[$suffix][$shippingKey]) ||
+                                            !isset($emailControlArray[$suffix][$shippingKey]['itemArray']) ||
+                                            !isset($emailControlArray[$suffix][$shippingKey]['itemArray'][$sort]) ||
+                                            !in_array($actItem, $emailControlArray[$suffix][$shippingKey]['itemArray'][$sort])
+                                        )
+                                    ) {
+                                        $emailControlArray[$suffix][$shippingKey]['itemArray'][$sort][] =
+                                            $actItem;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			$reducedCalculatedArray = $calculatedArray; // TODO: allow calculation on reduced products
+            $reducedCalculatedArray = $calculatedArray; // TODO: allow calculation on reduced products
 
-			foreach ($emailControlArray as $suffix => $shippingControlArray) {
+            foreach ($emailControlArray as $suffix => $shippingControlArray) {
 
-				foreach ($shippingControlArray as $shippingPoint => $suffixControlArray) {
-					if (isset($suffixControlArray) && is_array($suffixControlArray)) {
+                foreach ($shippingControlArray as $shippingPoint => $suffixControlArray) {
+                    if (isset($suffixControlArray) && is_array($suffixControlArray)) {
 
-						if (
-							isset($suffixControlArray['itemArray']) &&
-							is_array($suffixControlArray['itemArray'])
-						) {
-							$basketItemArray = $suffixControlArray['itemArray'];
-						} else if ($suffix == 'customer' || $suffix == 'shop') {
-							$basketItemArray = $itemArray;
-						} else {
-							$basketItemArray = '';
-						}
+                        if (
+                            isset($suffixControlArray['itemArray']) &&
+                            is_array($suffixControlArray['itemArray'])
+                        ) {
+                            $basketItemArray = $suffixControlArray['itemArray'];
+                        } else if ($suffix == 'customer' || $suffix == 'shop') {
+                            $basketItemArray = $itemArray;
+                        } else {
+                            $basketItemArray = '';
+                        }
                         $basketText = '';
                         $basketHtml = '';
 
-						if (isset($basketItemArray) && is_array($basketItemArray)) {
+                        if (isset($basketItemArray) && is_array($basketItemArray)) {
 
-							$basketText =
-								$basketView->getView(
-									$errorCode,
-									$templateCode,
-									'EMAIL',
-									$infoViewObj,
-									false,
-									true,
-									$reducedCalculatedArray,
-									false,
-									$suffixControlArray['template'],
-									$mainMarkerArray,
-									'',
-									$basketItemArray,
+                            $basketText =
+                                $basketView->getView(
+                                    $errorCode,
+                                    $templateCode,
+                                    'EMAIL',
+                                    $infoViewObj,
+                                    false,
+                                    true,
+                                    $reducedCalculatedArray,
+                                    false,
+                                    $suffixControlArray['template'],
+                                    $mainMarkerArray,
+                                    '',
+                                    $basketItemArray,
                                     $notOverwritePriceIfSet = true,
-									['0' => $orderArray],
-									[],
-									$basketExtra,
-									$basketRecs
-								);
-							$basketText = trim($basketText);
+                                    ['0' => $orderArray],
+                                    [],
+                                    $basketExtra,
+                                    $basketRecs
+                                );
+                            $basketText = trim($basketText);
 
                             if ($conf['orderEmail_htmlmail']) {
                                 $basketHtml =
@@ -1150,9 +1150,9 @@ class tx_ttproducts_api {
                                     );
                                 $basketHtml = trim($basketHtml);
                             }
-						}
+                        }
 
-						if (
+                        if (
                             $basketText != '' ||
                             $basketHtml != ''
                         ) {
@@ -1183,229 +1183,229 @@ class tx_ttproducts_api {
                                     );
                             }
 
-							$fromArray = [];
+                            $fromArray = [];
 
-							if (
-								isset($suffixControlArray['from'])
-								&& is_array($suffixControlArray['from'])
-							) {
-								$fromArray = $suffixControlArray['from'];
-							} else {
-								$fromArray = $defaultFromArray['shop'];
-							}
+                            if (
+                                isset($suffixControlArray['from'])
+                                && is_array($suffixControlArray['from'])
+                            ) {
+                                $fromArray = $suffixControlArray['from'];
+                            } else {
+                                $fromArray = $defaultFromArray['shop'];
+                            }
 
-							if (
-								isset($suffixControlArray['recipient']) &&
-								is_array($suffixControlArray['recipient'])
-							) {
-								foreach ($suffixControlArray['recipient'] as $recipientEmail) {
+                            if (
+                                isset($suffixControlArray['recipient']) &&
+                                is_array($suffixControlArray['recipient'])
+                            ) {
+                                foreach ($suffixControlArray['recipient'] as $recipientEmail) {
 
-									\JambageCom\Div2007\Utility\MailUtility::send(
-										$recipientEmail,
-										$apostrophe . $subject . $apostrophe,
-										$textContent,
-										$HTMLmailContent,
-										$fromArray['email'],
-										$fromArray['name'],
-										$suffixControlArray['attachmentFile'] ?? '',
-										$suffixControlArray['cc'] ?? '',
-										$suffixControlArray['bcc'] ?? '',
-										$suffixControlArray['returnPath'] ?? '',
-										$suffixControlArray['replyTo'] ?? '',
-										TT_PRODUCTS_EXT,
-										'sendMail'
-									);
-								}
-							}
-						}
-					}
-				}
-			}
+                                    \JambageCom\Div2007\Utility\MailUtility::send(
+                                        $recipientEmail,
+                                        $apostrophe . $subject . $apostrophe,
+                                        $textContent,
+                                        $HTMLmailContent,
+                                        $fromArray['email'],
+                                        $fromArray['name'],
+                                        $suffixControlArray['attachmentFile'] ?? '',
+                                        $suffixControlArray['cc'] ?? '',
+                                        $suffixControlArray['bcc'] ?? '',
+                                        $suffixControlArray['returnPath'] ?? '',
+                                        $suffixControlArray['replyTo'] ?? '',
+                                        TT_PRODUCTS_EXT,
+                                        'sendMail'
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			$finalizeConf = $cnfObj->getFinalizeConf('productsFilter');
+            $finalizeConf = $cnfObj->getFinalizeConf('productsFilter');
 
-			if (is_array($finalizeConf) && count($finalizeConf)) {
+            if (is_array($finalizeConf) && count($finalizeConf)) {
 
-				foreach ($finalizeConf as $k => $confpart) {
-					$reducedItemArray = [];
+                foreach ($finalizeConf as $k => $confpart) {
+                    $reducedItemArray = [];
 
-					if (isset($confpart['pid']) && isset($confpart['email'])) {
-						foreach ($itemArray as $sort => $actItemArray) {
-							$reducedActItemArray = [];
-							foreach ($actItemArray as $k1 => $actItem) {
-								$row = $actItem['rec'];
-								if ($row['pid'] == $confpart['pid']) {
-									$reducedActItemArray[] = $actItem;
-								}
-							}
-							if (count($reducedActItemArray)) {
-								$reducedItemArray[$sort] = $reducedActItemArray;
-							}
-						}
+                    if (isset($confpart['pid']) && isset($confpart['email'])) {
+                        foreach ($itemArray as $sort => $actItemArray) {
+                            $reducedActItemArray = [];
+                            foreach ($actItemArray as $k1 => $actItem) {
+                                $row = $actItem['rec'];
+                                if ($row['pid'] == $confpart['pid']) {
+                                    $reducedActItemArray[] = $actItem;
+                                }
+                            }
+                            if (count($reducedActItemArray)) {
+                                $reducedItemArray[$sort] = $reducedActItemArray;
+                            }
+                        }
 
-						if (!empty($emailControlArray['shop']['none']['content'])) {
-							$emailKey = 'shop';
-						} else {
-							$emailKey = 'customer';
-						}
+                        if (!empty($emailControlArray['shop']['none']['content'])) {
+                            $emailKey = 'shop';
+                        } else {
+                            $emailKey = 'customer';
+                        }
 
-						$reducedCalculatedArray = $calculatedArray;  // Todo: use a different calculation
+                        $reducedCalculatedArray = $calculatedArray;  // Todo: use a different calculation
 
-						$reducedBasketPlaintext =
-							trim(
-								$basketView->getView(
-									$errorCode,
-									$templateCode,
-									'EMAIL',
-									$infoViewObj,
-									false,
-									true,
-									$reducedCalculatedArray,
-									$conf['orderEmail_htmlmail'],
-									$emailControlArray[$emailKey]['none']['template'],
-									$mainMarkerArray,
-									'',
-									$reducedItemArray,
+                        $reducedBasketPlaintext =
+                            trim(
+                                $basketView->getView(
+                                    $errorCode,
+                                    $templateCode,
+                                    'EMAIL',
+                                    $infoViewObj,
+                                    false,
+                                    true,
+                                    $reducedCalculatedArray,
+                                    $conf['orderEmail_htmlmail'],
+                                    $emailControlArray[$emailKey]['none']['template'],
+                                    $mainMarkerArray,
+                                    '',
+                                    $reducedItemArray,
                                     $notOverwritePriceIfSet = true,
-									['0' => $orderArray],
-									[],
-									$basketExtra,
-									$basketRecs
-								)
-							);
-						self::splitSubjectAndText(
-							$reducedBasketPlaintext,
-							$conf['orderEmail_subject'],
-							$markerArray,
-							$subject,
-							$textContent
-						);
+                                    ['0' => $orderArray],
+                                    [],
+                                    $basketExtra,
+                                    $basketRecs
+                                )
+                            );
+                        self::splitSubjectAndText(
+                            $reducedBasketPlaintext,
+                            $conf['orderEmail_subject'],
+                            $markerArray,
+                            $subject,
+                            $textContent
+                        );
 
-						if ($conf['orderEmail_htmlmail']) {
-							$reducedBasketHtml =
-								trim(
-									$basketView->getView(
-										$errorCode,
-										$templateCode,
-										'EMAIL',
-										$infoViewObj,
-										false,
-										true,
-										$reducedCalculatedArray,
-										true,
-										$emailControlArray[$emailKey]['none']['htmltemplate'],
-										$mainMarkerArray,
-										'',
-										$reducedItemArray,
+                        if ($conf['orderEmail_htmlmail']) {
+                            $reducedBasketHtml =
+                                trim(
+                                    $basketView->getView(
+                                        $errorCode,
+                                        $templateCode,
+                                        'EMAIL',
+                                        $infoViewObj,
+                                        false,
+                                        true,
+                                        $reducedCalculatedArray,
+                                        true,
+                                        $emailControlArray[$emailKey]['none']['htmltemplate'],
+                                        $mainMarkerArray,
+                                        '',
+                                        $reducedItemArray,
                                         $notOverwritePriceIfSet = true,
-										['0' => $orderArray],
-										[],
-										$basketExtra,
-										$basketRecs
-									)
-								);
+                                        ['0' => $orderArray],
+                                        [],
+                                        $basketExtra,
+                                        $basketRecs
+                                    )
+                                );
 
-							$HTMLmailContent =
-								$templateService->substituteMarker(
-									$HTMLmailShell,
-									'###HTML_BODY###',
-									$reducedBasketHtml
-								);
+                            $HTMLmailContent =
+                                $templateService->substituteMarker(
+                                    $HTMLmailShell,
+                                    '###HTML_BODY###',
+                                    $reducedBasketHtml
+                                );
 
-							$HTMLmailContent =
-								$templateService->substituteMarkerArray(
-									$HTMLmailContent,
-									$markerArray
-								);
-						} else {
-							$HTMLmailContent = '';
-						}
+                            $HTMLmailContent =
+                                $templateService->substituteMarkerArray(
+                                    $HTMLmailContent,
+                                    $markerArray
+                                );
+                        } else {
+                            $HTMLmailContent = '';
+                        }
 
-						\JambageCom\Div2007\Utility\MailUtility::send(
-							$confpart['email'],
-							$apostrophe . $subject . $apostrophe,
-							$textContent,
-							$HTMLmailContent,
-							$emailControlArray['customer']['none']['from']['email'],
-							$emailControlArray['customer']['none']['from']['name'],
-							'',
-							'',
-							'',
-							$emailControlArray['customer']['none']['returnPath'] ?? '',
-							$emailControlArray['customer']['none']['replyTo'] ?? '',
-							TT_PRODUCTS_EXT,
-							'sendMail'
-						);
-					}
-				}
-			}
+                        \JambageCom\Div2007\Utility\MailUtility::send(
+                            $confpart['email'],
+                            $apostrophe . $subject . $apostrophe,
+                            $textContent,
+                            $HTMLmailContent,
+                            $emailControlArray['customer']['none']['from']['email'],
+                            $emailControlArray['customer']['none']['from']['name'],
+                            '',
+                            '',
+                            '',
+                            $emailControlArray['customer']['none']['returnPath'] ?? '',
+                            $emailControlArray['customer']['none']['replyTo'] ?? '',
+                            TT_PRODUCTS_EXT,
+                            'sendMail'
+                        );
+                    }
+                }
+            }
 
-			if (
-				isset($emailControlArray['radio1']['plaintext']) &&
-				isset($emailControlArray['radio1']['recipient'])
-			) {
-				foreach ($emailControlArray['radio1']['recipient'] as $key => $recipient) {
+            if (
+                isset($emailControlArray['radio1']['plaintext']) &&
+                isset($emailControlArray['radio1']['recipient'])
+            ) {
+                foreach ($emailControlArray['radio1']['recipient'] as $key => $recipient) {
 
-					\JambageCom\Div2007\Utility\MailUtility::send(
-						$recipient,
-						$apostrophe . $emailControlArray['radio1']['none']['subject'] . $apostrophe,
-						$emailControlArray['radio1']['none']['plaintext'],
-						$customerHTMLmailContent,
-						$emailControlArray['shop']['none']['from']['email'],
-						$emailControlArray['shop']['none']['from']['name'],
-						$emailControlArray['radio1']['none']['attachmentFile'],
-						'',
-						'',
-						$emailControlArray['shop']['none']['returnPath'] ?? '',
-						$emailControlArray['shop']['none']['replyTo'] ?? '',
-						TT_PRODUCTS_EXT,
-						'sendMail'
-					);
-				}
-			}
-		} else {
+                    \JambageCom\Div2007\Utility\MailUtility::send(
+                        $recipient,
+                        $apostrophe . $emailControlArray['radio1']['none']['subject'] . $apostrophe,
+                        $emailControlArray['radio1']['none']['plaintext'],
+                        $customerHTMLmailContent,
+                        $emailControlArray['shop']['none']['from']['email'],
+                        $emailControlArray['shop']['none']['from']['name'],
+                        $emailControlArray['radio1']['none']['attachmentFile'],
+                        '',
+                        '',
+                        $emailControlArray['shop']['none']['returnPath'] ?? '',
+                        $emailControlArray['shop']['none']['replyTo'] ?? '',
+                        TT_PRODUCTS_EXT,
+                        'sendMail'
+                    );
+                }
+            }
+        } else {
             debug ($templateCode, '$templateCode is empty'); // keep this
-		}
+        }
 
 
-		// 3 different hook methods - There must be one for your needs, too.
+        // 3 different hook methods - There must be one for your needs, too.
 
-			// This cObject may be used to call a function which clears settings in an external order system.
-			// The output is NOT included anywhere
-		\JambageCom\Div2007\Utility\ObsoleteUtility::getExternalCObject($pObj, 'externalFinalizing');
+            // This cObject may be used to call a function which clears settings in an external order system.
+            // The output is NOT included anywhere
+        \JambageCom\Div2007\Utility\ObsoleteUtility::getExternalCObject($pObj, 'externalFinalizing');
 
-		if (!empty($conf['externalOrderProcessFunc'])) {
+        if (!empty($conf['externalOrderProcessFunc'])) {
             \JambageCom\Div2007\Utility\ObsoleteUtility::userProcess(
                 $pObj,
                 $conf,
                 'externalOrderProcessFunc',
                 $itemArray
             );
-		}
+        }
 
-			// Call all finalizeOrder hooks
-		if (
+            // Call all finalizeOrder hooks
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['finalizeOrder']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['finalizeOrder'])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['finalizeOrder'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'finalizeOrder')) {
-					$hookObj->finalizeOrder(
-						$pObj,
-						$infoViewObj,
-						$templateCode,
-						$basketView,
-						$functablename,
-						$orderUid,
-						$orderConfirmationHTML,
-						$errorMessage,
-						$result
-					);
-				}
-			}
-		}
-		return $result;
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['finalizeOrder'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'finalizeOrder')) {
+                    $hookObj->finalizeOrder(
+                        $pObj,
+                        $infoViewObj,
+                        $templateCode,
+                        $basketView,
+                        $functablename,
+                        $orderUid,
+                        $orderConfirmationHTML,
+                        $errorMessage,
+                        $result
+                    );
+                }
+            }
+        }
+        return $result;
     }
 }
 

--- a/api/class.tx_ttproducts_api_download.php
+++ b/api/class.tx_ttproducts_api_download.php
@@ -44,32 +44,32 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_api_download {
 
-	static public function fetchFal (
-		$fileReferenceUid
-	) {
-		$storageRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
-		$storage = $storageRepository->findByUid(1);
+    static public function fetchFal (
+        $fileReferenceUid
+    ) {
+        $storageRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
+        $storage = $storageRepository->findByUid(1);
         $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
-		$fileObj = $resourceFactory->getFileReferenceObject($fileReferenceUid);
+        $fileObj = $resourceFactory->getFileReferenceObject($fileReferenceUid);
 
-		$fileInfo = $storage->getFileInfo($fileObj);
-		$mimeType = $fileInfo['mimetype'];
-		$content = $fileObj->getContents();
-		$properties = $fileObj->getProperties();
+        $fileInfo = $storage->getFileInfo($fileObj);
+        $mimeType = $fileInfo['mimetype'];
+        $content = $fileObj->getContents();
+        $properties = $fileObj->getProperties();
 
-		if (!empty($properties['mime_type'])) {
-			$mimeType = $properties['mime_type'];
-		}
+        if (!empty($properties['mime_type'])) {
+            $mimeType = $properties['mime_type'];
+        }
 
-		ob_end_clean();
-		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-		header('Content-Type: ' . $mimeType);
-		header("Content-Type: application/download");
-		header('Content-Disposition: attachment; filename=' . $properties['name']);
-		header('Content-Length: ' . $properties['size']);
+        ob_end_clean();
+        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+        header('Content-Type: ' . $mimeType);
+        header("Content-Type: application/download");
+        header('Content-Disposition: attachment; filename=' . $properties['name']);
+        header('Content-Length: ' . $properties['size']);
 
-		echo $content;
-		exit;
+        echo $content;
+        exit;
 
-	}
+    }
 }

--- a/api/class.tx_ttproducts_ts.php
+++ b/api/class.tx_ttproducts_ts.php
@@ -41,154 +41,154 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_ts implements \TYPO3\CMS\Core\SingletonInterface {
-	static $count = 0;
+    static $count = 0;
 
-	protected function getChilds ($uid = 0) {
+    protected function getChilds ($uid = 0) {
         $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('pages');
-		$where = 'pid = ' . $uid . $enableFields;
+        $where = 'pid = ' . $uid . $enableFields;
 
-		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid', 'pages', $where);
-		$childs = [];
+        $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid', 'pages', $where);
+        $childs = [];
 
-		if (isset($rows) && is_array($rows) && count($rows)) {
-			foreach ($rows as $row) {
-				$childs[] = $row['uid'];
-			}
-		}
+        if (isset($rows) && is_array($rows) && count($rows)) {
+            foreach ($rows as $row) {
+                $childs[] = $row['uid'];
+            }
+        }
 
-		return $childs;
-	}
-
-
-	protected function getAllChilds ($uid = 0) {
-
-		$childs = $this->getChilds($uid);
-		$allChilds = $childs;
-
-		if (isset($childs) && is_array($childs) && count($childs)) {
-
-			foreach ($childs as $child) {
-				$grandchilds = $this->getAllChilds($child);
-				if (isset($grandchilds) && is_array($grandchilds) && count($grandchilds)) {
-					$allChilds = array_merge($allChilds, $grandchilds);
-				}
-			}
-		}
-
-		return $allChilds;
-	}
+        return $childs;
+    }
 
 
-	protected function getProductCount ($uid = 0) {
-		$result = 0;
-		$allChilds = $this->getAllChilds($uid);
+    protected function getAllChilds ($uid = 0) {
 
-		if (isset($allChilds) && is_array($allChilds) && count($allChilds)) {
-			$pids = implode(',', $allChilds);
+        $childs = $this->getChilds($uid);
+        $allChilds = $childs;
+
+        if (isset($childs) && is_array($childs) && count($childs)) {
+
+            foreach ($childs as $child) {
+                $grandchilds = $this->getAllChilds($child);
+                if (isset($grandchilds) && is_array($grandchilds) && count($grandchilds)) {
+                    $allChilds = array_merge($allChilds, $grandchilds);
+                }
+            }
+        }
+
+        return $allChilds;
+    }
+
+
+    protected function getProductCount ($uid = 0) {
+        $result = 0;
+        $allChilds = $this->getAllChilds($uid);
+
+        if (isset($allChilds) && is_array($allChilds) && count($allChilds)) {
+            $pids = implode(',', $allChilds);
             $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('tt_products');
-			$where = 'pid IN (' . $pids . ')' . $enableFields;
-			$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid', 'tt_products', $where);
-			$result = false;
+            $where = 'pid IN (' . $pids . ')' . $enableFields;
+            $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid', 'tt_products', $where);
+            $result = false;
 
-			if (isset($rows) && is_array($rows)) {
-				$result = count($rows);
-			}
-		}
+            if (isset($rows) && is_array($rows)) {
+                $result = count($rows);
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	protected function getMemoCount ($uid = 0) {
-		$result = 0;
+    protected function getMemoCount ($uid = 0) {
+        $result = 0;
         $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('tt_content');
-		$where = 'pid = ' . $uid . $enableFields;
+        $where = 'pid = ' . $uid . $enableFields;
 
-		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid,CType,list_type,pi_flexform', 'tt_content', $where);
+        $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid,CType,list_type,pi_flexform', 'tt_content', $where);
 
-		if (isset($rows) && is_array($rows) && count($rows)) {
-			$count = 0;
-			$fieldName = 'display_mode';
+        if (isset($rows) && is_array($rows) && count($rows)) {
+            $count = 0;
+            $fieldName = 'display_mode';
 
-			$bMemoFound = false;
+            $bMemoFound = false;
 
-			foreach ($rows as $row) {
-				if (
-					$row['CType'] == 'list' &&
-					$row['list_type'] == '5' &&
-					!empty($row['pi_flexform'])
-				) {
-					$flexformArray = GeneralUtility::xml2array($row['pi_flexform']);
-					$codes =
-						\JambageCom\Div2007\Utility\FlexformUtility::get(
-							$flexformArray,
-							$fieldName,
-							'sDEF',
-							'lDEF',
-							'vDEF'
-						);
+            foreach ($rows as $row) {
+                if (
+                    $row['CType'] == 'list' &&
+                    $row['list_type'] == '5' &&
+                    !empty($row['pi_flexform'])
+                ) {
+                    $flexformArray = GeneralUtility::xml2array($row['pi_flexform']);
+                    $codes =
+                        \JambageCom\Div2007\Utility\FlexformUtility::get(
+                            $flexformArray,
+                            $fieldName,
+                            'sDEF',
+                            'lDEF',
+                            'vDEF'
+                        );
 
-					$codeArray = GeneralUtility::trimExplode(',' , $codes);
-					if (in_array('MEMO', $codeArray)) {
+                    $codeArray = GeneralUtility::trimExplode(',' , $codes);
+                    if (in_array('MEMO', $codeArray)) {
 
-						$bMemoFound = true;
-						break;
-					}
-				}
-			}
+                        $bMemoFound = true;
+                        break;
+                    }
+                }
+            }
 
-			if ($bMemoFound) {
-				$functablename = 'tt_products';
-				$memoItems = tx_ttproducts_control_memo::readSessionMemoItems($functablename);
-				if ($memoItems != '') {
-					$memoArray = GeneralUtility::trimExplode(',', $memoItems);
-					$count = count($memoArray);
-				}
-			}
+            if ($bMemoFound) {
+                $functablename = 'tt_products';
+                $memoItems = tx_ttproducts_control_memo::readSessionMemoItems($functablename);
+                if ($memoItems != '') {
+                    $memoArray = GeneralUtility::trimExplode(',', $memoItems);
+                    $count = count($memoArray);
+                }
+            }
 
-			$result = $count;
-		}
+            $result = $count;
+        }
 
-		return $result;
-	}
-
-
-	/**
-	* Used to show the product count in a page menu used with pages as categories
-	*
-	* @param	array		The menu item array, $this->I (in the parent object)
-	* @param	array		TypoScript configuration for the function. Notice that the property "parentObj" is a reference to the parent (calling) object (the tslib_Xmenu class instantiated)
-	* @return	array		The processed $I array returned (and stored in $this->I of the parent object again)
-	* @see tslib_menu::userProcess(), tslib_tmenu::writeMenu(), tslib_gmenu::writeMenu()
-	*/
-	public function pageProductCount_IProcFunc ($I, $conf) {
-
-		self::$count++;
-		$itemRow = $conf['parentObj']->menuArr[$I['key']];
-		$memoCount = $this->getMemoCount($itemRow['uid']);
-
-		if (is_int($memoCount) && $memoCount > 0) {
-			$I['parts']['title'] .= ' (' . $memoCount . ')';
-		} else {
-			$productCount = $this->getProductCount($itemRow['uid']);
-
-			if (is_int($productCount) && $productCount > 0) {
-				$I['parts']['title'] .= ' (' . $productCount . ')';
-			}
-		}
-
-		return $I;
-	}
+        return $result;
+    }
 
 
-	public function processMemo () {
+    /**
+    * Used to show the product count in a page menu used with pages as categories
+    *
+    * @param	array		The menu item array, $this->I (in the parent object)
+    * @param	array		TypoScript configuration for the function. Notice that the property "parentObj" is a reference to the parent (calling) object (the tslib_Xmenu class instantiated)
+    * @return	array		The processed $I array returned (and stored in $this->I of the parent object again)
+    * @see tslib_menu::userProcess(), tslib_tmenu::writeMenu(), tslib_gmenu::writeMenu()
+    */
+    public function pageProductCount_IProcFunc ($I, $conf) {
 
-		$functablename = 'tt_products';
-		$conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
-		$piVars = GeneralUtility::_GPmerged('tt_products');
+        self::$count++;
+        $itemRow = $conf['parentObj']->menuArr[$I['key']];
+        $memoCount = $this->getMemoCount($itemRow['uid']);
 
-		tx_ttproducts_control_memo::process($functablename, $piVars, $conf);
-	}
+        if (is_int($memoCount) && $memoCount > 0) {
+            $I['parts']['title'] .= ' (' . $memoCount . ')';
+        } else {
+            $productCount = $this->getProductCount($itemRow['uid']);
+
+            if (is_int($productCount) && $productCount > 0) {
+                $I['parts']['title'] .= ' (' . $productCount . ')';
+            }
+        }
+
+        return $I;
+    }
+
+
+    public function processMemo () {
+
+        $functablename = 'tt_products';
+        $conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
+        $piVars = GeneralUtility::_GPmerged('tt_products');
+
+        tx_ttproducts_control_memo::process($functablename, $piVars, $conf);
+    }
 }
 
 

--- a/control/class.tx_ttproducts_activity_finalize.php
+++ b/control/class.tx_ttproducts_activity_finalize.php
@@ -44,159 +44,159 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_activity_finalize implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function getEmailControlArray (
-		$templateCode,
-		$conf,
-		$fromArray
-	) {
-		$suffixArray = [];
-		if (is_array($conf['orderEmail.'])) {
-			foreach ($conf['orderEmail.'] as $k => $emailConfig) {
-				$suffix = strtolower($emailConfig['suffix']);
-				$suffixArray[] = $suffix;
-			}
-		}
+    public function getEmailControlArray (
+        $templateCode,
+        $conf,
+        $fromArray
+    ) {
+        $suffixArray = [];
+        if (is_array($conf['orderEmail.'])) {
+            foreach ($conf['orderEmail.'] as $k => $emailConfig) {
+                $suffix = strtolower($emailConfig['suffix']);
+                $suffixArray[] = $suffix;
+            }
+        }
 
-		if (in_array('customer', $suffixArray)) {
-			$emailControlArray = [];
-			$emailControlArray['customer']['none']['template'] = 'EMAIL_PLAINTEXT_TEMPLATE'; // keep this on first position of the array
-			$emailControlArray['customer']['none']['recipient'] = [];
-			if ($fromArray['customer']['email']) {
-				$emailControlArray['customer']['none']['recipient'][] = $fromArray['customer']['email'];
-			}
+        if (in_array('customer', $suffixArray)) {
+            $emailControlArray = [];
+            $emailControlArray['customer']['none']['template'] = 'EMAIL_PLAINTEXT_TEMPLATE'; // keep this on first position of the array
+            $emailControlArray['customer']['none']['recipient'] = [];
+            if ($fromArray['customer']['email']) {
+                $emailControlArray['customer']['none']['recipient'][] = $fromArray['customer']['email'];
+            }
 
-			$templateSubpart = 'EMAIL_HTML_TEMPLATE';
-			if (strpos($templateCode, '###' . $templateSubpart . '###') === false) {
-				$templateSubpart = 'BASKET_ORDERCONFIRMATION_TEMPLATE';
-			}
+            $templateSubpart = 'EMAIL_HTML_TEMPLATE';
+            if (strpos($templateCode, '###' . $templateSubpart . '###') === false) {
+                $templateSubpart = 'BASKET_ORDERCONFIRMATION_TEMPLATE';
+            }
 
-			$emailControlArray['customer']['none']['htmltemplate'] = $templateSubpart;
-			$emailControlArray['customer']['none']['from'] = $fromArray['customer'];
-		}
+            $emailControlArray['customer']['none']['htmltemplate'] = $templateSubpart;
+            $emailControlArray['customer']['none']['from'] = $fromArray['customer'];
+        }
 
-		if (in_array('shop', $suffixArray)) {
-			$emailControlArray['shop']['none']['from'] = $fromArray['shop'];
+        if (in_array('shop', $suffixArray)) {
+            $emailControlArray['shop']['none']['from'] = $fromArray['shop'];
 
-			if (!empty($conf['orderEmail_to'])) {
-				$emailControlArray['shop']['none']['recipient'][] = $conf['orderEmail_to'];
-			}
-		}
+            if (!empty($conf['orderEmail_to'])) {
+                $emailControlArray['shop']['none']['recipient'][] = $conf['orderEmail_to'];
+            }
+        }
 
-		return $emailControlArray;
-	}
+        return $emailControlArray;
+    }
 
-	public function doProcessing (
-		$templateCode,
-		$mainMarkerArray,
-		$functablename,
-		$orderUid,
-		&$orderArray,
-		$productRowArray,
-		$bAlwaysInStock,
-		$useArticles,
-		$addressArray,
-		$bFinalVerify,
-		$basketExt,
-		$usedCreditpoints,
-		&$errorCode,
-		&$errorMessage
-	) {
+    public function doProcessing (
+        $templateCode,
+        $mainMarkerArray,
+        $functablename,
+        $orderUid,
+        &$orderArray,
+        $productRowArray,
+        $bAlwaysInStock,
+        $useArticles,
+        $addressArray,
+        $bFinalVerify,
+        $basketExt,
+        $usedCreditpoints,
+        &$errorCode,
+        &$errorMessage
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$orderObj = $tablesObj->get('sys_products_orders');
+        $orderObj = $tablesObj->get('sys_products_orders');
 
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
 
-		$customerEmail = $infoViewObj->getCustomerEmail();
-		$defaultFromArray = $infoViewObj->getFromArray($customerEmail);
+        $customerEmail = $infoViewObj->getCustomerEmail();
+        $defaultFromArray = $infoViewObj->getFromArray($customerEmail);
 
-		$activityConf = $cnfObj->getBasketConf('activity', 'finalize');
+        $activityConf = $cnfObj->getBasketConf('activity', 'finalize');
 
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
-		$basketRecs = tx_ttproducts_control_basket::getRecs();
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $basketRecs = tx_ttproducts_control_basket::getRecs();
 
-		$cnfObj->setConf('domain', '###LICENCE_DOMAIN###');
-		$conf = $cnfObj->getConf();
+        $cnfObj->setConf('domain', '###LICENCE_DOMAIN###');
+        $conf = $cnfObj->getConf();
 
-		$empty = '';
+        $empty = '';
 
-		$orderConfirmationHTML =
-			$basketView->getView(
-				$errorCode,
-				$templateCode,
-				'FINALIZE',
-				$infoViewObj,
-				false,
-				false,
-				$basketObj->getCalculatedArray(),
-				true,
-				'BASKET_ORDERCONFIRMATION_TEMPLATE',
-				$mainMarkerArray,
-				'',
-				$basketObj->getItemArray(),
+        $orderConfirmationHTML =
+            $basketView->getView(
+                $errorCode,
+                $templateCode,
+                'FINALIZE',
+                $infoViewObj,
+                false,
+                false,
+                $basketObj->getCalculatedArray(),
+                true,
+                'BASKET_ORDERCONFIRMATION_TEMPLATE',
+                $mainMarkerArray,
+                '',
+                $basketObj->getItemArray(),
                 $notOverwritePriceIfSet = false,
-				['0' => $orderArray],
-				[],
-				tx_ttproducts_control_basket::getBasketExtra()
-			);
+                ['0' => $orderArray],
+                [],
+                tx_ttproducts_control_basket::getBasketExtra()
+            );
 
-		$markerArray = array_merge($mainMarkerArray, $markerObj->getGlobalMarkerArray());
-		$markerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = $infoViewObj->getCustomerEmail();
-		$orderConfirmationHTML = $templateService->substituteMarkerArray(
-			$orderConfirmationHTML,
-			$markerArray
-		);
-		$result = $orderConfirmationHTML;
+        $markerArray = array_merge($mainMarkerArray, $markerObj->getGlobalMarkerArray());
+        $markerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = $infoViewObj->getCustomerEmail();
+        $orderConfirmationHTML = $templateService->substituteMarkerArray(
+            $orderConfirmationHTML,
+            $markerArray
+        );
+        $result = $orderConfirmationHTML;
 
-		if (!$bAlwaysInStock) {
-			$emailControlArray = $this->getEmailControlArray($templateCode, $conf, $defaultFromArray);
+        if (!$bAlwaysInStock) {
+            $emailControlArray = $this->getEmailControlArray($templateCode, $conf, $defaultFromArray);
 
-			$itemObj = $tablesObj->get($functablename);
-			$instockTableArray =
-				$itemObj->reduceInStockItems(
-					$basketObj->getItemArray(),
-					$useArticles
-				);
+            $itemObj = $tablesObj->get($functablename);
+            $instockTableArray =
+                $itemObj->reduceInStockItems(
+                    $basketObj->getItemArray(),
+                    $useArticles
+                );
 
-			if (is_array($instockTableArray) && $conf['warningInStockLimit']) {
-				$tableDescArray =
-					array (
-						'tt_products' => 'product',
-						'tt_products_articles' => 'article'
-					);
-				foreach ($instockTableArray as $tablename => $instockArray) {
-					$tableDesc = $languageObj->getLabel($tableDescArray[$tablename]);
+            if (is_array($instockTableArray) && $conf['warningInStockLimit']) {
+                $tableDescArray =
+                    array (
+                        'tt_products' => 'product',
+                        'tt_products_articles' => 'article'
+                    );
+                foreach ($instockTableArray as $tablename => $instockArray) {
+                    $tableDesc = $languageObj->getLabel($tableDescArray[$tablename]);
 
-					if (isset($instockArray) && is_array($instockArray)) {
-						foreach ($instockArray as $instockTmp => $count) {
-							$uidItemnrTitle = GeneralUtility::trimExplode(',', $instockTmp);
+                    if (isset($instockArray) && is_array($instockArray)) {
+                        foreach ($instockArray as $instockTmp => $count) {
+                            $uidItemnrTitle = GeneralUtility::trimExplode(',', $instockTmp);
 
-							if ($count <= $conf['warningInStockLimit']) {
-								$content =
-									sprintf(
-										$languageObj->getLabel('instock_warning'),
-										$tableDesc,
-										$uidItemnrTitle[2],
-										$uidItemnrTitle[1],
-										intval($count)
-									);
+                            if ($count <= $conf['warningInStockLimit']) {
+                                $content =
+                                    sprintf(
+                                        $languageObj->getLabel('instock_warning'),
+                                        $tableDesc,
+                                        $uidItemnrTitle[2],
+                                        $uidItemnrTitle[1],
+                                        intval($count)
+                                    );
 
-								$subject =
-									sprintf(
-										$languageObj->getLabel('instock_warning_header'),
-										$uidItemnrTitle[2],
-										intval($count)
-									);
+                                $subject =
+                                    sprintf(
+                                        $languageObj->getLabel('instock_warning_header'),
+                                        $uidItemnrTitle[2],
+                                        intval($count)
+                                    );
 
-								if (
-									isset($emailControlArray['shop']['none']['recipient']) && is_array($emailControlArray['shop']['none']['recipient'])
-								) {
-									foreach ($emailControlArray['shop']['none']['recipient'] as $key => $recipient) {
+                                if (
+                                    isset($emailControlArray['shop']['none']['recipient']) && is_array($emailControlArray['shop']['none']['recipient'])
+                                ) {
+                                    foreach ($emailControlArray['shop']['none']['recipient'] as $key => $recipient) {
                                         $tmp = '';
                                         \JambageCom\Div2007\Utility\MailUtility::send(
                                             $recipient,
@@ -213,105 +213,105 @@ class tx_ttproducts_activity_finalize implements \TYPO3\CMS\Core\SingletonInterf
                                             TT_PRODUCTS_EXT,
                                             'sendMail'
                                         );
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		if (
-			!empty($infoViewObj->infoArray['billing']['email']) &&
-			!\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
-			(
+        if (
+            !empty($infoViewObj->infoArray['billing']['email']) &&
+            !\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
+            (
                 empty($GLOBALS['TSFE']->fe_user->user) ||
                 trim($GLOBALS['TSFE']->fe_user->user['username']) == ''
             )
-		) {
-			// Move the user creation in front so that when we create the order we have a fe_userid so that the order lists work.
+        ) {
+            // Move the user creation in front so that when we create the order we have a fe_userid so that the order lists work.
 
-			$feuserUid = tx_ttproducts_api::createFeuser(
-				$conf['createUsers'], // Is no user is logged in --> create one
-				$templateCode,
-				$conf,
-				$infoViewObj,
-				$basketView,
-				$basketObj->getCalculatedArray(),
-				$defaultFromArray
-			);
+            $feuserUid = tx_ttproducts_api::createFeuser(
+                $conf['createUsers'], // Is no user is logged in --> create one
+                $templateCode,
+                $conf,
+                $infoViewObj,
+                $basketView,
+                $basketObj->getCalculatedArray(),
+                $defaultFromArray
+            );
 
-			if ($feuserUid) {
-				$infoViewObj->infoArray['billing']['feusers_uid'] = $feuserUid;
-			}
-		}
+            if ($feuserUid) {
+                $infoViewObj->infoArray['billing']['feusers_uid'] = $feuserUid;
+            }
+        }
 
-		if (isset($activityConf) && is_array($activityConf)) {
-			if (isset($activityConf['clear'])) {
-				$clearArray = GeneralUtility::trimExplode(',', $activityConf['clear']);
-				foreach ($clearArray as $v) {
-					switch ($v) {
-						case 'memo':
-							$feuserField = 'tt_products_memoItems';
-							$memoItems = '';
+        if (isset($activityConf) && is_array($activityConf)) {
+            if (isset($activityConf['clear'])) {
+                $clearArray = GeneralUtility::trimExplode(',', $activityConf['clear']);
+                foreach ($clearArray as $v) {
+                    switch ($v) {
+                        case 'memo':
+                            $feuserField = 'tt_products_memoItems';
+                            $memoItems = '';
 
-							if (
+                            if (
                                 \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
                                 !empty($GLOBALS['TSFE']->fe_user->user[$feuserField])
                             ) {
-								$memoItems = $GLOBALS['TSFE']->fe_user->user[$feuserField];
-							}
-							$uidArray = $basketObj->getUidArray();
-							if (
-								isset($uidArray) &&
-								is_array($uidArray) &&
-								count($uidArray) &&
-								$memoItems != ''
-							) {
-								$newMemoItems = $memoItems;
-								foreach ($uidArray as $uid) {
-									$newMemoItems = GeneralUtility::rmFromList($uid, $newMemoItems);
-								}
+                                $memoItems = $GLOBALS['TSFE']->fe_user->user[$feuserField];
+                            }
+                            $uidArray = $basketObj->getUidArray();
+                            if (
+                                isset($uidArray) &&
+                                is_array($uidArray) &&
+                                count($uidArray) &&
+                                $memoItems != ''
+                            ) {
+                                $newMemoItems = $memoItems;
+                                foreach ($uidArray as $uid) {
+                                    $newMemoItems = GeneralUtility::rmFromList($uid, $newMemoItems);
+                                }
 
-								if ($newMemoItems != $memoItems) {
-									tx_ttproducts_control_memo::saveMemo(
-										'tt_products',
-										$newMemoItems,
-										$conf
-									);
-								}
-							}
-						break;
-					}
-				}
-			}
-		}
+                                if ($newMemoItems != $memoItems) {
+                                    tx_ttproducts_control_memo::saveMemo(
+                                        'tt_products',
+                                        $newMemoItems,
+                                        $conf
+                                    );
+                                }
+                            }
+                        break;
+                    }
+                }
+            }
+        }
 
-		if (!$bFinalVerify) {
-			tx_ttproducts_api::finalizeOrder(
-				$this,
-				$templateCode,
-				$mainMarkerArray,
-				$functablename,
-				$orderUid,
-				$orderArray,
-				$basketObj->getItemArray(),
-				$basketObj->getCalculatedArray(),
-				$addressArray,
-				$basketExtra,
-				$basketRecs,
-				$basketExt['gift'] ?? '',
-				$usedCreditpoints,
-				$conf['debug'] ?? '',
-				$errorMessage
-			);
-		}
+        if (!$bFinalVerify) {
+            tx_ttproducts_api::finalizeOrder(
+                $this,
+                $templateCode,
+                $mainMarkerArray,
+                $functablename,
+                $orderUid,
+                $orderArray,
+                $basketObj->getItemArray(),
+                $basketObj->getCalculatedArray(),
+                $addressArray,
+                $basketExtra,
+                $basketRecs,
+                $basketExt['gift'] ?? '',
+                $usedCreditpoints,
+                $conf['debug'] ?? '',
+                $errorMessage
+            );
+        }
 
-		$orderObj->clearUid();
+        $orderObj->clearUid();
 
-		return $result;
-	} // doProcessing
+        return $result;
+    } // doProcessing
 }
 
 

--- a/control/class.tx_ttproducts_control.php
+++ b/control/class.tx_ttproducts_control.php
@@ -47,16 +47,16 @@ use JambageCom\TtProducts\Api\PaymentShippingHandling;
 
 
 class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pibase; // reference to object of pibase
-	public $pibaseClass;
-	public $cObj;
-	public $conf;
-	public $config;
-	public $activityArray;		// activities for the CODEs
-	public $funcTablename;
-	public $urlObj; // url functions
-	public $urlArray; // overridden url destinations
-	public $useArticles;
+    public $pibase; // reference to object of pibase
+    public $pibaseClass;
+    public $cObj;
+    public $conf;
+    public $config;
+    public $activityArray;		// activities for the CODEs
+    public $funcTablename;
+    public $urlObj; // url functions
+    public $urlArray; // overridden url destinations
+    public $useArticles;
 
 
     static public $nextActivity = [
@@ -71,54 +71,54 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
             'finalize' => 'products_finalize'
         ];
 
-	public function init ($pibaseClass, $funcTablename, $useArticles) {
-		$this->pibaseClass = $pibaseClass;
-		$this->pibase = GeneralUtility::makeInstance('' . $pibaseClass);
-		$this->cObj = $this->pibase->cObj;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->conf;
-		$this->config = $cnf->config;
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$this->funcTablename = $funcTablename;
-		$this->useArticles = $useArticles;
+    public function init ($pibaseClass, $funcTablename, $useArticles) {
+        $this->pibaseClass = $pibaseClass;
+        $this->pibase = GeneralUtility::makeInstance('' . $pibaseClass);
+        $this->cObj = $this->pibase->cObj;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->conf;
+        $this->config = $cnf->config;
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $this->funcTablename = $funcTablename;
+        $this->useArticles = $useArticles;
 
-		$this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
-		// This handleURL is called instead of the THANKS-url in order to let handleScript process the information if payment by credit card or so.
-		$this->urlArray = [];
-		if (!empty($basketObj->basketExtra['payment.']['handleURL'])) {
-			$this->urlArray['form_url_thanks'] = $basketObj->basketExtra['payment.']['handleURL'];
-		}
-		if (!empty($basketObj->basketExtra['payment.']['handleTarget'])) {	// Alternative target
-			$this->urlArray['form_url_target'] = $basketObj->basketExtra['payment.']['handleTarget'];
-		}
-		$this->urlObj->setUrlArray($this->urlArray);
-	} // init
+        $this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
+        // This handleURL is called instead of the THANKS-url in order to let handleScript process the information if payment by credit card or so.
+        $this->urlArray = [];
+        if (!empty($basketObj->basketExtra['payment.']['handleURL'])) {
+            $this->urlArray['form_url_thanks'] = $basketObj->basketExtra['payment.']['handleURL'];
+        }
+        if (!empty($basketObj->basketExtra['payment.']['handleTarget'])) {	// Alternative target
+            $this->urlArray['form_url_target'] = $basketObj->basketExtra['payment.']['handleTarget'];
+        }
+        $this->urlObj->setUrlArray($this->urlArray);
+    } // init
 
 
-	protected function getOrderUid (&$orderArray) {
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$orderUid = 0;
-		$result = false;
+    protected function getOrderUid (&$orderArray) {
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $orderUid = 0;
+        $result = false;
 
-		if (isset($orderArray['uid'])) {
-			$orderUid = $orderArray['uid'];
-			$result = $orderUid;
-		}
+        if (isset($orderArray['uid'])) {
+            $orderUid = $orderArray['uid'];
+            $result = $orderUid;
+        }
 
-		if (!$orderUid && count($basketObj->itemArray)) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$orderObj = $tablesObj->get('sys_products_orders');
-			$orderUid = $orderObj->getUid();
-			$orderArray = $orderObj->getCurrentArray();
-			if (!$orderUid) {
-				$orderUid = $orderObj->getBlankUid($orderArray);
-				$orderObj->setUid($orderUid);
-			}
-			$result = $orderUid;
-		}
+        if (!$orderUid && count($basketObj->itemArray)) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $orderObj = $tablesObj->get('sys_products_orders');
+            $orderUid = $orderObj->getUid();
+            $orderArray = $orderObj->getCurrentArray();
+            if (!$orderUid) {
+                $orderUid = $orderObj->getBlankUid($orderArray);
+                $orderObj->setUid($orderUid);
+            }
+            $result = $orderUid;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
     protected function getOrdernumber ($orderUid) {
@@ -133,74 +133,74 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
     }
 
 
-	/**
-	 * returns the activities in the order in which they have to be processed
-	 *
-	 * @param		string		  $fieldname is the field in the table you want to create a JavaScript for
-	 * @return	  void
-	 */
-	public function transformActivities ($activities) {
-		$retActivities = [];
-		$codeActivities = [];
-		$codeActivityArray = [
-			'1' =>
-				'products_overview',
-				'products_basket',
-				'products_info',
-				'products_payment',
-				'products_customized_payment',
-				'products_verify',
-				'products_finalize',
-		];
+    /**
+     * returns the activities in the order in which they have to be processed
+     *
+     * @param		string		  $fieldname is the field in the table you want to create a JavaScript for
+     * @return	  void
+     */
+    public function transformActivities ($activities) {
+        $retActivities = [];
+        $codeActivities = [];
+        $codeActivityArray = [
+            '1' =>
+                'products_overview',
+                'products_basket',
+                'products_info',
+                'products_payment',
+                'products_customized_payment',
+                'products_verify',
+                'products_finalize',
+        ];
 
-		$activityArray =  [
-			'1' =>
-			'products_redeem_gift',
-			'products_clear_basket'
-		];
+        $activityArray =  [
+            '1' =>
+            'products_redeem_gift',
+            'products_clear_basket'
+        ];
 
 /*		if ($activities['products_basket']) {
-			$basketActivityArray = array(
-				'1' =>
-					'products_info',
-					'products_payment',
-					'products_finalize'
-				);
-			// if 'products_basket' has been set, then the user should always return to the basket page
-			foreach ($basketActivityArray as $k => $activity) {
-				if ($activities[$activity]) {
-					unset($activities[$activity]);
-				}
-			}
-		}*/
+            $basketActivityArray = array(
+                '1' =>
+                    'products_info',
+                    'products_payment',
+                    'products_finalize'
+                );
+            // if 'products_basket' has been set, then the user should always return to the basket page
+            foreach ($basketActivityArray as $k => $activity) {
+                if ($activities[$activity]) {
+                    unset($activities[$activity]);
+                }
+            }
+        }*/
 
-		if (is_array($activities)) {
-			foreach ($activities as $activity => $value) {
-				if ($value && in_array($activity, $codeActivityArray)) {
-					$codeActivities[$activity] = true;
-				}
-			}
-		}
+        if (is_array($activities)) {
+            foreach ($activities as $activity => $value) {
+                if ($value && in_array($activity, $codeActivityArray)) {
+                    $codeActivities[$activity] = true;
+                }
+            }
+        }
 
-		if (!empty($codeActivities['products_info'])) {
-			if(!empty($codeActivities['products_payment'])) {
-				$codeActivities['products_payment'] = false;
-			}
-		}
+        if (!empty($codeActivities['products_info'])) {
+            if(!empty($codeActivities['products_payment'])) {
+                $codeActivities['products_payment'] = false;
+            }
+        }
 
-		if (
-			!empty($codeActivities['products_basket']) &&
-			count($codeActivities) > 1
-		) {
-			if (
-				count($codeActivities) > 2 ||
-				empty($codeActivities['products_overview'])
-			) {
-				$codeActivities['products_basket'] = false;
-			}
-		}
+        if (
+            !empty($codeActivities['products_basket']) &&
+            count($codeActivities) > 1
+        ) {
+            if (
+                count($codeActivities) > 2 ||
+                empty($codeActivities['products_overview'])
+            ) {
+                $codeActivities['products_basket'] = false;
+            }
+        }
 
-		$sortedCodeActivities = [];
+        $sortedCodeActivities = [];
         foreach ($codeActivityArray as $activity) { // You must keep the order of activities.
             if (isset($codeActivities[$activity])) {
                 $sortedCodeActivities[$activity] = $codeActivities[$activity];
@@ -208,17 +208,17 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
         }
         $codeActivities = $sortedCodeActivities;
 
-		if (is_array($activities)) {
-			foreach ($activityArray as $k => $activity) {
-				if (!empty($activities[$activity])) {
-					$retActivities[$activity] = true;
-				}
-			}
-			$retActivities = array_merge($retActivities, $codeActivities);
-		}
+        if (is_array($activities)) {
+            foreach ($activityArray as $k => $activity) {
+                if (!empty($activities[$activity])) {
+                    $retActivities[$activity] = true;
+                }
+            }
+            $retActivities = array_merge($retActivities, $codeActivities);
+        }
 
-		return ($retActivities);
-	}
+        return ($retActivities);
+    }
 
     protected function getTransactorConf ($handleLib) {
         $transactorConf = '';
@@ -230,56 +230,56 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
         return $transactorConf;
     }
 
-	protected function processPayment (
-		$orderUid,
+    protected function processPayment (
+        $orderUid,
         $orderNumber,
-		$cardRow,
-		$pidArray,
-		$currentPaymentActivity,
-		$calculatedArray,
-		$basketExtra,
-		$basketRecs,
-		$orderArray,
-		$productRowArray,
-		&$bFinalize,
-		&$bFinalVerify,
-		&$paymentScript,
-		&$errorCode,
-		&$errorMessage
-	) {
-		$content = '';
-		$paymentScript = false;
-		$handleLib = '';
-		$localTemplateCode = '';
+        $cardRow,
+        $pidArray,
+        $currentPaymentActivity,
+        $calculatedArray,
+        $basketExtra,
+        $basketRecs,
+        $orderArray,
+        $productRowArray,
+        &$bFinalize,
+        &$bFinalVerify,
+        &$paymentScript,
+        &$errorCode,
+        &$errorMessage
+    ) {
+        $content = '';
+        $paymentScript = false;
+        $handleLib = '';
+        $localTemplateCode = '';
 
-		if ($orderUid) {
-			$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-			$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-			$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-			$handleScript = '';
+        if ($orderUid) {
+            $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+            $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+            $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+            $handleScript = '';
             if (isset($basketExtra['payment.']['handleScript'])) {
                 $sanitizer = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class);
                 $handleScript = $sanitizer->sanitize($basketExtra['payment.']['handleScript']);
             }
 
-			$handleLib = $basketExtra['payment.']['handleLib'] ?? '';
+            $handleLib = $basketExtra['payment.']['handleLib'] ?? '';
 
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			if ($handleScript) {
-				$paymentScript = true;
-				$content = PaymentShippingHandling::includeHandleScript(
-					$handleScript,
-					$basketExtra['payment.']['handleScript.'] ?? '',
-					$this->conf['paymentActivity'] ?? '',
-					$bFinalize,
-					$this->pibase,
-					$infoViewObj
-				);
-			} else if (
-				strpos($handleLib, 'paymentlib') === false &&
-				\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
-			) {
+            if ($handleScript) {
+                $paymentScript = true;
+                $content = PaymentShippingHandling::includeHandleScript(
+                    $handleScript,
+                    $basketExtra['payment.']['handleScript.'] ?? '',
+                    $this->conf['paymentActivity'] ?? '',
+                    $bFinalize,
+                    $this->pibase,
+                    $infoViewObj
+                );
+            } else if (
+                strpos($handleLib, 'paymentlib') === false &&
+                \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($handleLib)
+            ) {
                 $transactorConf = $this->getTransactorConf($handleLib);
                 $useNewTransactor = false;
             
@@ -390,58 +390,58 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                     );
                 }
 
-				if (
-					!$errorMessage &&
-					$content == '' &&
-					!$bFinalize &&
-					$localTemplateCode != ''
-				) {
-					$content = $basketView->getView(
-						$errorCode,
-						$localTemplateCode,
-						'PAYMENT',
-						$infoViewObj,
-						false,
-						false,
-						$calculatedArray,
-						true,
-						'TRANSACTOR_FORM_TEMPLATE',
-						$markerArray,
-						$templateFilename,
-						$basketObj->getItemArray(),
+                if (
+                    !$errorMessage &&
+                    $content == '' &&
+                    !$bFinalize &&
+                    $localTemplateCode != ''
+                ) {
+                    $content = $basketView->getView(
+                        $errorCode,
+                        $localTemplateCode,
+                        'PAYMENT',
+                        $infoViewObj,
+                        false,
+                        false,
+                        $calculatedArray,
+                        true,
+                        'TRANSACTOR_FORM_TEMPLATE',
+                        $markerArray,
+                        $templateFilename,
+                        $basketObj->getItemArray(),
                         $notOverwritePriceIfSet = true,
-						['0' => $orderArray],
-						$productRowArray,
-						$basketExtra,
-						$basketRecs
-					);
-				}
-			}
-		}
-		return $content;
-	} // processPayment
+                        ['0' => $orderArray],
+                        $productRowArray,
+                        $basketExtra,
+                        $basketRecs
+                    );
+                }
+            }
+        }
+        return $content;
+    } // processPayment
 
 
-	public function getErrorLabel (
-		$languageObj,
-		$accountObj,
-		$cardObj,
-		$pidagb,
-		$infoArray,
-		$checkRequired,
-		$checkAllowed,
-		$cardRequired,
-		$accountRequired,
-		$giftRequired,
-		$paymentErrorMsg
-	) {
+    public function getErrorLabel (
+        $languageObj,
+        $accountObj,
+        $cardObj,
+        $pidagb,
+        $infoArray,
+        $checkRequired,
+        $checkAllowed,
+        $cardRequired,
+        $accountRequired,
+        $giftRequired,
+        $paymentErrorMsg
+    ) {
         $label = '';
         $languageKey = '';
 
-		if ($checkRequired || $checkAllowed) {
+        if ($checkRequired || $checkAllowed) {
 
-			$check = ($checkRequired ? $checkRequired: $checkAllowed);
-			$check = ($check ? $check : $giftRequired);
+            $check = ($checkRequired ? $checkRequired: $checkAllowed);
+            $check = ($check ? $check : $giftRequired);
             if (
                 $checkAllowed == 'email'
             ) {
@@ -455,17 +455,17 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                 }
             }
 
-			if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('agency')) {
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('agency')) {
                 if (!$languageKey) {
                     $languageKey = 'missing_' . $check;
                 }
                 $label = $GLOBALS['TSFE']->sL('LLL:EXT:agency/pi/locallang.xml:' . $languageKey);
-				$editPID = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_agency.']['editPID'];
+                $editPID = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_agency.']['editPID'];
 
-				if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() && $editPID) {
+                if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() && $editPID) {
                     $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
-					$addParams = array ('products_payment' => 1);
-					$addParams = $this->urlObj->getLinkParams('', $addParams, true);
+                    $addParams = array ('products_payment' => 1);
+                    $addParams = $this->urlObj->getLinkParams('', $addParams, true);
 // 					$agencyBackUrl =
 // 						$this->pibase->pi_getPageLink($GLOBALS['TSFE']->id, '', $addParams);
                     $agencyBackUrl =
@@ -476,36 +476,36 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                             '',
                             []
                         );
-					$agencyParams = ['agency[backURL]' => $agencyBackUrl];
-					$addParams =
-						$this->urlObj->getLinkParams(
-							'',
-							$agencyParams,
-							true
-						);
+                    $agencyParams = ['agency[backURL]' => $agencyBackUrl];
+                    $addParams =
+                        $this->urlObj->getLinkParams(
+                            '',
+                            $agencyParams,
+                            true
+                        );
                     $markerArray['###FORM_URL_INFO###'] =
                         FrontendUtility::getTypoLink_URL(
                             $cObj,
                             $editPID,
                             $addParams
                         );
-				}
+                }
 
-			} else if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('sr_feuser_register')) {
+            } else if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('sr_feuser_register')) {
                 if (!$languageKey) {
                     $languageKey = 'missing_' . $check;
                 }
                 $label = $GLOBALS['TSFE']->sL('LLL:EXT:sr_feuser_register/Resources/Private/Language/locallang.xlf:' . $languageKey);
-				$editPID = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_srfeuserregister_pi1.']['editPID'];
+                $editPID = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_srfeuserregister_pi1.']['editPID'];
 
-				if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() && $editPID) {
-					$addParams = array ('products_payment' => 1);
-					$addParams =
-						$this->urlObj->getLinkParams(
-							'',
-							$addParams,
-							true
-						);
+                if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() && $editPID) {
+                    $addParams = array ('products_payment' => 1);
+                    $addParams =
+                        $this->urlObj->getLinkParams(
+                            '',
+                            $addParams,
+                            true
+                        );
                     $srfeuserBackUrl =
                         FrontendUtility::getTypoLink_URL(
                             $cObj,
@@ -538,244 +538,244 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                         $label = 'field: ' . $check;
                     }
                 }
-			}
-		} else if ($pidagb && empty($_REQUEST['recs']['personinfo']['agb']) && !GeneralUtility::_GET('products_payment') && empty($infoArray['billing']['agb'])) {
-				// so AGB has not been accepted
-			$label = $languageObj->getLabel('accept_AGB');
+            }
+        } else if ($pidagb && empty($_REQUEST['recs']['personinfo']['agb']) && !GeneralUtility::_GET('products_payment') && empty($infoArray['billing']['agb'])) {
+                // so AGB has not been accepted
+            $label = $languageObj->getLabel('accept_AGB');
 
-			$addQueryString['agb'] = 0;
-		} else if ($cardRequired) {
-			$label = '*' . $languageObj->getLabel($cardObj->getTablename() . '.' . $cardRequired) . '*';
-		} else if ($accountRequired) {
-			$label = '*' . $languageObj->getLabel($accountObj->getTablename()) . ': ' . $languageObj->getLabel($accountObj->getTablename() . '.' . $accountRequired) .  '*';
-		} else if ($paymentErrorMsg) {
-			$label = $paymentErrorMsg;
-		} else {
-			$message = $languageObj->getLabel('internal_error');
-			$messageArr = explode('|', $message);
-			$label = $messageArr[0] . 'TTP_2' . $messageArr[1] . 'products_payment' . $messageArr[2];
-		}
+            $addQueryString['agb'] = 0;
+        } else if ($cardRequired) {
+            $label = '*' . $languageObj->getLabel($cardObj->getTablename() . '.' . $cardRequired) . '*';
+        } else if ($accountRequired) {
+            $label = '*' . $languageObj->getLabel($accountObj->getTablename()) . ': ' . $languageObj->getLabel($accountObj->getTablename() . '.' . $accountRequired) .  '*';
+        } else if ($paymentErrorMsg) {
+            $label = $paymentErrorMsg;
+        } else {
+            $message = $languageObj->getLabel('internal_error');
+            $messageArr = explode('|', $message);
+            $label = $messageArr[0] . 'TTP_2' . $messageArr[1] . 'products_payment' . $messageArr[2];
+        }
 
-		return $label;
-	}
+        return $label;
+    }
 
 
-	public function getContent (
-		$templateCode,
-		$templateFilename,
-		array $mainMarkerArray,
-		array $calculatedArray,
-		$basketExtra,
-		array $basketRecs,
-		$orderUid,
+    public function getContent (
+        $templateCode,
+        $templateFilename,
+        array $mainMarkerArray,
+        array $calculatedArray,
+        $basketExtra,
+        array $basketRecs,
+        $orderUid,
         $orderNumber,
-		$orderArray,
-		$productRowArray,
-		$theCode,
-		$basket_tmpl,
-		$bPayment,
-		$activityArray,
-		$currentPaymentActivity,
-		$pidArray,
-		$infoArray,
-		$checkBasket,
-		$bBasketEmpty,
-		$checkRequired,
-		$checkAllowed,
-		$cardRequired,
-		$accountRequired,
-		$giftRequired,
-		$checkEditVariants,
-		$paymentErrorMsg,
-		$pidagb,
-		$cardObj,
-		$cardRow,
-		$accountObj,
-		&$markerArray,
-		&$errorCode,
-		&$errorMessage,
-		&$bFinalize,
-		&$bFinalVerify
-	) {
+        $orderArray,
+        $productRowArray,
+        $theCode,
+        $basket_tmpl,
+        $bPayment,
+        $activityArray,
+        $currentPaymentActivity,
+        $pidArray,
+        $infoArray,
+        $checkBasket,
+        $bBasketEmpty,
+        $checkRequired,
+        $checkAllowed,
+        $cardRequired,
+        $accountRequired,
+        $giftRequired,
+        $checkEditVariants,
+        $paymentErrorMsg,
+        $pidagb,
+        $cardObj,
+        $cardRow,
+        $accountObj,
+        &$markerArray,
+        &$errorCode,
+        &$errorMessage,
+        &$bFinalize,
+        &$bFinalVerify
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$empty = '';
-		$cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$content = '';
-		$hiddenFields = '';
-		$paymentScript = false;
+        $empty = '';
+        $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $content = '';
+        $hiddenFields = '';
+        $paymentScript = false;
 
-		if ($checkBasket && !$bBasketEmpty) {
-			$basketConf = $cnf->getBasketConf('minPrice'); // check the basket limits
+        if ($checkBasket && !$bBasketEmpty) {
+            $basketConf = $cnf->getBasketConf('minPrice'); // check the basket limits
 
-			foreach ($activityArray as $activity => $valid) {
+            foreach ($activityArray as $activity => $valid) {
                 $bNeedsMinCheck = false;
-				if ($valid) {
-					$bNeedsMinCheck =
-						in_array(
-							$activity,
-							[
-								'products_info',
-								'products_payment',
-								'products_customized_payment',
-								'products_verify',
-								'products_finalize',
-								'unknown'
+                if ($valid) {
+                    $bNeedsMinCheck =
+                        in_array(
+                            $activity,
+                            [
+                                'products_info',
+                                'products_payment',
+                                'products_customized_payment',
+                                'products_verify',
+                                'products_finalize',
+                                'unknown'
                             ]
                         );
-				}
-				if ($bNeedsMinCheck) {
-					break;
-				}
-			}
+                }
+                if ($bNeedsMinCheck) {
+                    break;
+                }
+            }
 
-			if ($bNeedsMinCheck && isset($basketConf['type']) && $basketConf['type'] == 'price') {
-				$value = $calculatedArray['priceTax'][$basketConf['collect']];
+            if ($bNeedsMinCheck && isset($basketConf['type']) && $basketConf['type'] == 'price') {
+                $value = $calculatedArray['priceTax'][$basketConf['collect']];
 
-				if (
-					isset($value) &&
-					isset($basketConf['collect']) &&
-					$value < doubleval($basketConf['value'])
-				) {
-					$basket_tmpl = 'BASKET_TEMPLATE_MINPRICE_ERROR';
-					$bFinalize = false;
-				}
-			}
-		}
+                if (
+                    isset($value) &&
+                    isset($basketConf['collect']) &&
+                    $value < doubleval($basketConf['value'])
+                ) {
+                    $basket_tmpl = 'BASKET_TEMPLATE_MINPRICE_ERROR';
+                    $bFinalize = false;
+                }
+            }
+        }
 
-		$basketMarkerArray = [];
-		if ($checkBasket && $bBasketEmpty) {
-			$contentEmpty = '';
-			if (!empty($this->activityArray['products_overview'])) {
-				$contentEmpty = $templateService->getSubpart(
-					$templateCode,
-					$subpartmarkerObj->spMarker('###BASKET_OVERVIEW_EMPTY' . $this->config['templateSuffix'] . '###')
-				);
+        $basketMarkerArray = [];
+        if ($checkBasket && $bBasketEmpty) {
+            $contentEmpty = '';
+            if (!empty($this->activityArray['products_overview'])) {
+                $contentEmpty = $templateService->getSubpart(
+                    $templateCode,
+                    $subpartmarkerObj->spMarker('###BASKET_OVERVIEW_EMPTY' . $this->config['templateSuffix'] . '###')
+                );
 
-				if (!$contentEmpty) {
-					$contentEmpty = $templateService->getSubpart(
-						$templateCode,
-						$subpartmarkerObj->spMarker('###BASKET_OVERVIEW_EMPTY###')
-					);
-				}
-			} else if (
-				!empty($this->activityArray['products_basket']) ||
-				!empty($this->activityArray['products_info']) ||
-				!empty($this->activityArray['products_payment'])
-			) {
-				$subpart = 'BASKET_TEMPLATE_EMPTY';
-				$contentEmpty = tx_ttproducts_api::getErrorOut(
-					$theCode,
-					$templateCode,
-					$subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
-					$subpartmarkerObj->spMarker('###' . $subpart . '###'),
-					$errorCode
-				) ;
-			} else if (!empty($this->activityArray['products_finalize'])) {
-				// Todo: Neuabsenden einer bereits abgesendeten Bestellung. Der Warenkorb ist schon gelöscht.
-				if (!$orderArray) {
-					$contentEmpty = $languageObj->getLabel('order_already_finalized');
-				}
-			}
+                if (!$contentEmpty) {
+                    $contentEmpty = $templateService->getSubpart(
+                        $templateCode,
+                        $subpartmarkerObj->spMarker('###BASKET_OVERVIEW_EMPTY###')
+                    );
+                }
+            } else if (
+                !empty($this->activityArray['products_basket']) ||
+                !empty($this->activityArray['products_info']) ||
+                !empty($this->activityArray['products_payment'])
+            ) {
+                $subpart = 'BASKET_TEMPLATE_EMPTY';
+                $contentEmpty = tx_ttproducts_api::getErrorOut(
+                    $theCode,
+                    $templateCode,
+                    $subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
+                    $subpartmarkerObj->spMarker('###' . $subpart . '###'),
+                    $errorCode
+                ) ;
+            } else if (!empty($this->activityArray['products_finalize'])) {
+                // Todo: Neuabsenden einer bereits abgesendeten Bestellung. Der Warenkorb ist schon gelöscht.
+                if (!$orderArray) {
+                    $contentEmpty = $languageObj->getLabel('order_already_finalized');
+                }
+            }
 
-			if ($contentEmpty != '') {
-				$contentEmpty = $markerObj->replaceGlobalMarkers($contentEmpty);
-				$bFinalize = false;
-			}
-			$content .= $contentEmpty;
-			$taxRateArray =
-				$taxObj->getTaxRates(
-					$shopCountryArray,
-					$taxInfoArray,
-					$basketObj->getUidArray(),
-					$basketRecs
-				);
+            if ($contentEmpty != '') {
+                $contentEmpty = $markerObj->replaceGlobalMarkers($contentEmpty);
+                $bFinalize = false;
+            }
+            $content .= $contentEmpty;
+            $taxRateArray =
+                $taxObj->getTaxRates(
+                    $shopCountryArray,
+                    $taxInfoArray,
+                    $basketObj->getUidArray(),
+                    $basketRecs
+                );
 
-			if (
-				isset($taxRateArray) &&
-				is_array($taxRateArray) &&
-				isset($shopCountryArray) &&
-				is_array($shopCountryArray) &&
-				isset($shopCountryArray['country_code'])
-			){
-				$taxArray = $taxRateArray[$shopCountryArray['country_code']];
-			} else if (
-				isset($taxRateArray) &&
-				is_array($taxRateArray)
-			) {
-				$taxArray = current($taxRateArray);
-			} else {
-				$taxArray = [];
-			}
+            if (
+                isset($taxRateArray) &&
+                is_array($taxRateArray) &&
+                isset($shopCountryArray) &&
+                is_array($shopCountryArray) &&
+                isset($shopCountryArray['country_code'])
+            ){
+                $taxArray = $taxRateArray[$shopCountryArray['country_code']];
+            } else if (
+                isset($taxRateArray) &&
+                is_array($taxRateArray)
+            ) {
+                $taxArray = current($taxRateArray);
+            } else {
+                $taxArray = [];
+            }
 
-			$basketMarkerArray =
-				$basketView->getMarkerArray(
-					$basketExtra,
-					$calculatedArray,
-					$taxArray
-				);
-			$markerArray = $basketMarkerArray;
-		} else if (
-			empty($checkRequired) &&
-			empty($checkAllowed) &&
-			empty($cardRequired) &&
-			empty($accountRequired) &&
-			empty($paymentErrorMsg) &&
-			empty($giftRequired) &&
-			(
-				empty($pidagb) ||
-				!empty($_REQUEST['recs']['personinfo']['agb']) ||
-				($bPayment && GeneralUtility::_GET('products_payment')) ||
-				!empty($infoArray['billing']['agb'])
-			)
-		) {
-			if (
-				$bPayment &&
-				!$bBasketEmpty &&
-				isset($this->conf['paymentActivity']) &&
-				(
-					$this->conf['paymentActivity'] == 'payment' ||
-					$this->conf['paymentActivity'] == 'verify'
-				)
-			) {
-				$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
-					$this->processPayment(
-						$orderUid,
+            $basketMarkerArray =
+                $basketView->getMarkerArray(
+                    $basketExtra,
+                    $calculatedArray,
+                    $taxArray
+                );
+            $markerArray = $basketMarkerArray;
+        } else if (
+            empty($checkRequired) &&
+            empty($checkAllowed) &&
+            empty($cardRequired) &&
+            empty($accountRequired) &&
+            empty($paymentErrorMsg) &&
+            empty($giftRequired) &&
+            (
+                empty($pidagb) ||
+                !empty($_REQUEST['recs']['personinfo']['agb']) ||
+                ($bPayment && GeneralUtility::_GET('products_payment')) ||
+                !empty($infoArray['billing']['agb'])
+            )
+        ) {
+            if (
+                $bPayment &&
+                !$bBasketEmpty &&
+                isset($this->conf['paymentActivity']) &&
+                (
+                    $this->conf['paymentActivity'] == 'payment' ||
+                    $this->conf['paymentActivity'] == 'verify'
+                )
+            ) {
+                $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
+                    $this->processPayment(
+                        $orderUid,
                         $orderNumber,
-						$cardRow,
-						$pidArray,
-						$currentPaymentActivity,
-						$calculatedArray,
-						$basketExtra,
-						$basketRecs,
-						$orderArray,
-						$productRowArray,
-						$bFinalize,
-						$bFinalVerify,
-						$paymentScript,
-						$errorCode,
-						$errorMessage
-					);
-				if ($errorMessage != '') {
-					$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
-					$markerArray['###ERROR_DETAILS###'] = $errorMessage;
-				}
-			} else {
-				$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
-			}
-			$paymentHTML = '';
-			if (
-				!$bFinalize &&
-				$basket_tmpl != ''
-			) {
-				$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+                        $cardRow,
+                        $pidArray,
+                        $currentPaymentActivity,
+                        $calculatedArray,
+                        $basketExtra,
+                        $basketRecs,
+                        $orderArray,
+                        $productRowArray,
+                        $bFinalize,
+                        $bFinalVerify,
+                        $paymentScript,
+                        $errorCode,
+                        $errorMessage
+                    );
+                if ($errorMessage != '') {
+                    $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
+                    $markerArray['###ERROR_DETAILS###'] = $errorMessage;
+                }
+            } else {
+                $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
+            }
+            $paymentHTML = '';
+            if (
+                !$bFinalize &&
+                $basket_tmpl != ''
+            ) {
+                $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
 
                 if (is_array($activityArray)) {
                     $shortActivity = '';
@@ -799,147 +799,147 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                 );
 
                 $mainMarkerArray['###FORM_URL_NEXT_ACTIVITY###'] = $nextUrl;
-				$paymentHTML = $basketView->getView(
-					$errorCode,
-					$templateCode,
-					$theCode,
-					$infoViewObj,
-					$this->activityArray['products_info'] ?? false,
-					false,
-					$calculatedArray,
-					true,
-					$basket_tmpl,
-					$mainMarkerArray,
-					$templateFilename,
-					$basketObj->getItemArray(),
+                $paymentHTML = $basketView->getView(
+                    $errorCode,
+                    $templateCode,
+                    $theCode,
+                    $infoViewObj,
+                    $this->activityArray['products_info'] ?? false,
+                    false,
+                    $calculatedArray,
+                    true,
+                    $basket_tmpl,
+                    $mainMarkerArray,
+                    $templateFilename,
+                    $basketObj->getItemArray(),
                     $notOverwritePriceIfSet = true,
-					['0' => $orderArray],
-					$productRowArray,
-					$basketExtra,
-					$basketRecs
-				);
+                    ['0' => $orderArray],
+                    $productRowArray,
+                    $basketExtra,
+                    $basketRecs
+                );
 
-				$checkResult = false;
-				if (empty($errorCode)) {
-					$checkResult = $basketObj->checkEditVariants();
-				}
+                $checkResult = false;
+                if (empty($errorCode)) {
+                    $checkResult = $basketObj->checkEditVariants();
+                }
 
-				if (
-					$checkEditVariants &&
-					isset($checkResult) &&
-					is_array($checkResult)
-				) {
-					$errorOut = '';
-					$errorRowArray = [];
-					foreach ($checkResult as $uid => $errorArray) {
-						$basketObj->removeEditVariants($checkResult);
-						$errorRow = $errorArray['rec'];
-						$errorRowArray[] = $errorRow;
-						$message = $languageObj->getLabel('error_edit_variant_range');
-						$messageArr =  explode('|', $message);
+                if (
+                    $checkEditVariants &&
+                    isset($checkResult) &&
+                    is_array($checkResult)
+                ) {
+                    $errorOut = '';
+                    $errorRowArray = [];
+                    foreach ($checkResult as $uid => $errorArray) {
+                        $basketObj->removeEditVariants($checkResult);
+                        $errorRow = $errorArray['rec'];
+                        $errorRowArray[] = $errorRow;
+                        $message = $languageObj->getLabel('error_edit_variant_range');
+                        $messageArr =  explode('|', $message);
 
-						if (
+                        if (
                             isset($errorArray['error']) &&
                             is_array($errorArray['error'])
                         ) {
-							foreach ($errorArray['error'] as $field => $fieldErrorMessage) {
-								$errorMessage =
+                            foreach ($errorArray['error'] as $field => $fieldErrorMessage) {
+                                $errorMessage =
                                     $messageArr[0] . $errorRow[$field] . $messageArr[1] .
                                     $errorRow['title'] . $messageArr[2];
-								$errorOut .= $errorMessage . '<br />';
-								$errorOut .= $fieldErrorMessage . '<br />';
-							}
-						}
-					}
-					$paymentHTML .= $errorOut;
-				}
-				$content .= $paymentHTML;
-			}
+                                $errorOut .= $errorMessage . '<br />';
+                                $errorOut .= $fieldErrorMessage . '<br />';
+                            }
+                        }
+                    }
+                    $paymentHTML .= $errorOut;
+                }
+                $content .= $paymentHTML;
+            }
 
-			if (
-				$orderUid &&
-				$paymentHTML != '' &&
-				$paymentScript  // Do not save a redundant payment HTML if there is no payment script at all
-			) {
-				$basketExt = tx_ttproducts_control_basket::getBasketExt();
+            if (
+                $orderUid &&
+                $paymentHTML != '' &&
+                $paymentScript  // Do not save a redundant payment HTML if there is no payment script at all
+            ) {
+                $basketExt = tx_ttproducts_control_basket::getBasketExt();
 
-				$giftServiceArticleArray = [];
-				if (isset($basketExt) && is_array($basketExt)) {
-					foreach ($basketExt as $tmpUid => $tmpSubArr) {
-						if (is_array($tmpSubArr)) {
-							foreach ($tmpSubArr as $tmpKey => $tmpSubSubArr) {
-								if (
-									substr($tmpKey, -1) == '.' &&
-									isset($tmpSubSubArr['additional']) &&
-									is_array($tmpSubSubArr['additional'])
-								) {
-									$variant = substr($tmpKey, 0, -1);
-									$row = $basketObj->get($tmpUid, $variant);
-									if ($tmpSubSubArr['additional']['giftservice'] == 1) {
-										$giftServiceArticleArray[] = $row['title'];
-									}
-								}
-							}
-						}
-					}
-				}
+                $giftServiceArticleArray = [];
+                if (isset($basketExt) && is_array($basketExt)) {
+                    foreach ($basketExt as $tmpUid => $tmpSubArr) {
+                        if (is_array($tmpSubArr)) {
+                            foreach ($tmpSubArr as $tmpKey => $tmpSubSubArr) {
+                                if (
+                                    substr($tmpKey, -1) == '.' &&
+                                    isset($tmpSubSubArr['additional']) &&
+                                    is_array($tmpSubSubArr['additional'])
+                                ) {
+                                    $variant = substr($tmpKey, 0, -1);
+                                    $row = $basketObj->get($tmpUid, $variant);
+                                    if ($tmpSubSubArr['additional']['giftservice'] == 1) {
+                                        $giftServiceArticleArray[] = $row['title'];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
-				$orderObj = $tablesObj->get('sys_products_orders');
-				$orderObj->putData(
-					$orderUid,
-					$orderArray,
-					$basketObj->getItemArray(),
-					$paymentHTML,
-					0,
-					$basketExtra,
-					$basketObj->getCalculatedArray(),
-					$basketObj->recs['tt_products']['giftcode'],
-					$giftServiceArticleArray,
-					$basketObj->recs['tt_products']['vouchercode'] ?? '',
-					0,
-					0,
-					false
-				);
-			}
-		} else if (
+                $orderObj = $tablesObj->get('sys_products_orders');
+                $orderObj->putData(
+                    $orderUid,
+                    $orderArray,
+                    $basketObj->getItemArray(),
+                    $paymentHTML,
+                    0,
+                    $basketExtra,
+                    $basketObj->getCalculatedArray(),
+                    $basketObj->recs['tt_products']['giftcode'],
+                    $giftServiceArticleArray,
+                    $basketObj->recs['tt_products']['vouchercode'] ?? '',
+                    0,
+                    0,
+                    false
+                );
+            }
+        } else if (
             $theCode != 'OVERVIEW' &&
             (
                 $currentPaymentActivity != 'finalize' ||
                 $bFinalize
             )
         ) {	// If not all required info-fields are filled in, this is shown instead:
-			$infoArray['billing']['error'] = 1;
-			$subpart = 'BASKET_REQUIRED_INFO_MISSING';
-			$requiredOut = tx_ttproducts_api::getErrorOut(
-				$theCode,
-				$templateCode,
-				$subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
-				$subpartmarkerObj->spMarker('###' . $subpart . '###'),
-				$errorCode
-			);
+            $infoArray['billing']['error'] = 1;
+            $subpart = 'BASKET_REQUIRED_INFO_MISSING';
+            $requiredOut = tx_ttproducts_api::getErrorOut(
+                $theCode,
+                $templateCode,
+                $subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
+                $subpartmarkerObj->spMarker('###' . $subpart . '###'),
+                $errorCode
+            );
 
-			if (!$errorCode) {
-				$content .=
-					$markerObj->replaceGlobalMarkers($requiredOut);
-			}
+            if (!$errorCode) {
+                $content .=
+                    $markerObj->replaceGlobalMarkers($requiredOut);
+            }
 
-			$label = '';
-			$label = $this->getErrorLabel(
-				$languageObj,
-				$accountObj,
-				$cardObj,
-				$pidagb,
-				$infoArray,
-				$checkRequired,
-				$checkAllowed,
-				$cardRequired,
-				$accountRequired,
-				$giftRequired,
-				$paymentErrorMsg
-			);
-			$markerArray['###ERROR_DETAILS###'] = $label;
-			$bFinalize = false;
-		}
+            $label = '';
+            $label = $this->getErrorLabel(
+                $languageObj,
+                $accountObj,
+                $cardObj,
+                $pidagb,
+                $infoArray,
+                $checkRequired,
+                $checkAllowed,
+                $cardRequired,
+                $accountRequired,
+                $giftRequired,
+                $paymentErrorMsg
+            );
+            $markerArray['###ERROR_DETAILS###'] = $label;
+            $bFinalize = false;
+        }
 
         if (strpos($templateCode, '###ERROR_DETAILS###') !== false) {
             $tempContent =
@@ -954,28 +954,28 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
             }
         }
 
-		return $content;
-	} // getContent
+        return $content;
+    } // getContent
 
 
-	public function processActivities (
-		$activityArray,
-		$activityVarsArray,
-		$codeActivityArray,
-		&$calculatedArray,
-		$basketExtra,
-		array $basketRecs,
-		$basketExt,
-		$addressArray,
-		&$errorCode,
-		&$errorMessage
-	) {
-		$empty = '';
-		$content = '';
-		$bPayment = false;
-		$checkRequired = '';
-		$cardRequired = '';
-		$accountRequired = '';
+    public function processActivities (
+        $activityArray,
+        $activityVarsArray,
+        $codeActivityArray,
+        &$calculatedArray,
+        $basketExtra,
+        array $basketRecs,
+        $basketExt,
+        $addressArray,
+        &$errorCode,
+        &$errorMessage
+    ) {
+        $empty = '';
+        $content = '';
+        $bPayment = false;
+        $checkRequired = '';
+        $cardRequired = '';
+        $accountRequired = '';
         $paymentErrorMsg = '';
         $pidagb = '';
         $cardObj = null;
@@ -983,221 +983,221 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
         $accountObj = null;
 
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-		$orderUid = false;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+        $orderUid = false;
         $orderNumber = '';
 
-		$markerArray = [];
-		$checkAllowed = false;
-		$checkBasket = false;
-		$checkEditVariants = false;
-		$giftRequired = false;
+        $markerArray = [];
+        $checkAllowed = false;
+        $checkBasket = false;
+        $checkEditVariants = false;
+        $giftRequired = false;
         $bBasketEmpty = $basketObj->isEmpty();
-		$orderArray = tx_ttproducts_control_basket::getStoredOrder();
-		$productRowArray = []; // Todo: make this a parameter
+        $orderArray = tx_ttproducts_control_basket::getStoredOrder();
+        $productRowArray = []; // Todo: make this a parameter
 
-		$markerArray['###ERROR_DETAILS###'] = '';
-		$conf = $cnf->getConf();
+        $markerArray['###ERROR_DETAILS###'] = '';
+        $conf = $cnf->getConf();
 
-		$pidTypeArray = ['PIDthanks', 'PIDfinalize', 'PIDpayment', 'PIDbasket', 'PIDinfo'];
-		$pidArray = [];
-		foreach ($pidTypeArray as $pidType) {
-			if (
+        $pidTypeArray = ['PIDthanks', 'PIDfinalize', 'PIDpayment', 'PIDbasket', 'PIDinfo'];
+        $pidArray = [];
+        foreach ($pidTypeArray as $pidType) {
+            if (
                 $conf[$pidType] &&
                 MathUtility::canBeInterpretedAsInteger($conf[$pidType])
             ) {
-				$pidArray[$pidType] = $conf[$pidType];
+                $pidArray[$pidType] = $conf[$pidType];
             } else if ($pidType != 'PIDthanks') {
                 $pidArray[$pidType] = $conf['PIDbasket'];
              }
-		}
+        }
 
-		$mainMarkerArray = [];
-		$bFinalize = false; // no finalization must be called.
-		$bFinalVerify = false;
+        $mainMarkerArray = [];
+        $bFinalize = false; // no finalization must be called.
+        $bFinalVerify = false;
 
-		if (
-			!empty($activityArray['products_info']) ||
-			!empty($activityArray['products_payment']) ||
-			!empty($activityArray['products_customized_payment']) ||
-			!empty($activityArray['products_verify']) ||
-			!empty($activityArray['products_finalize'])
-		) {
-			// get credit card info
-			$cardViewObj = $tablesObj->get('sys_products_cards', true);
-			if (is_object($cardViewObj)) {
-				$cardObj = $cardViewObj->getModelObj();
-				$cardUid = $cardObj->getUid();
-				$cardRow = $cardObj->getRow($cardUid);
-				$cardViewObj->getMarkerArray(
-					$cardRow,
-					$mainMarkerArray,
-					$cardObj->getAllowedArray(),
-					$cardObj->getTablename()
-				);
-			}
+        if (
+            !empty($activityArray['products_info']) ||
+            !empty($activityArray['products_payment']) ||
+            !empty($activityArray['products_customized_payment']) ||
+            !empty($activityArray['products_verify']) ||
+            !empty($activityArray['products_finalize'])
+        ) {
+            // get credit card info
+            $cardViewObj = $tablesObj->get('sys_products_cards', true);
+            if (is_object($cardViewObj)) {
+                $cardObj = $cardViewObj->getModelObj();
+                $cardUid = $cardObj->getUid();
+                $cardRow = $cardObj->getRow($cardUid);
+                $cardViewObj->getMarkerArray(
+                    $cardRow,
+                    $mainMarkerArray,
+                    $cardObj->getAllowedArray(),
+                    $cardObj->getTablename()
+                );
+            }
 
-			// get bank account info
-			$accountViewObj = $tablesObj->get('sys_products_accounts', true);
-			if (is_object($accountViewObj)) {
-				$accountObj = $accountViewObj->getModelObj();
-				$accountViewObj->getMarkerArray(
-					$accountObj->acArray,
-					$mainMarkerArray,
-					$accountObj->getIsAllowed()
-				);
-			}
-		}
+            // get bank account info
+            $accountViewObj = $tablesObj->get('sys_products_accounts', true);
+            if (is_object($accountViewObj)) {
+                $accountObj = $accountViewObj->getModelObj();
+                $accountViewObj->getMarkerArray(
+                    $accountObj->acArray,
+                    $mainMarkerArray,
+                    $accountObj->getIsAllowed()
+                );
+            }
+        }
 
-		foreach ($activityArray as $activity => $value) {
-			$theCode = 'BASKET';
-			$basket_tmpl = '';
+        foreach ($activityArray as $activity => $value) {
+            $theCode = 'BASKET';
+            $basket_tmpl = '';
 
-			if ($value) {
-				$currentPaymentActivity = array_search($activity, $activityVarsArray);
-				$activityConf = $cnf->getBasketConf('activity', $currentPaymentActivity);
+            if ($value) {
+                $currentPaymentActivity = array_search($activity, $activityVarsArray);
+                $activityConf = $cnf->getBasketConf('activity', $currentPaymentActivity);
 
-				if (isset($activityConf['check'])) {
-					$checkArray = GeneralUtility::trimExplode(',', $activityConf['check']);
+                if (isset($activityConf['check'])) {
+                    $checkArray = GeneralUtility::trimExplode(',', $activityConf['check']);
 
-					foreach ($checkArray as $checkType) {
+                    foreach ($checkArray as $checkType) {
 
-						switch ($checkType) {
-							case 'account':
-								if (PaymentShippingHandling::useAccount($basketExtra)) {
-									$accountRequired = $accountObj->checkRequired();
-								}
-								break;
-							case 'address':
-								$checkRequired = $infoViewObj->checkRequired('billing', $basketExtra);
+                        switch ($checkType) {
+                            case 'account':
+                                if (PaymentShippingHandling::useAccount($basketExtra)) {
+                                    $accountRequired = $accountObj->checkRequired();
+                                }
+                                break;
+                            case 'address':
+                                $checkRequired = $infoViewObj->checkRequired('billing', $basketExtra);
 
-								if (!$checkRequired) {
-									$checkRequired = $infoViewObj->checkRequired('delivery', $basketExtra);
-								}
-								$checkAllowed = $infoViewObj->checkAllowed($basketExtra);
-								break;
-							case 'agb':
-								$pidagb = intval($conf['PIDagb']);
-								break;
-							case 'basket':
-								$checkBasket = true;
-								break;
-							case 'edit_variant':
-								$checkEditVariants = true;
-								break;
-							case 'card':
-								if (PaymentShippingHandling::useCreditcard($basketExtra)) {
-									$cardRequired = $cardObj->checkRequired();
-								}
-								break;
-							case 'gift':
-								$wrongGiftNumber = 0;
-								$giftRequired = tx_ttproducts_gifts_div::checkRequired($basketExt, $infoViewObj, $wrongGiftNumber);
-								if ($wrongGiftNumber) {
-									tx_ttproducts_gifts_div::deleteGiftNumber($wrongGiftNumber);
-								}
-								break;
-						}
-					}
-				}
+                                if (!$checkRequired) {
+                                    $checkRequired = $infoViewObj->checkRequired('delivery', $basketExtra);
+                                }
+                                $checkAllowed = $infoViewObj->checkAllowed($basketExtra);
+                                break;
+                            case 'agb':
+                                $pidagb = intval($conf['PIDagb']);
+                                break;
+                            case 'basket':
+                                $checkBasket = true;
+                                break;
+                            case 'edit_variant':
+                                $checkEditVariants = true;
+                                break;
+                            case 'card':
+                                if (PaymentShippingHandling::useCreditcard($basketExtra)) {
+                                    $cardRequired = $cardObj->checkRequired();
+                                }
+                                break;
+                            case 'gift':
+                                $wrongGiftNumber = 0;
+                                $giftRequired = tx_ttproducts_gifts_div::checkRequired($basketExt, $infoViewObj, $wrongGiftNumber);
+                                if ($wrongGiftNumber) {
+                                    tx_ttproducts_gifts_div::deleteGiftNumber($wrongGiftNumber);
+                                }
+                                break;
+                        }
+                    }
+                }
 
-					// perform action
-				switch($activity) {
-					case 'products_clear_basket':
-						// Empties the shopping basket!
-						$basketObj->clearBasket(true);
+                    // perform action
+                switch($activity) {
+                    case 'products_clear_basket':
+                        // Empties the shopping basket!
+                        $basketObj->clearBasket(true);
                         $bBasketEmpty = $basketObj->isEmpty();
-						$calculatedArray = [];
-						$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-						$calculObj->setCalculatedArray($calculatedArray);
-						$calculObj->clear();
-						$calculatedArray = $calculObj->getCalculatedArray();
-					break;
-					case 'products_basket':
-						if (
-							count($activityArray) == 1 ||
-							count($activityArray) == 2 && !empty($activityArray['products_overview'])
-						) {
-							$basket_tmpl = 'BASKET_TEMPLATE';
-						}
-					break;
-					case 'products_overview':
-						$basket_tmpl = 'BASKET_OVERVIEW_TEMPLATE';
+                        $calculatedArray = [];
+                        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+                        $calculObj->setCalculatedArray($calculatedArray);
+                        $calculObj->clear();
+                        $calculatedArray = $calculObj->getCalculatedArray();
+                    break;
+                    case 'products_basket':
+                        if (
+                            count($activityArray) == 1 ||
+                            count($activityArray) == 2 && !empty($activityArray['products_overview'])
+                        ) {
+                            $basket_tmpl = 'BASKET_TEMPLATE';
+                        }
+                    break;
+                    case 'products_overview':
+                        $basket_tmpl = 'BASKET_OVERVIEW_TEMPLATE';
 
-						if (!empty($codeActivityArray[$activity])) {
-							$theCode = 'OVERVIEW';
-						}
-					break;
-					case 'products_redeem_gift': 	// this shall never be the only activity
-						if (trim($GLOBALS['TSFE']->fe_user->user['username']) == '') {
-							$basket_tmpl = 'BASKET_TEMPLATE_NOT_LOGGED_IN';
-						} else {
-							$uniqueId = GeneralUtility::trimExplode ('-', $basketObj->recs['tt_products']['giftcode'], true);
-							$query='uid=\'' . intval($uniqueId[0]) . '\' AND crdate=\'' . intval($uniqueId[1]) . '\'' . ' AND NOT deleted' ;
-							$giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
-							$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes);
+                        if (!empty($codeActivityArray[$activity])) {
+                            $theCode = 'OVERVIEW';
+                        }
+                    break;
+                    case 'products_redeem_gift': 	// this shall never be the only activity
+                        if (trim($GLOBALS['TSFE']->fe_user->user['username']) == '') {
+                            $basket_tmpl = 'BASKET_TEMPLATE_NOT_LOGGED_IN';
+                        } else {
+                            $uniqueId = GeneralUtility::trimExplode ('-', $basketObj->recs['tt_products']['giftcode'], true);
+                            $query='uid=\'' . intval($uniqueId[0]) . '\' AND crdate=\'' . intval($uniqueId[1]) . '\'' . ' AND NOT deleted' ;
+                            $giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
+                            $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes);
 
-							$pricefactor = doubleval($conf['creditpoints.']['pricefactor']);
-							if ($row && $pricefactor > 0) {
-								$money = $row['amount'];
-								$uid = $row['uid'];
-								$fieldsArray = [];
-								$fieldsArray['deleted']=1;
-									// Delete the gift record
-								$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_products_gifts', 'uid='.intval($uid), $fieldsArray);
-								$creditpoints = $money / $pricefactor;
-								tx_ttproducts_creditpoints_div::addCreditPoints($GLOBALS['TSFE']->fe_user->user['username'], $creditpoints);
-								$cpArray =  tx_ttproducts_control_session::readSession('cp');
-								$cpArray['gift']['amount'] += $creditpoints;
-								tx_ttproducts_control_basket::store('cp', $cpArray);
-							}
-						}
-					break;
-					case 'products_info':
-						$basket_tmpl = 'BASKET_INFO_TEMPLATE';
+                            $pricefactor = doubleval($conf['creditpoints.']['pricefactor']);
+                            if ($row && $pricefactor > 0) {
+                                $money = $row['amount'];
+                                $uid = $row['uid'];
+                                $fieldsArray = [];
+                                $fieldsArray['deleted']=1;
+                                    // Delete the gift record
+                                $GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_products_gifts', 'uid='.intval($uid), $fieldsArray);
+                                $creditpoints = $money / $pricefactor;
+                                tx_ttproducts_creditpoints_div::addCreditPoints($GLOBALS['TSFE']->fe_user->user['username'], $creditpoints);
+                                $cpArray =  tx_ttproducts_control_session::readSession('cp');
+                                $cpArray['gift']['amount'] += $creditpoints;
+                                tx_ttproducts_control_basket::store('cp', $cpArray);
+                            }
+                        }
+                    break;
+                    case 'products_info':
+                        $basket_tmpl = 'BASKET_INFO_TEMPLATE';
 
-						if (!empty($codeActivityArray[$activity]) ||  
+                        if (!empty($codeActivityArray[$activity]) ||  
                             empty($activityArray['products_basket'])) {
-							$theCode = 'INFO';
-						}
-					break;
-					case 'products_payment':
-						$bPayment = true;
-						$orderUid = $this->getOrderUid($orderArray);
+                            $theCode = 'INFO';
+                        }
+                    break;
+                    case 'products_payment':
+                        $bPayment = true;
+                        $orderUid = $this->getOrderUid($orderArray);
                         $orderNumber = $this->getOrdernumber($orderUid);
 
-						if ($conf['paymentActivity'] == 'payment' || $conf['paymentActivity'] == 'verify') {
-							$handleLib =
-								PaymentShippingHandling::getHandleLib(
-									'request',
-									$basketExtra
-								);
+                        if ($conf['paymentActivity'] == 'payment' || $conf['paymentActivity'] == 'verify') {
+                            $handleLib =
+                                PaymentShippingHandling::getHandleLib(
+                                    'request',
+                                    $basketExtra
+                                );
 
-							if (strpos($handleLib,'transactor') !== false) {
-								// Payment Transactor
-								tx_transactor_api::init($this->pibase, $this->cObj, $conf);
-								$referenceId = tx_transactor_api::getReferenceUid(
-									$handleLib,
-									$basketObj->basketExtra['payment.']['handleLib.'],
-									TT_PRODUCTS_EXT,
-									$orderUid
-								);
-								$addQueryString = [];
-								$excludeList = '';
-								$linkParams =
-									$this->urlObj->getLinkParams(
-										$excludeList,
-										$addQueryString,
-										true
-									);
+                            if (strpos($handleLib,'transactor') !== false) {
+                                // Payment Transactor
+                                tx_transactor_api::init($this->pibase, $this->cObj, $conf);
+                                $referenceId = tx_transactor_api::getReferenceUid(
+                                    $handleLib,
+                                    $basketObj->basketExtra['payment.']['handleLib.'],
+                                    TT_PRODUCTS_EXT,
+                                    $orderUid
+                                );
+                                $addQueryString = [];
+                                $excludeList = '';
+                                $linkParams =
+                                    $this->urlObj->getLinkParams(
+                                        $excludeList,
+                                        $addQueryString,
+                                        true
+                                    );
                                 $useNewTransactor = false;
                                 $transactorConf = $this->getTransactorConf($handleLib);
                                 if (
@@ -1250,31 +1250,31 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                                         $cardRow
                                     );
                                 }
-							} else if (strpos($handleLib,'paymentlib') !== false) {
-								$paymentlib = GeneralUtility::makeInstance('tx_ttproducts_paymentlib');
-								$paymentlib->init($this->pibase, $basketView, $this->urlObj);
-								$referenceId = $paymentlib->getReferenceUid();
-								$paymentErrorMsg = $paymentlib->checkRequired(
-									$referenceId,
-									$orderArray,
-									$basketObj->basketExtra['payment.']['handleLib'],
-									$basketObj->basketExtra['payment.']['handleLib.']
-								);
-							}
-						}
+                            } else if (strpos($handleLib,'paymentlib') !== false) {
+                                $paymentlib = GeneralUtility::makeInstance('tx_ttproducts_paymentlib');
+                                $paymentlib->init($this->pibase, $basketView, $this->urlObj);
+                                $referenceId = $paymentlib->getReferenceUid();
+                                $paymentErrorMsg = $paymentlib->checkRequired(
+                                    $referenceId,
+                                    $orderArray,
+                                    $basketObj->basketExtra['payment.']['handleLib'],
+                                    $basketObj->basketExtra['payment.']['handleLib.']
+                                );
+                            }
+                        }
 
-						if (
+                        if (
                             !empty($codeActivityArray[$activity]) ||
                              empty($activityArray['products_basket'])          
                         ) {
-							$theCode = 'PAYMENT';
-						}
-						$basket_tmpl = 'BASKET_PAYMENT_TEMPLATE';
-					break;
-					// a special step after payment and before finalization needed for some payment methods
-					case 'products_customized_payment': // deprecated
-					case 'products_verify':
-						$bPayment = true;
+                            $theCode = 'PAYMENT';
+                        }
+                        $basket_tmpl = 'BASKET_PAYMENT_TEMPLATE';
+                    break;
+                    // a special step after payment and before finalization needed for some payment methods
+                    case 'products_customized_payment': // deprecated
+                    case 'products_verify':
+                        $bPayment = true;
 
                         if (
                             !$bBasketEmpty &&
@@ -1282,360 +1282,360 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                                 $conf['paymentActivity'] == 'verify' || $conf['paymentActivity'] == 'customized' /* deprecated */
                             )
                         ) {
-							$orderUid = $this->getOrderUid($orderArray);
-							$orderNumber = $this->getOrdernumber($orderUid);
+                            $orderUid = $this->getOrderUid($orderArray);
+                            $orderNumber = $this->getOrdernumber($orderUid);
 
-							$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
-								$this->processPayment(
-									$orderUid,
+                            $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
+                                $this->processPayment(
+                                    $orderUid,
                                     $orderNumber,
-									$cardRow,
-									$pidArray,
-									$currentPaymentActivity,
-									$calculatedArray,
-									$basketExtra,
-									$basketRecs,
-									$orderArray,
-									$productRowArray,
-									$bFinalize,
-									$bFinalVerify,
-									$paymentScript,
-									$errorCode,
-									$errorMessage
-								);
+                                    $cardRow,
+                                    $pidArray,
+                                    $currentPaymentActivity,
+                                    $calculatedArray,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $orderArray,
+                                    $productRowArray,
+                                    $bFinalize,
+                                    $bFinalVerify,
+                                    $paymentScript,
+                                    $errorCode,
+                                    $errorMessage
+                                );
 
-							$paymentErrorMsg = $errorMessage;
+                            $paymentErrorMsg = $errorMessage;
 
-							if ($errorMessage != '') {
-								$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
-							}
-							if (!$bFinalize) {
-								$basket_tmpl = 'BASKET_PAYMENT_TEMPLATE';
-							}
-						} else {
-							$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
-						}
-					break;
-					case 'products_finalize':
-						$bPayment = true;
-						$handleLib = PaymentShippingHandling::getHandleLib('request', $basketExtra);
-						if ($handleLib == '') {
-							$handleLib = PaymentShippingHandling::getHandleLib('form', $basketExtra);
-						}
-						$orderUid = $this->getOrderUid($orderArray);
-						$orderNumber = $this->getOrdernumber($orderUid);
+                            if ($errorMessage != '') {
+                                $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
+                            }
+                            if (!$bFinalize) {
+                                $basket_tmpl = 'BASKET_PAYMENT_TEMPLATE';
+                            }
+                        } else {
+                            $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
+                        }
+                    break;
+                    case 'products_finalize':
+                        $bPayment = true;
+                        $handleLib = PaymentShippingHandling::getHandleLib('request', $basketExtra);
+                        if ($handleLib == '') {
+                            $handleLib = PaymentShippingHandling::getHandleLib('form', $basketExtra);
+                        }
+                        $orderUid = $this->getOrderUid($orderArray);
+                        $orderNumber = $this->getOrdernumber($orderUid);
 
-						if (
+                        if (
                             !$bBasketEmpty &&
                             $handleLib != ''
                         ) {
-							$rc = $this->processPayment(
-								$orderUid,
+                            $rc = $this->processPayment(
+                                $orderUid,
                                 $orderNumber,
-								$cardRow,
-								$pidArray,
-								$currentPaymentActivity,
-								$calculatedArray,
-								$basketExtra,
-								$basketRecs,
-								$orderArray,
-								$productRowArray,
-								$bFinalize,
-								$bFinalVerify,
-								$paymentScript,
-								$errorCode,
-								$errorMessage
-							);
-							$paymentErrorMsg = $errorMessage;
+                                $cardRow,
+                                $pidArray,
+                                $currentPaymentActivity,
+                                $calculatedArray,
+                                $basketExtra,
+                                $basketRecs,
+                                $orderArray,
+                                $productRowArray,
+                                $bFinalize,
+                                $bFinalVerify,
+                                $paymentScript,
+                                $errorCode,
+                                $errorMessage
+                            );
+                            $paymentErrorMsg = $errorMessage;
 
-							if($bFinalize == false) {
-								$label = $paymentErrorMsg;
-								$markerArray['###ERROR_DETAILS###'] = $label;
-								$basket_tmpl = 'BASKET_TEMPLATE'; // step back to the basket page
-							} else {
-								$content = ''; // do not show the content of payment again
-							}
-						} else {
-							$bFinalize = true;
-						}
+                            if($bFinalize == false) {
+                                $label = $paymentErrorMsg;
+                                $markerArray['###ERROR_DETAILS###'] = $label;
+                                $basket_tmpl = 'BASKET_TEMPLATE'; // step back to the basket page
+                            } else {
+                                $content = ''; // do not show the content of payment again
+                            }
+                        } else {
+                            $bFinalize = true;
+                        }
 
-						if (
-							(!empty($codeActivityArray[$activity]) || empty($activityArray['products_basket'])) &&
-							$bFinalize
-						) {
-							$theCode = 'FINALIZE';
-						}
-					break;
-					default:
-						// nothing yet
-						$activity = 'unknown';
-					break;
-				} // switch
-			}	// if ($value)
-			$templateFilename = '';
-			$templateCode = $templateObj->get(
-				$theCode,
-				$templateFilename,
-				$errorCode
-			);
+                        if (
+                            (!empty($codeActivityArray[$activity]) || empty($activityArray['products_basket'])) &&
+                            $bFinalize
+                        ) {
+                            $theCode = 'FINALIZE';
+                        }
+                    break;
+                    default:
+                        // nothing yet
+                        $activity = 'unknown';
+                    break;
+                } // switch
+            }	// if ($value)
+            $templateFilename = '';
+            $templateCode = $templateObj->get(
+                $theCode,
+                $templateFilename,
+                $errorCode
+            );
 
-			if ($errorCode) {
-				return '';
-			}
+            if ($errorCode) {
+                return '';
+            }
 
-			if ($value) {
-				$newContent = $this->getContent(
-					$templateCode,
-					$templateFilename,
-					$mainMarkerArray,
-					$calculatedArray,
-					$basketExtra,
-					$basketRecs,
-					$orderUid,
+            if ($value) {
+                $newContent = $this->getContent(
+                    $templateCode,
+                    $templateFilename,
+                    $mainMarkerArray,
+                    $calculatedArray,
+                    $basketExtra,
+                    $basketRecs,
+                    $orderUid,
                     $orderNumber,
-					$orderArray,
-					$productRowArray,
-					$theCode,
-					$basket_tmpl,
-					$bPayment,
-					$activityArray,
-					$currentPaymentActivity,
-					$pidArray,
-					$infoViewObj->infoArray,
-					$checkBasket,
-					$bBasketEmpty,
-					$checkRequired,
-					$checkAllowed,
-					$cardRequired,
-					$accountRequired,
-					$giftRequired,
-					$checkEditVariants,
-					$paymentErrorMsg,
-					$pidagb,
-					$cardObj,
-					$cardRow,
-					$accountObj,
-					$markerArray,
-					$errorCode,
-					$errorMessage,
-					$bFinalize,
-					$bFinalVerify
-				);
+                    $orderArray,
+                    $productRowArray,
+                    $theCode,
+                    $basket_tmpl,
+                    $bPayment,
+                    $activityArray,
+                    $currentPaymentActivity,
+                    $pidArray,
+                    $infoViewObj->infoArray,
+                    $checkBasket,
+                    $bBasketEmpty,
+                    $checkRequired,
+                    $checkAllowed,
+                    $cardRequired,
+                    $accountRequired,
+                    $giftRequired,
+                    $checkEditVariants,
+                    $paymentErrorMsg,
+                    $pidagb,
+                    $cardObj,
+                    $cardRow,
+                    $accountObj,
+                    $markerArray,
+                    $errorCode,
+                    $errorMessage,
+                    $bFinalize,
+                    $bFinalVerify
+                );
 
-				$addQueryString = [];
-				$overwriteMarkerArray = [];
+                $addQueryString = [];
+                $overwriteMarkerArray = [];
 
-				$piVars = tx_ttproducts_model_control::getPiVars();
-				if (is_array($piVars)) {
-					$backPID = $piVars['backPID'] ?? '';
-				}
-				$overwriteMarkerArray =
-					$this->urlObj->addURLMarkers(
-						$backPID,
-						[],
-						$addQueryString
-					);
-				$markerArray = array_merge($markerArray, $overwriteMarkerArray);
-				$content = $templateService->substituteMarkerArray($content . $newContent, $markerArray);
-			}
-		} // foreach ($activityArray as $activity=>$value)
+                $piVars = tx_ttproducts_model_control::getPiVars();
+                if (is_array($piVars)) {
+                    $backPID = $piVars['backPID'] ?? '';
+                }
+                $overwriteMarkerArray =
+                    $this->urlObj->addURLMarkers(
+                        $backPID,
+                        [],
+                        $addQueryString
+                    );
+                $markerArray = array_merge($markerArray, $overwriteMarkerArray);
+                $content = $templateService->substituteMarkerArray($content . $newContent, $markerArray);
+            }
+        } // foreach ($activityArray as $activity=>$value)
 
-			// finalization at the end so that after every activity this can be called
-		if ($bFinalize && !$bBasketEmpty && $orderUid) {
-			$checkRequired = $infoViewObj->checkRequired('billing', $basketExtra);
+            // finalization at the end so that after every activity this can be called
+        if ($bFinalize && !$bBasketEmpty && $orderUid) {
+            $checkRequired = $infoViewObj->checkRequired('billing', $basketExtra);
 
-			if (!$checkRequired) {
-				$checkRequired = $infoViewObj->checkRequired('delivery', $basketExtra);
-			}
+            if (!$checkRequired) {
+                $checkRequired = $infoViewObj->checkRequired('delivery', $basketExtra);
+            }
 
-			$checkAllowed = $infoViewObj->checkAllowed($basketExtra);
-			if ($checkRequired == '' && $checkAllowed == '') {
-				$orderUid = $this->getOrderUid($orderArray);
+            $checkAllowed = $infoViewObj->checkAllowed($basketExtra);
+            if ($checkRequired == '' && $checkAllowed == '') {
+                $orderUid = $this->getOrderUid($orderArray);
                 $orderNumber = $this->getOrdernumber($orderUid);
 
-				if (
+                if (
                     !$bBasketEmpty &&
                     trim($conf['paymentActivity']) == 'finalize'
                 ) {
-					$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
-						$this->processPayment(
-							$orderUid,
+                    $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] =
+                        $this->processPayment(
+                            $orderUid,
                             $orderNumber,
                             $cardRow,
-							$pidArray,
-							'finalize',
-							$calculatedArray,
-							$basketExtra,
-							$basketRecs,
-							$orderArray,
-							$productRowArray,
-							$bFinalize,
-							$bFinalVerify,
-							$paymentScript,
-							$errorCode,
-							$errorMessage
-						);
-					if ($errorMessage != '') {
-						$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
-					}
-				} else {
-					$mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
-				}
+                            $pidArray,
+                            'finalize',
+                            $calculatedArray,
+                            $basketExtra,
+                            $basketRecs,
+                            $orderArray,
+                            $productRowArray,
+                            $bFinalize,
+                            $bFinalVerify,
+                            $paymentScript,
+                            $errorCode,
+                            $errorMessage
+                        );
+                    if ($errorMessage != '') {
+                        $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = $errorMessage;
+                    }
+                } else {
+                    $mainMarkerArray['###MESSAGE_PAYMENT_SCRIPT###'] = '';
+                }
 
-					// order finalization
-				$activityFinalize = GeneralUtility::makeInstance('tx_ttproducts_activity_finalize');
-				if (intval($conf['alwaysInStock'])) {
-					$alwaysInStock = 1;
-				} else {
-					$alwaysInStock = 0;
-				}
+                    // order finalization
+                $activityFinalize = GeneralUtility::makeInstance('tx_ttproducts_activity_finalize');
+                if (intval($conf['alwaysInStock'])) {
+                    $alwaysInStock = 1;
+                } else {
+                    $alwaysInStock = 0;
+                }
 
-				$usedCreditpoints = 0;
-				if (isset($_REQUEST['recs'])) {
+                $usedCreditpoints = 0;
+                if (isset($_REQUEST['recs'])) {
                     $usedCreditpoints = tx_ttproducts_creditpoints_div::getUsedCreditpoints($_REQUEST['recs']);
                 }
 
-				$contentTmp = $activityFinalize->doProcessing(
-					$templateCode,
-					$mainMarkerArray,
-					$this->funcTablename,
-					$orderUid,
-					$orderArray,
-					$productRowArray,
-					$alwaysInStock,
-					$conf['useArticles'],
-					$addressArray,
-					$bFinalVerify,
-					$basketExt,
-					$usedCreditpoints,
-					$errorCode,
-					$errorMessage
-				);
+                $contentTmp = $activityFinalize->doProcessing(
+                    $templateCode,
+                    $mainMarkerArray,
+                    $this->funcTablename,
+                    $orderUid,
+                    $orderArray,
+                    $productRowArray,
+                    $alwaysInStock,
+                    $conf['useArticles'],
+                    $addressArray,
+                    $bFinalVerify,
+                    $basketExt,
+                    $usedCreditpoints,
+                    $errorCode,
+                    $errorMessage
+                );
 
-				if (isset($conf['PIDthanks']) && $conf['PIDthanks'] == $GLOBALS['TSFE']->id) {
-					$tmpl = 'BASKET_ORDERTHANKS_TEMPLATE';
-					$contentTmpThanks = $basketView->getView(
-						$errorCode,
-						$templateCode,
-						$theCode,
-						$infoViewObj,
-						false,
-						false,
-						$calculatedArray,
-						true,
-						$tmpl,
-						$mainMarkerArray,
-						$templateFilename,
-						$basketObj->getItemArray(),
+                if (isset($conf['PIDthanks']) && $conf['PIDthanks'] == $GLOBALS['TSFE']->id) {
+                    $tmpl = 'BASKET_ORDERTHANKS_TEMPLATE';
+                    $contentTmpThanks = $basketView->getView(
+                        $errorCode,
+                        $templateCode,
+                        $theCode,
+                        $infoViewObj,
+                        false,
+                        false,
+                        $calculatedArray,
+                        true,
+                        $tmpl,
+                        $mainMarkerArray,
+                        $templateFilename,
+                        $basketObj->getItemArray(),
                         $notOverwritePriceIfSet = true,
-						['0' => $orderArray],
-						$productRowArray,
-						$basketExtra,
-						$basketRecs
-					);
-					if ($contentTmpThanks != '') {
-						$contentTmp = $contentTmpThanks;
-					}
-				}
-				if (!empty($activityArray['products_payment'])) {	// forget the payment output from before if it comes to finalize
-					$content = '';
-				}
-				$content .= $contentTmp;
-				$contentNoSave = $basketView->getView(
-					$errorCode,
-					$templateCode,
-					$theCode,
-					$infoViewObj,
-					false,
-					false,
-					$calculatedArray,
-					true,
-					'BASKET_ORDERCONFIRMATION_NOSAVE_TEMPLATE',
-					$mainMarkerArray,
-					$templateFilename,
-					$basketObj->getItemArray(),
+                        ['0' => $orderArray],
+                        $productRowArray,
+                        $basketExtra,
+                        $basketRecs
+                    );
+                    if ($contentTmpThanks != '') {
+                        $contentTmp = $contentTmpThanks;
+                    }
+                }
+                if (!empty($activityArray['products_payment'])) {	// forget the payment output from before if it comes to finalize
+                    $content = '';
+                }
+                $content .= $contentTmp;
+                $contentNoSave = $basketView->getView(
+                    $errorCode,
+                    $templateCode,
+                    $theCode,
+                    $infoViewObj,
+                    false,
+                    false,
+                    $calculatedArray,
+                    true,
+                    'BASKET_ORDERCONFIRMATION_NOSAVE_TEMPLATE',
+                    $mainMarkerArray,
+                    $templateFilename,
+                    $basketObj->getItemArray(),
                     $notOverwritePriceIfSet = true,
-					['0' => $orderArray],
-					$productRowArray,
-					$basketExtra,
-					$basketRecs
-				);
-				$content .= $contentNoSave;
+                    ['0' => $orderArray],
+                    $productRowArray,
+                    $basketExtra,
+                    $basketRecs
+                );
+                $content .= $contentNoSave;
 
-				// Empties the shopping basket!
-				$basketObj->clearBasket();
-			} else {	// If not all required info-fields are filled in, this is shown instead:
-				$subpart = 'BASKET_REQUIRED_INFO_MISSING';
-				$requiredOut = tx_ttproducts_api::getErrorOut(
-					$theCode,
-					$templateCode,
-					$subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
-					$subpartmarkerObj->spMarker('###' . $subpart . '###'),
-					$errorCode
-				);
+                // Empties the shopping basket!
+                $basketObj->clearBasket();
+            } else {	// If not all required info-fields are filled in, this is shown instead:
+                $subpart = 'BASKET_REQUIRED_INFO_MISSING';
+                $requiredOut = tx_ttproducts_api::getErrorOut(
+                    $theCode,
+                    $templateCode,
+                    $subpartmarkerObj->spMarker('###' . $subpart . $this->config['templateSuffix'] . '###'),
+                    $subpartmarkerObj->spMarker('###' . $subpart . '###'),
+                    $errorCode
+                );
 
-				if (!$requiredOut) {
-					return '';
-				}
+                if (!$requiredOut) {
+                    return '';
+                }
 
-				$label = $this->getErrorLabel(
-					$languageObj,
-					$accountObj,
-					$cardObj,
-					$pidagb,
-					$infoViewObj->infoArray,
-					$checkRequired,
-					$checkAllowed,
-					$cardRequired,
-					$accountRequired,
-					$paymentErrorMsg
-				);
+                $label = $this->getErrorLabel(
+                    $languageObj,
+                    $accountObj,
+                    $cardObj,
+                    $pidagb,
+                    $infoViewObj->infoArray,
+                    $checkRequired,
+                    $checkAllowed,
+                    $cardRequired,
+                    $accountRequired,
+                    $paymentErrorMsg
+                );
 
-				$mainMarkerArray['###ERROR_DETAILS###'] = $label;
+                $mainMarkerArray['###ERROR_DETAILS###'] = $label;
                 $urlMarkerArray = $this->urlObj->addURLMarkers(0, [], $theCode);
-				$markerArray = array_merge($mainMarkerArray, $urlMarkerArray);
+                $markerArray = array_merge($mainMarkerArray, $urlMarkerArray);
 
-				$content .= $requiredOut;
-				$content = $templateService->substituteMarkerArray(
-					$content,
-					$markerArray
-				);
-			}
-		}
+                $content .= $requiredOut;
+                $content = $templateService->substituteMarkerArray(
+                    $content,
+                    $markerArray
+                );
+            }
+        }
 
-		$content = $markerObj->replaceGlobalMarkers(
-			$content
-		);
+        $content = $markerObj->replaceGlobalMarkers(
+            $content
+        );
 
-		return $content;
-	} // processActivities
+        return $content;
+    } // processActivities
 
 
-	/**
-	 * Do all the things to be done for this activity
-	 * former functions products_basket and basketView::printView
-	 * Takes care of basket, address info, confirmation and gate to payment
-	 * Also the 'products_...' script parameters are used here.
-	 *
-	 * @param	array		  CODEs for display mode
-	 * @return	string	text to display
-	 */
-	public function doProcessing (
-		$codes,
-		$calculatedArray,
-		$basketExtra,
-		array $basketRecs,
-		$basketExt,
-		$addressArray,
-		&$errorCode,
-		&$errorMessage
-	) {
-		$content = '';
-		$empty = '';
-		$activityArray = [];
-		$this->activityArray = [];
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    /**
+     * Do all the things to be done for this activity
+     * former functions products_basket and basketView::printView
+     * Takes care of basket, address info, confirmation and gate to payment
+     * Also the 'products_...' script parameters are used here.
+     *
+     * @param	array		  CODEs for display mode
+     * @return	string	text to display
+     */
+    public function doProcessing (
+        $codes,
+        $calculatedArray,
+        $basketExtra,
+        array $basketRecs,
+        $basketExt,
+        $addressArray,
+        &$errorCode,
+        &$errorMessage
+    ) {
+        $content = '';
+        $empty = '';
+        $activityArray = [];
+        $this->activityArray = [];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
         $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
         $templateFilename = '';
         $templateCode = $templateObj->get(
@@ -1644,94 +1644,94 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
             $errorCode
         );
 
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$basketView->init(
-			$this->useArticles,
-			$errorCode,
-			$this->urlArray
-		);
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $basketView->init(
+            $this->useArticles,
+            $errorCode,
+            $this->urlArray
+        );
 
-		$activityVarsArray = [
-			'clear_basket' => 'products_clear_basket',
-			'customized_payment' => 'products_customized_payment',
-			'basket' => 'products_basket',
-			'finalize' => 'products_finalize',
-			'info' => 'products_info',
-			'overview' => 'products_overview',
-			'payment' => 'products_payment',
-			'redeem_gift' => 'products_redeem_gift',
-			'verify' => 'products_verify'
-		];
+        $activityVarsArray = [
+            'clear_basket' => 'products_clear_basket',
+            'customized_payment' => 'products_customized_payment',
+            'basket' => 'products_basket',
+            'finalize' => 'products_finalize',
+            'info' => 'products_info',
+            'overview' => 'products_overview',
+            'payment' => 'products_payment',
+            'redeem_gift' => 'products_redeem_gift',
+            'verify' => 'products_verify'
+        ];
 
-		$update = GeneralUtility::_POST('products_update') || GeneralUtility::_POST('products_update_x');
-		$info = GeneralUtility::_POST('products_info') || GeneralUtility::_POST('products_info_x');
-		$payment = GeneralUtility::_POST('products_payment') || GeneralUtility::_POST('products_payment_x');
-		$gpVars = GeneralUtility::_GP(TT_PRODUCTS_EXT);
+        $update = GeneralUtility::_POST('products_update') || GeneralUtility::_POST('products_update_x');
+        $info = GeneralUtility::_POST('products_info') || GeneralUtility::_POST('products_info_x');
+        $payment = GeneralUtility::_POST('products_payment') || GeneralUtility::_POST('products_payment_x');
+        $gpVars = GeneralUtility::_GP(TT_PRODUCTS_EXT);
 
-		if (!$update && !$payment && !$info && isset($gpVars) && is_array($gpVars) && isset($gpVars['activity']) && is_array($gpVars['activity'])) {
-			$changedActivity = key($gpVars['activity']);
-			$theActivity = $activityVarsArray[$changedActivity];
-			if ($theActivity) {
-				$activityArray[$theActivity] = $gpVars['activity'][$changedActivity];
-			}
-		}
+        if (!$update && !$payment && !$info && isset($gpVars) && is_array($gpVars) && isset($gpVars['activity']) && is_array($gpVars['activity'])) {
+            $changedActivity = key($gpVars['activity']);
+            $theActivity = $activityVarsArray[$changedActivity];
+            if ($theActivity) {
+                $activityArray[$theActivity] = $gpVars['activity'][$changedActivity];
+            }
+        }
 
-			// use '_x' for coordinates from Internet Explorer if button images are used
-		if (GeneralUtility::_GP('products_redeem_gift') || GeneralUtility::_GP('products_redeem_gift_x')) {
-		 	$activityArray['products_redeem_gift'] = true;
-		}
+            // use '_x' for coordinates from Internet Explorer if button images are used
+        if (GeneralUtility::_GP('products_redeem_gift') || GeneralUtility::_GP('products_redeem_gift_x')) {
+            $activityArray['products_redeem_gift'] = true;
+        }
 
-		if (GeneralUtility::_GP('products_clear_basket') || GeneralUtility::_GP('products_clear_basket_x')) {
-			$activityArray['products_clear_basket'] = true;
-		}
-		if (GeneralUtility::_GP('products_overview') || GeneralUtility::_GP('products_overview_x')) {
-			$activityArray['products_overview'] = true;
-		}
-		if (!$update) {
-			if (GeneralUtility::_GP('products_payment') || GeneralUtility::_GP('products_payment_x')) {
-				$activityArray['products_payment'] = true;
-			} else if (GeneralUtility::_GP('products_info') || GeneralUtility::_GP('products_info_x')) {
-				$activityArray['products_info'] = true;
-			}
-		}
+        if (GeneralUtility::_GP('products_clear_basket') || GeneralUtility::_GP('products_clear_basket_x')) {
+            $activityArray['products_clear_basket'] = true;
+        }
+        if (GeneralUtility::_GP('products_overview') || GeneralUtility::_GP('products_overview_x')) {
+            $activityArray['products_overview'] = true;
+        }
+        if (!$update) {
+            if (GeneralUtility::_GP('products_payment') || GeneralUtility::_GP('products_payment_x')) {
+                $activityArray['products_payment'] = true;
+            } else if (GeneralUtility::_GP('products_info') || GeneralUtility::_GP('products_info_x')) {
+                $activityArray['products_info'] = true;
+            }
+        }
 
-		if (GeneralUtility::_GP('products_customized_payment') || GeneralUtility::_GP('products_customized_payment_x')) {
-			$activityArray['products_customized_payment'] = true;
-		}
-		if (GeneralUtility::_GP('products_verify') || GeneralUtility::_GP('products_verify_x')) {
-			$activityArray['products_verify'] = true;
-		}
-		if (GeneralUtility::_GP('products_finalize') || GeneralUtility::_GP('products_finalize_x')) {
-			$activityArray['products_finalize'] = true;
-		}
+        if (GeneralUtility::_GP('products_customized_payment') || GeneralUtility::_GP('products_customized_payment_x')) {
+            $activityArray['products_customized_payment'] = true;
+        }
+        if (GeneralUtility::_GP('products_verify') || GeneralUtility::_GP('products_verify_x')) {
+            $activityArray['products_verify'] = true;
+        }
+        if (GeneralUtility::_GP('products_finalize') || GeneralUtility::_GP('products_finalize_x')) {
+            $activityArray['products_finalize'] = true;
+        }
 
-		$codeActivityArray = [];
-		$bBasketCode = false;
-		if (is_array($codes)) {
-			foreach ($codes as $k => $code) {
-				switch ($code) {
-					case 'BASKET':
-						$codeActivityArray['products_basket'] = true;
-						$bBasketCode = true;
-						break;
-					case 'INFO':
-						if (
-							!(
-								!empty($activityArray['products_verify']) ||
-								!empty($activityArray['products_customized_payment']) ||
-								!empty($activityArray['products_payment']) ||
-								!empty($activityArray['products_finalize'])
-							)
-						) {
-							$codeActivityArray['products_info'] = true;
-						}
+        $codeActivityArray = [];
+        $bBasketCode = false;
+        if (is_array($codes)) {
+            foreach ($codes as $k => $code) {
+                switch ($code) {
+                    case 'BASKET':
+                        $codeActivityArray['products_basket'] = true;
                         $bBasketCode = true;
-						break;
-					case 'OVERVIEW':
-						$codeActivityArray['products_overview'] = true;
-						break;
-					case 'PAYMENT':
+                        break;
+                    case 'INFO':
+                        if (
+                            !(
+                                !empty($activityArray['products_verify']) ||
+                                !empty($activityArray['products_customized_payment']) ||
+                                !empty($activityArray['products_payment']) ||
+                                !empty($activityArray['products_finalize'])
+                            )
+                        ) {
+                            $codeActivityArray['products_info'] = true;
+                        }
+                        $bBasketCode = true;
+                        break;
+                    case 'OVERVIEW':
+                        $codeActivityArray['products_overview'] = true;
+                        break;
+                    case 'PAYMENT':
                         if (
                             !empty($activityArray['products_finalize'])
                         ) {
@@ -1743,67 +1743,67 @@ class tx_ttproducts_control implements \TYPO3\CMS\Core\SingletonInterface {
                         if (!empty($activityArray['products_verify'])) {
                             $bBasketCode = true; // damit verify gesetzt bleibt, wenn vorhanden
                         }
-						break;
-					case 'FINALIZE':
-						$codeActivityArray['products_finalize'] = true;
+                        break;
+                    case 'FINALIZE':
+                        $codeActivityArray['products_finalize'] = true;
                         if (!empty($activityArray['products_verify'])) {
                             $bBasketCode = true;
                         }
-						break;
-					default:
-						// nothing
-						break;
-				}
-			}
-		}
+                        break;
+                    default:
+                        // nothing
+                        break;
+                }
+            }
+        }
 
-		if ($bBasketCode) {
-			$activityArray = array_merge($activityArray, $codeActivityArray);
-			$this->activityArray = $this->transformActivities($activityArray);
-		} else {
-			// only the code activities if there is no code BASKET or INFO set
-			$this->activityArray = $codeActivityArray;
-		}
-		tx_ttproducts_model_activity::setActivityArray($this->activityArray);
-		$fixCountry =
-			(
-				!empty($this->activityArray['products_basket']) ||
-				!empty($this->activityArray['products_info']) ||
-				!empty($this->activityArray['products_payment']) ||
-				!empty($this->activityArray['products_verify']) ||
-				!empty($this->activityArray['products_finalize']) ||
-				!empty($this->activityArray['products_customized_payment'])
-			);
+        if ($bBasketCode) {
+            $activityArray = array_merge($activityArray, $codeActivityArray);
+            $this->activityArray = $this->transformActivities($activityArray);
+        } else {
+            // only the code activities if there is no code BASKET or INFO set
+            $this->activityArray = $codeActivityArray;
+        }
+        tx_ttproducts_model_activity::setActivityArray($this->activityArray);
+        $fixCountry =
+            (
+                !empty($this->activityArray['products_basket']) ||
+                !empty($this->activityArray['products_info']) ||
+                !empty($this->activityArray['products_payment']) ||
+                !empty($this->activityArray['products_verify']) ||
+                !empty($this->activityArray['products_finalize']) ||
+                !empty($this->activityArray['products_customized_payment'])
+            );
 
-		$infoViewObj->init(
-			$activityArray['products_payment'] ?? false,
-			$fixCountry,
-			$basketExtra
-		);
+        $infoViewObj->init(
+            $activityArray['products_payment'] ?? false,
+            $fixCountry,
+            $basketExtra
+        );
 
-		if (
-			$fixCountry &&
-			$infoViewObj->checkRequired('billing', $basketExtra) == ''
-		) {
-			$infoViewObj->mapPersonIntoDelivery($basketExtra);
-		}
+        if (
+            $fixCountry &&
+            $infoViewObj->checkRequired('billing', $basketExtra) == ''
+        ) {
+            $infoViewObj->mapPersonIntoDelivery($basketExtra);
+        }
 
-		if (count($this->activityArray)) {
-			$content = $this->processActivities(
-				$this->activityArray,
-				$activityVarsArray,
-				$codeActivityArray,
-				$calculatedArray,
-				$basketExtra,
-				$basketRecs,
-				$basketExt,
-				$addressArray,
-				$errorCode,
-				$errorMessage
-			);
-		}
-		return $content;
-	}
+        if (count($this->activityArray)) {
+            $content = $this->processActivities(
+                $this->activityArray,
+                $activityVarsArray,
+                $codeActivityArray,
+                $calculatedArray,
+                $basketExtra,
+                $basketRecs,
+                $basketExt,
+                $addressArray,
+                $errorCode,
+                $errorMessage
+            );
+        }
+        return $content;
+    }
 }
 
 

--- a/control/class.tx_ttproducts_control_access.php
+++ b/control/class.tx_ttproducts_control_access.php
@@ -42,61 +42,61 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_control_access implements \TYPO3\CMS\Core\SingletonInterface {
 
-	static public function getVariables (
-		$conf,
-		&$updateCode,
-		&$bIsAllowed,
-		&$bValidUpdateCode,
-		&$trackingCode
-	) {
-		if (!$conf['update_code']) {
-			throw new exception('ERROR in tt_products: The setup "update_code" must not be empty');
-		}
+    static public function getVariables (
+        $conf,
+        &$updateCode,
+        &$bIsAllowed,
+        &$bValidUpdateCode,
+        &$trackingCode
+    ) {
+        if (!$conf['update_code']) {
+            throw new exception('ERROR in tt_products: The setup "update_code" must not be empty');
+        }
 
-		$updateCode = GeneralUtility::_GP('update_code') ?? '';
-		$bRequireBEAdmin = ($conf['shopAdmin'] == 'BE');
+        $updateCode = GeneralUtility::_GP('update_code') ?? '';
+        $bRequireBEAdmin = ($conf['shopAdmin'] == 'BE');
         $bIsAllowed = self::isAllowed($bRequireBEAdmin);
 
-		$bValidUpdateCode =
-			self::isValidUpdateCode(
-				$bRequireBEAdmin,
-				$conf['update_code'],
-				$updateCode
-			);
+        $bValidUpdateCode =
+            self::isValidUpdateCode(
+                $bRequireBEAdmin,
+                $conf['update_code'],
+                $updateCode
+            );
 
-		if (!$bValidUpdateCode) {
-			$updateCode = ''; // the update code must not be used if it is wrong
-		}
+        if (!$bValidUpdateCode) {
+            $updateCode = ''; // the update code must not be used if it is wrong
+        }
 
-		$trackingCode = GeneralUtility::_GP('tracking') ?? '';
-	}
+        $trackingCode = GeneralUtility::_GP('tracking') ?? '';
+    }
 
 
-	static public function isAllowed ($bRequireBEAdmin) {
-		$beUserLogin = false;
+    static public function isAllowed ($bRequireBEAdmin) {
+        $beUserLogin = false;
         $context = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Context\Context::class);
         $beUserLogin = $context->getPropertyFromAspect('backend.user', 'isLoggedIn');
 
-		$result = (!$bRequireBEAdmin || $beUserLogin);
-		return $result;
-	}
+        $result = (!$bRequireBEAdmin || $beUserLogin);
+        return $result;
+    }
 
 
-	/**
-	 * Returns 1 if user is a shop admin
-	 */
-	static public function isValidUpdateCode ($bRequireBEAdmin, $password, &$updateCode) {
-		$result = false;
+    /**
+     * Returns 1 if user is a shop admin
+     */
+    static public function isValidUpdateCode ($bRequireBEAdmin, $password, &$updateCode) {
+        $result = false;
 
-		if (self::isAllowed($bRequireBEAdmin)) {
-			$updateCode = GeneralUtility::_GP('update_code') ?? '';
+        if (self::isAllowed($bRequireBEAdmin)) {
+            $updateCode = GeneralUtility::_GP('update_code') ?? '';
 
-			if ($updateCode == $password) {
-				$result = true;	// Means that the administrator of the website is authenticated.
-			}
-		}
+            if ($updateCode == $password) {
+                $result = true;	// Means that the administrator of the website is authenticated.
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/control/class.tx_ttproducts_control_address.php
+++ b/control/class.tx_ttproducts_control_address.php
@@ -41,47 +41,47 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class tx_ttproducts_control_address {
 
-	static protected $addressExtKeyTable = array(
-		'tt_address' => TT_ADDRESS_EXT,
-		'tx_partner_main' => PARTNER_EXT,
-		'tx_party_addresses' => PARTY_EXT,
-		'tx_party_parties' => PARTY_EXT,
-		'fe_users' => '0'
-	);
+    static protected $addressExtKeyTable = array(
+        'tt_address' => TT_ADDRESS_EXT,
+        'tx_partner_main' => PARTNER_EXT,
+        'tx_party_addresses' => PARTY_EXT,
+        'tx_party_parties' => PARTY_EXT,
+        'fe_users' => '0'
+    );
 
 
-	static public function getAddressExtKeyTable () {
-		return self::$addressExtKeyTable;
-	}
+    static public function getAddressExtKeyTable () {
+        return self::$addressExtKeyTable;
+    }
 
 
-	static public function getAddressTablename (&$extKey) {
+    static public function getAddressTablename (&$extKey) {
         $emClass = '\\TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility';
-		$extKey = '';
-		$addressTable = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addressTable'];
+        $extKey = '';
+        $addressTable = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addressTable'];
 
-		if (!$addressTable) {
-			$addressExtKeyTable = self::getAddressExtKeyTable();
+        if (!$addressTable) {
+            $addressExtKeyTable = self::getAddressExtKeyTable();
 
-			foreach ($addressExtKeyTable as $addressTable => $extKey) {
+            foreach ($addressExtKeyTable as $addressTable => $extKey) {
 
                 $testIntResult = MathUtility::canBeInterpretedAsInteger($extKey);
-				if (
-					$testIntResult
-				) {
-					$extKey = '';
-				}
+                if (
+                    $testIntResult
+                ) {
+                    $extKey = '';
+                }
 
-				if (
-					$extKey == '' ||
-					call_user_func($emClass . '::isLoaded', $extKey)
-				) {
-					break;
-				}
-			}
-		}
+                if (
+                    $extKey == '' ||
+                    call_user_func($emClass . '::isLoaded', $extKey)
+                ) {
+                    break;
+                }
+            }
+        }
 
-		return $addressTable;
-	}
+        return $addressTable;
+    }
 }
 

--- a/control/class.tx_ttproducts_control_basket.php
+++ b/control/class.tx_ttproducts_control_basket.php
@@ -45,19 +45,19 @@ use JambageCom\TtProducts\Api\CustomerApi;
 
 
 abstract class BasketRecsIndex {
-	const Billing = 'personinfo';
-	const Delivery = 'delivery';
+    const Billing = 'personinfo';
+    const Delivery = 'delivery';
 }
 
 
 class tx_ttproducts_control_basket {
-	static protected $recs = [];
-	static protected $basketExt = [];	// "Basket Extension" - holds extended attributes
-	static protected $basketExtra = [];	// initBasket() uses this for additional information like the current payment/shipping methods
-	static protected $infoArray = [];
-	static private $pidListObj;
-	static private $bHasBeenInitialised = false;
-	static private $funcTablename;			// tt_products or tt_products_articles
+    static protected $recs = [];
+    static protected $basketExt = [];	// "Basket Extension" - holds extended attributes
+    static protected $basketExtra = [];	// initBasket() uses this for additional information like the current payment/shipping methods
+    static protected $infoArray = [];
+    static private $pidListObj;
+    static private $bHasBeenInitialised = false;
+    static private $funcTablename;			// tt_products or tt_products_articles
 
 
     static public function storeNewRecs ($transmissionSecurity = false) {
@@ -90,202 +90,202 @@ class tx_ttproducts_control_basket {
         }
     }
 
-	static public function init (
-		&$conf,
-		$tablesObj,
-		$pid_list,
-		$useArticles,
-		array $recs = [],
-		array $basketRec = []
-	) {
-		if (!self::$bHasBeenInitialised) {
+    static public function init (
+        &$conf,
+        $tablesObj,
+        $pid_list,
+        $useArticles,
+        array $recs = [],
+        array $basketRec = []
+    ) {
+        if (!self::$bHasBeenInitialised) {
             self::setRecs($recs);
 
             if (
                 isset($GLOBALS['TSFE']) && 
                 $GLOBALS['TSFE'] instanceof TypoScriptFrontendController
             ) {
-				self::setBasketExt(self::getStoredBasketExt());
-				$basketExtra = self::getBasketExtras($tablesObj, $recs, $conf);
-				self::setBasketExtra($basketExtra);
-			} else {
-				self::setRecs($recs);
-				self::setBasketExt([]);
-				self::setBasketExtra([]);
-			}
+                self::setBasketExt(self::getStoredBasketExt());
+                $basketExtra = self::getBasketExtras($tablesObj, $recs, $conf);
+                self::setBasketExtra($basketExtra);
+            } else {
+                self::setRecs($recs);
+                self::setBasketExt([]);
+                self::setBasketExtra([]);
+            }
 
-			self::$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-			self::$pidListObj->applyRecursive(
-				99,
-				$pid_list,
-				true
-			);
+            self::$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+            self::$pidListObj->applyRecursive(
+                99,
+                $pid_list,
+                true
+            );
 
-			self::$pidListObj->setPageArray();
+            self::$pidListObj->setPageArray();
 
-			if ($useArticles == 2) {
-				$funcTablename = 'tt_products_articles';
-			} else {
-				$funcTablename = 'tt_products';
-			}
-			self::setFuncTablename($funcTablename);
-			$recs = self::getRecs();
-			CustomerApi::init(
-				$conf,
-				$recs[BasketRecsIndex::Billing] ?? '',
-				$recs[BasketRecsIndex::Delivery] ?? '',
-				self::getBasketExtra()
-			);
+            if ($useArticles == 2) {
+                $funcTablename = 'tt_products_articles';
+            } else {
+                $funcTablename = 'tt_products';
+            }
+            self::setFuncTablename($funcTablename);
+            $recs = self::getRecs();
+            CustomerApi::init(
+                $conf,
+                $recs[BasketRecsIndex::Billing] ?? '',
+                $recs[BasketRecsIndex::Delivery] ?? '',
+                self::getBasketExtra()
+            );
 
-			self::$bHasBeenInitialised = true;
-		}
-	}
-
-
-	static public function cleanConfArr ($confArray, $checkShow = 0) {
-		$outArr = [];
-		if (is_array($confArray)) {
-			foreach($confArray as $key => $val) {
-				if (
-					intval($key) &&
-					is_array($val) &&
-					!MathUtility::canBeInterpretedAsInteger($key) &&
-					(!$checkShow || !isset($val['show']) || $val['show'])
-				) {
-					$i = intval($key);
- 					$outArr[$i] = $val;
-				}
-			}
-		}
-		ksort($outArr);
-		reset($outArr);
-		return $outArr;
-	} // cleanConfArr
+            self::$bHasBeenInitialised = true;
+        }
+    }
 
 
-	/**
-	 * Check if payment/shipping option is available
-	 */
-	static public function checkExtraAvailable ($confArray) {
-		$result = false;
+    static public function cleanConfArr ($confArray, $checkShow = 0) {
+        $outArr = [];
+        if (is_array($confArray)) {
+            foreach($confArray as $key => $val) {
+                if (
+                    intval($key) &&
+                    is_array($val) &&
+                    !MathUtility::canBeInterpretedAsInteger($key) &&
+                    (!$checkShow || !isset($val['show']) || $val['show'])
+                ) {
+                    $i = intval($key);
+                    $outArr[$i] = $val;
+                }
+            }
+        }
+        ksort($outArr);
+        reset($outArr);
+        return $outArr;
+    } // cleanConfArr
 
-		if (
-			is_array($confArray) &&
-			(
-				!isset($confArray['show']) ||
-				$confArray['show']
-			)
-		) {
-			$result = true;
-		}
 
-		return $result;
-	} // checkExtraAvailable
+    /**
+     * Check if payment/shipping option is available
+     */
+    static public function checkExtraAvailable ($confArray) {
+        $result = false;
+
+        if (
+            is_array($confArray) &&
+            (
+                !isset($confArray['show']) ||
+                $confArray['show']
+            )
+        ) {
+            $result = true;
+        }
+
+        return $result;
+    } // checkExtraAvailable
 
 
-	/**
-	 * Setting shipping, payment methods
-	 */
-	static public function getBasketExtras ($tablesObj, $basketRec, &$conf) {
+    /**
+     * Setting shipping, payment methods
+     */
+    static public function getBasketExtras ($tablesObj, $basketRec, &$conf) {
 
-		$basketExtra = [];
+        $basketExtra = [];
 
 // 		$conf = $cnfObj->getConf();
-		// handling and shipping
-		$pskeyArray = ['shipping' => false, 'handling' => true];	// keep this order, because shipping can unable some payment and handling configuration
-		$excludePayment = '';
-		$excludeHandling = '';
+        // handling and shipping
+        $pskeyArray = ['shipping' => false, 'handling' => true];	// keep this order, because shipping can unable some payment and handling configuration
+        $excludePayment = '';
+        $excludeHandling = '';
 
-		foreach ($pskeyArray as $pskey => $bIsMulti) {
+        foreach ($pskeyArray as $pskey => $bIsMulti) {
 
-			if (!empty($conf[$pskey . '.'])) {        
-				if ($bIsMulti) {
-					ksort($conf[$pskey . '.']);
+            if (!empty($conf[$pskey . '.'])) {        
+                if ($bIsMulti) {
+                    ksort($conf[$pskey . '.']);
 
-					foreach ($conf[$pskey . '.'] as $k => $confArray) {
+                    foreach ($conf[$pskey . '.'] as $k => $confArray) {
 
-						if (strpos($k, '.') == strlen($k) - 1) {
-							$k1 = substr($k, 0, strlen($k) - 1);
+                        if (strpos($k, '.') == strlen($k) - 1) {
+                            $k1 = substr($k, 0, strlen($k) - 1);
 
-							if (
-								MathUtility::canBeInterpretedAsInteger($k1)
-							) {
-								self::getHandlingShipping(
-									$basketRec,
-									$pskey,
-									$k1,
-									$confArray,
-									$excludePayment,
-									$excludeHandling,
-									$basketExtra
-								);
-							}
-						}
-					}
-				} else {
-					$confArray = $conf[$pskey . '.'];
+                            if (
+                                MathUtility::canBeInterpretedAsInteger($k1)
+                            ) {
+                                self::getHandlingShipping(
+                                    $basketRec,
+                                    $pskey,
+                                    $k1,
+                                    $confArray,
+                                    $excludePayment,
+                                    $excludeHandling,
+                                    $basketExtra
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    $confArray = $conf[$pskey . '.'];
 
-					self::getHandlingShipping(
-						$basketRec,
-						$pskey,
-						'',
-						$confArray,
-						$excludePayment,
-						$excludeHandling,
-						$basketExtra
-					);
-				}
-			}
+                    self::getHandlingShipping(
+                        $basketRec,
+                        $pskey,
+                        '',
+                        $confArray,
+                        $excludePayment,
+                        $excludeHandling,
+                        $basketExtra
+                    );
+                }
+            }
 
-				// overwrite handling from shipping
-			if ($pskey == 'shipping' && !empty($conf['handling.'])) {
-				if ($excludeHandling) {
-					$exclArr = GeneralUtility::intExplode(',', $excludeHandling);
-					foreach($exclArr as $theVal) {
-						unset($conf['handling.'][$theVal]);
-						unset($conf['handling.'][$theVal . '.']);
-					}
-				}
-			}
-		}
+                // overwrite handling from shipping
+            if ($pskey == 'shipping' && !empty($conf['handling.'])) {
+                if ($excludeHandling) {
+                    $exclArr = GeneralUtility::intExplode(',', $excludeHandling);
+                    foreach($exclArr as $theVal) {
+                        unset($conf['handling.'][$theVal]);
+                        unset($conf['handling.'][$theVal . '.']);
+                    }
+                }
+            }
+        }
 
-		// overwrite payment from shipping
-		if (isset($basketExtra['shipping.']) &&
-			!empty($basketExtra['shipping.']['replacePayment.'])
+        // overwrite payment from shipping
+        if (isset($basketExtra['shipping.']) &&
+            !empty($basketExtra['shipping.']['replacePayment.'])
         ) {
-			if (!$conf['payment.']) {
-				$conf['payment.'] = [];
-			}
+            if (!$conf['payment.']) {
+                $conf['payment.'] = [];
+            }
 
-			foreach ($basketExtra['shipping.']['replacePayment.'] as $k1 => $replaceArray) {
-				foreach ($replaceArray as $k2 => $value2) {
+            foreach ($basketExtra['shipping.']['replacePayment.'] as $k1 => $replaceArray) {
+                foreach ($replaceArray as $k2 => $value2) {
                     if (
                         is_array($value2) &&
                         isset($conf['payment.'][$k1][$k2]) &&
                         is_array($conf['payment.'][$k1][$k2])
                     ) {
                         $conf['payment.'][$k1][$k2] = array_merge($conf['payment.'][$k1][$k2], $value2);
-					} else {
-						$conf['payment.'][$k1][$k2] = $value2;
-					}
-				}
-			}
-		}
+                    } else {
+                        $conf['payment.'][$k1][$k2] = $value2;
+                    }
+                }
+            }
+        }
 
-			// payment
-		if (!empty($conf['payment.'])) {
+            // payment
+        if (!empty($conf['payment.'])) {
 
-			if ($excludePayment) {
-				$exclArr = GeneralUtility::intExplode(',', $excludePayment);
+            if ($excludePayment) {
+                $exclArr = GeneralUtility::intExplode(',', $excludePayment);
 
-				foreach($exclArr as $theVal) {
-					unset($conf['payment.'][$theVal]);
-					unset($conf['payment.'][$theVal . '.']);
-				}
-			}
+                foreach($exclArr as $theVal) {
+                    unset($conf['payment.'][$theVal]);
+                    unset($conf['payment.'][$theVal . '.']);
+                }
+            }
 
-			$confArray = self::cleanConfArr($conf['payment.']);
-			foreach($confArray as $confKey => $val) {
+            $confArray = self::cleanConfArr($conf['payment.']);
+            foreach($confArray as $confKey => $val) {
 //                 if (
 //                     ($val['show'] || !isset($val['show']))
 //                 ) {
@@ -310,9 +310,9 @@ class tx_ttproducts_control_basket {
                     unset($conf['payment.'][$confKey . '.']);
                 }
 // 				}
-			}
-			ksort($conf['payment.']);
-			reset($conf['payment.']);
+            }
+            ksort($conf['payment.']);
+            reset($conf['payment.']);
             $k = 0;
             if (isset($basketRec['tt_products']['payment'])) {
                 $k = intval($basketRec['tt_products']['payment']);
@@ -335,25 +335,25 @@ class tx_ttproducts_control_basket {
                     $basketExtra['payment.'] = $conf['payment.'][$k . '.'];
                 }
             }
-		}
+        }
 
-		return $basketExtra;
-	} // getBasketExtras
+        return $basketExtra;
+    } // getBasketExtras
 
 
-	/**
-	 * Setting shipping, payment methods
-	 */
-	static public function getHandlingShipping (
-		$basketRec,
-		$pskey,
-		$subkey,
-		$confArray,
-		&$excludePayment,
-		&$excludeHandling,
-		&$basketExtra
-	) {
-		ksort($confArray);
+    /**
+     * Setting shipping, payment methods
+     */
+    static public function getHandlingShipping (
+        $basketRec,
+        $pskey,
+        $subkey,
+        $confArray,
+        &$excludePayment,
+        &$excludeHandling,
+        &$basketExtra
+    ) {
+        ksort($confArray);
         $valueArray = [];
         $k = 0;
         if (
@@ -383,199 +383,199 @@ class tx_ttproducts_control_basket {
             }
         }
 
-		if (!self::checkExtraAvailable($confArray[$k . '.'] ?? [])) {
-			$temp = self::cleanConfArr($confArray, 1);
-			$valueArray[0] = $k = intval(key($temp));
-		}
+        if (!self::checkExtraAvailable($confArray[$k . '.'] ?? [])) {
+            $temp = self::cleanConfArr($confArray, 1);
+            $valueArray[0] = $k = intval(key($temp));
+        }
 
-		if ($subkey != '') {
-			$basketExtra[$pskey . '.'][$subkey] = $valueArray;
-			$basketExtra[$pskey . '.'][$subkey . '.'] = $confArray[$k . '.'] ?? [];
-			if ($pskey == 'shipping') {
-				$newExcludePayment = trim($basketExtra[$pskey . '.'][$subkey . '.']['excludePayment'] ?? '');
-				$newExcludeHandling = trim($basketExtra[$pskey . '.'][$subkey . '.']['excludeHandling'] ?? '');
-			}
-		} else {
-			$basketExtra[$pskey] = $valueArray;
-			$basketExtra[$pskey . '.'] = $confArray[$k . '.'] ?? [];
-			if ($pskey == 'shipping') {
-				$newExcludePayment = trim($basketExtra[$pskey . '.']['excludePayment'] ?? '');
-				$newExcludeHandling = trim($basketExtra[$pskey . '.']['excludeHandling'] ?? '');
-			}
-		}
+        if ($subkey != '') {
+            $basketExtra[$pskey . '.'][$subkey] = $valueArray;
+            $basketExtra[$pskey . '.'][$subkey . '.'] = $confArray[$k . '.'] ?? [];
+            if ($pskey == 'shipping') {
+                $newExcludePayment = trim($basketExtra[$pskey . '.'][$subkey . '.']['excludePayment'] ?? '');
+                $newExcludeHandling = trim($basketExtra[$pskey . '.'][$subkey . '.']['excludeHandling'] ?? '');
+            }
+        } else {
+            $basketExtra[$pskey] = $valueArray;
+            $basketExtra[$pskey . '.'] = $confArray[$k . '.'] ?? [];
+            if ($pskey == 'shipping') {
+                $newExcludePayment = trim($basketExtra[$pskey . '.']['excludePayment'] ?? '');
+                $newExcludeHandling = trim($basketExtra[$pskey . '.']['excludeHandling'] ?? '');
+            }
+        }
 
-		if ($newExcludePayment != '') {
-			$excludePayment = ($excludePayment != '' ? $excludePayment . ',' : '') . $newExcludePayment;
-		}
-		if ($newExcludeHandling != '') {
-			$excludeHandling = ($excludeHandling != '' ? $excludeHandling . ',' : '') . $newExcludeHandling;
-		}
-	}
-
-
-	static public function getCmdArray () {
-		$result = ['delete'];
-
-		return $result;
-	}
+        if ($newExcludePayment != '') {
+            $excludePayment = ($excludePayment != '' ? $excludePayment . ',' : '') . $newExcludePayment;
+        }
+        if ($newExcludeHandling != '') {
+            $excludeHandling = ($excludeHandling != '' ? $excludeHandling . ',' : '') . $newExcludeHandling;
+        }
+    }
 
 
-	static public function getPidListObj () {
-		return self::$pidListObj;
-	}
+    static public function getCmdArray () {
+        $result = ['delete'];
+
+        return $result;
+    }
 
 
-	static public function doProcessing () {
-
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$basketExtModified = false;
-
-		if (isset($piVars) && is_array($piVars)) {
-			foreach ($piVars as $piVar => $value) {
-				switch ($piVar) {
-					case 'delete':
-						$uid = $value;
-
-						$basketVar = tx_ttproducts_model_control::getBasketParamVar();
-
-						if (isset($piVars[$basketVar])) {
-
-							if (
-								isset(self::$basketExt[$uid]) &&
-								is_array(self::$basketExt[$uid])
-							) {
-
-								foreach (self::$basketExt[$uid] as $allVariants => $count) {
-									if (
-										md5($allVariants) == $piVars[$basketVar]
-									) {
-										unset(self::$basketExt[$uid][$allVariants]);
-										$basketExtModified = true;
-									}
-								}
-							}
-						}
-					break;
-				}
-			}
-		}
-
-		if ($basketExtModified) {
-			self::storeBasketExt(self::$basketExt);
-		}
-	}
+    static public function getPidListObj () {
+        return self::$pidListObj;
+    }
 
 
-	static public function setFuncTablename ($funcTablename) {
-		self::$funcTablename = $funcTablename;
-	}
+    static public function doProcessing () {
+
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $basketExtModified = false;
+
+        if (isset($piVars) && is_array($piVars)) {
+            foreach ($piVars as $piVar => $value) {
+                switch ($piVar) {
+                    case 'delete':
+                        $uid = $value;
+
+                        $basketVar = tx_ttproducts_model_control::getBasketParamVar();
+
+                        if (isset($piVars[$basketVar])) {
+
+                            if (
+                                isset(self::$basketExt[$uid]) &&
+                                is_array(self::$basketExt[$uid])
+                            ) {
+
+                                foreach (self::$basketExt[$uid] as $allVariants => $count) {
+                                    if (
+                                        md5($allVariants) == $piVars[$basketVar]
+                                    ) {
+                                        unset(self::$basketExt[$uid][$allVariants]);
+                                        $basketExtModified = true;
+                                    }
+                                }
+                            }
+                        }
+                    break;
+                }
+            }
+        }
+
+        if ($basketExtModified) {
+            self::storeBasketExt(self::$basketExt);
+        }
+    }
 
 
-	static public function getFuncTablename () {
-		return self::$funcTablename;
-	}
+    static public function setFuncTablename ($funcTablename) {
+        self::$funcTablename = $funcTablename;
+    }
 
 
-	static public function getRecs () {
-		return self::$recs;
-	}
+    static public function getFuncTablename () {
+        return self::$funcTablename;
+    }
 
 
-	static public function setRecs ($recs) {
-
-		$newRecs = [];
- 		$allowedTags = '<br><a><b><td><tr><div>';
-
-		foreach ($recs as $type => $valueArray) {
-			if (is_array($valueArray)) {
-				foreach ($valueArray as $k => $infoRow) {
-					$newRecs[$type][$k] = strip_tags($infoRow, $allowedTags);
-				}
-			} else {
-				$newRecs[$type] = strip_tags($valueArray, $allowedTags);
-			}
-		}
-
-		self::$recs = $newRecs;
-	}
+    static public function getRecs () {
+        return self::$recs;
+    }
 
 
-	static public function getStoredRecs () {
-		$result = [];
+    static public function setRecs ($recs) {
+
+        $newRecs = [];
+        $allowedTags = '<br><a><b><td><tr><div>';
+
+        foreach ($recs as $type => $valueArray) {
+            if (is_array($valueArray)) {
+                foreach ($valueArray as $k => $infoRow) {
+                    $newRecs[$type][$k] = strip_tags($infoRow, $allowedTags);
+                }
+            } else {
+                $newRecs[$type] = strip_tags($valueArray, $allowedTags);
+            }
+        }
+
+        self::$recs = $newRecs;
+    }
+
+
+    static public function getStoredRecs () {
+        $result = [];
 
         $recs = tx_ttproducts_control_session::readSession('recs');
         if (!empty($recs)) {
             $result = $recs;
         }
         
-		return $result;
-	}
+        return $result;
+    }
 
 
-	static public function setStoredRecs ($valueArray) {
-		self::store('recs', $valueArray);
-	}
+    static public function setStoredRecs ($valueArray) {
+        self::store('recs', $valueArray);
+    }
 
 
-	static public function getStoredVariantRecs () {
-		$result = tx_ttproducts_control_session::readSession('variant');
-		return $result;
-	}
+    static public function getStoredVariantRecs () {
+        $result = tx_ttproducts_control_session::readSession('variant');
+        return $result;
+    }
 
 
-	static public function setStoredVariantRecs ($valueArray) {
-		self::store('variant', $valueArray);
-	}
+    static public function setStoredVariantRecs ($valueArray) {
+        self::store('variant', $valueArray);
+    }
 
 
-	static public function store ($type, $valueArray) {
-		tx_ttproducts_control_session::writeSession($type, $valueArray);
-	}
+    static public function store ($type, $valueArray) {
+        tx_ttproducts_control_session::writeSession($type, $valueArray);
+    }
 
 
-	static public function getBasketExt () {
-		return self::$basketExt;
-	}
+    static public function getBasketExt () {
+        return self::$basketExt;
+    }
 
 
-	static public function setBasketExt ($basketExt) {
-		self::$basketExt = $basketExt;
-	}
+    static public function setBasketExt ($basketExt) {
+        self::$basketExt = $basketExt;
+    }
 
 
-	static public function getBasketExtra () {
-		return self::$basketExtra;
-	}
+    static public function getBasketExtra () {
+        return self::$basketExtra;
+    }
 
 
-	static public function setBasketExtra ($basketExtra) {
-		self::$basketExtra = $basketExtra;
-	}
+    static public function setBasketExtra ($basketExtra) {
+        self::$basketExtra = $basketExtra;
+    }
 
 
-	static public function getBasketExtRaw () {
-		$basketVar = tx_ttproducts_model_control::getBasketVar();
-		$result = GeneralUtility::_GP($basketVar);
-		return $result;
-	}
+    static public function getBasketExtRaw () {
+        $basketVar = tx_ttproducts_model_control::getBasketVar();
+        $result = GeneralUtility::_GP($basketVar);
+        return $result;
+    }
 
 
-	static public function getStoredBasketExt () {
-		$result = tx_ttproducts_control_session::readSession('basketExt');
-		return $result;
-	}
+    static public function getStoredBasketExt () {
+        $result = tx_ttproducts_control_session::readSession('basketExt');
+        return $result;
+    }
 
 
-	static public function getStoredOrder () {
-		$result = tx_ttproducts_control_session::readSession('order');
-		return $result;
-	}
+    static public function getStoredOrder () {
+        $result = tx_ttproducts_control_session::readSession('order');
+        return $result;
+    }
 
 
-	static public function storeBasketExt ($basketExt) {
-		self::store('basketExt', $basketExt);
-		self::setBasketExt($basketExt);
-	}
+    static public function storeBasketExt ($basketExt) {
+        self::store('basketExt', $basketExt);
+        self::setBasketExt($basketExt);
+    }
 
     static public function generatedBasketExtFromRow ($row, $count) {
         $basketExt = [];
@@ -588,113 +588,113 @@ class tx_ttproducts_control_basket {
     }
 
 
-	static public function removeFromBasketExt ($removeBasketExt) {
-		$basketExt = self::getStoredBasketExt();
-		$bChanged = false;
+    static public function removeFromBasketExt ($removeBasketExt) {
+        $basketExt = self::getStoredBasketExt();
+        $bChanged = false;
 
-		if (isset($removeBasketExt) && is_array($removeBasketExt)) {
-			foreach ($removeBasketExt as $uid => $removeRow) {
-				$allVariants = key($removeRow);
-				$bRemove = current($removeRow);
+        if (isset($removeBasketExt) && is_array($removeBasketExt)) {
+            foreach ($removeBasketExt as $uid => $removeRow) {
+                $allVariants = key($removeRow);
+                $bRemove = current($removeRow);
 
-				if (
-					$bRemove &&
-					isset($basketExt[$uid]) &&
-					isset($basketExt[$uid][$allVariants])
-				) {
-					unset($basketExt[$uid][$allVariants]);
-					$bChanged = true;
-				}
-			}
-		}
-		if ($bChanged) {
-			self::storeBasketExt($basketExt);
-		}
-	}
+                if (
+                    $bRemove &&
+                    isset($basketExt[$uid]) &&
+                    isset($basketExt[$uid][$allVariants])
+                ) {
+                    unset($basketExt[$uid][$allVariants]);
+                    $bChanged = true;
+                }
+            }
+        }
+        if ($bChanged) {
+            self::storeBasketExt($basketExt);
+        }
+    }
 
-	static public function getBasketCount (
-		$row,
-		$variant,
-		$quantityIsFloat,
-		$ignoreVariant = false
-	) {
-		$count = '';
-		$basketExt = static::getBasketExt();
-		$uid = $row['uid'];
+    static public function getBasketCount (
+        $row,
+        $variant,
+        $quantityIsFloat,
+        $ignoreVariant = false
+    ) {
+        $count = '';
+        $basketExt = static::getBasketExt();
+        $uid = $row['uid'];
 
-		if (isset($basketExt[$uid])) {
-			$subArr = $basketExt[$uid];
+        if (isset($basketExt[$uid])) {
+            $subArr = $basketExt[$uid];
 
-			if (
-				$ignoreVariant &&
-				is_array($subArr)
-			) {
-				$count = 0;
-				foreach ($subArr as $subVariant => $subCount) {
-					$count += $subCount;
-				}
-			} else if (
-				is_array($subArr) &&
-				isset($subArr[$variant])
-			) {
-				$tmpCount = $subArr[$variant];
+            if (
+                $ignoreVariant &&
+                is_array($subArr)
+            ) {
+                $count = 0;
+                foreach ($subArr as $subVariant => $subCount) {
+                    $count += $subCount;
+                }
+            } else if (
+                is_array($subArr) &&
+                isset($subArr[$variant])
+            ) {
+                $tmpCount = $subArr[$variant];
 
-				if (
-					$tmpCount > 0 &&
-					(
-						$quantityIsFloat ||
-						MathUtility::canBeInterpretedAsInteger($tmpCount)
-					)
-				) {
-					$count = $tmpCount;
-				}
-			}
-		}
-		return $count;
-	}
-
-
-	static public function getStoredInfoArray () {
-		$formerBasket = self::getRecs();
-
-		$infoArray = [];
-
-		if (isset($formerBasket) && is_array($formerBasket)) {
-			$infoArray['billing'] = $formerBasket['personinfo'] ?? '';
-			$infoArray['delivery'] = $formerBasket['delivery'] ?? '';
-		}
-		if (!$infoArray['billing']) {
-			$infoArray['billing'] = [];
-		}
-		if (!$infoArray['delivery']) {
-			$infoArray['delivery'] = [];
-		}
-		return $infoArray;
-	}
+                if (
+                    $tmpCount > 0 &&
+                    (
+                        $quantityIsFloat ||
+                        MathUtility::canBeInterpretedAsInteger($tmpCount)
+                    )
+                ) {
+                    $count = $tmpCount;
+                }
+            }
+        }
+        return $count;
+    }
 
 
-	static public function setInfoArray ($infoArray) {
-		self::$infoArray = $infoArray;
+    static public function getStoredInfoArray () {
+        $formerBasket = self::getRecs();
 
-		if (
-			isset($infoArray['billing']) &&
-			is_array($infoArray['billing'])
-		) {
-			CustomerApi::setBillingInfo($infoArray['billing']);
-		}
+        $infoArray = [];
 
-		if (
-			isset($infoArray['delivery']) &&
-			is_array($infoArray['delivery'])
-		) {
-			CustomerApi::setShippingInfo($infoArray['delivery']);
-		}
-	}
+        if (isset($formerBasket) && is_array($formerBasket)) {
+            $infoArray['billing'] = $formerBasket['personinfo'] ?? '';
+            $infoArray['delivery'] = $formerBasket['delivery'] ?? '';
+        }
+        if (!$infoArray['billing']) {
+            $infoArray['billing'] = [];
+        }
+        if (!$infoArray['delivery']) {
+            $infoArray['delivery'] = [];
+        }
+        return $infoArray;
+    }
 
 
-	static public function getInfoArray () {
-		return self::$infoArray;
-	}
+    static public function setInfoArray ($infoArray) {
+        self::$infoArray = $infoArray;
+
+        if (
+            isset($infoArray['billing']) &&
+            is_array($infoArray['billing'])
+        ) {
+            CustomerApi::setBillingInfo($infoArray['billing']);
+        }
+
+        if (
+            isset($infoArray['delivery']) &&
+            is_array($infoArray['delivery'])
+        ) {
+            CustomerApi::setShippingInfo($infoArray['delivery']);
+        }
+    }
+
+
+    static public function getInfoArray () {
+        return self::$infoArray;
+    }
 
     static public function setCountry (&$infoArray, $basketExtra) {
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
@@ -727,112 +727,112 @@ class tx_ttproducts_control_basket {
         }
     }
 
-	static public function uncheckAgb (&$infoArray, $bProductsPayment) {
-		if (
-			$bProductsPayment &&
-			isset($_REQUEST['recs']) &&
-			is_array($_REQUEST['recs']) &&
-			isset($_REQUEST['recs']['personinfo']) &&
-			is_array($_REQUEST['recs']['personinfo']) &&
-			empty($_REQUEST['recs']['personinfo']['agb'])
-		) {
-			$infoArray['billing']['agb'] = false;
-		}
-	}
+    static public function uncheckAgb (&$infoArray, $bProductsPayment) {
+        if (
+            $bProductsPayment &&
+            isset($_REQUEST['recs']) &&
+            is_array($_REQUEST['recs']) &&
+            isset($_REQUEST['recs']['personinfo']) &&
+            is_array($_REQUEST['recs']['personinfo']) &&
+            empty($_REQUEST['recs']['personinfo']['agb'])
+        ) {
+            $infoArray['billing']['agb'] = false;
+        }
+    }
 
-	// normally the delivery is copied from the bill data. But also another table can be used for it.
-	static public function needsDeliveryAddresss ($basketExtra) {
-		$result = true;
+    // normally the delivery is copied from the bill data. But also another table can be used for it.
+    static public function needsDeliveryAddresss ($basketExtra) {
+        $result = true;
 
-		$shippingType = \JambageCom\TtProducts\Api\PaymentShippingHandling::get(
-			'shipping',
-			'type',
-			$basketExtra
-		);
+        $shippingType = \JambageCom\TtProducts\Api\PaymentShippingHandling::get(
+            'shipping',
+            'type',
+            $basketExtra
+        );
 
-		if (
-			$shippingType == 'pick_store' ||
-			$shippingType == 'nocopy'
-		) {
-			$result = false;
-		}
+        if (
+            $shippingType == 'pick_store' ||
+            $shippingType == 'nocopy'
+        ) {
+            $result = false;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function fixCountries (&$infoArray) {
-		$result = false;
+    static public function fixCountries (&$infoArray) {
+        $result = false;
 
-		if (
-			!empty($infoArray['billing']['country_code']) &&
-			(
+        if (
+            !empty($infoArray['billing']['country_code']) &&
+            (
                 !isset($infoArray['delivery']['zip']) ||
-				$infoArray['delivery']['zip'] == '' ||
-				(
-					$infoArray['delivery']['zip'] == $infoArray['billing']['zip']
-				)
-			)
-		) {
-			// a country change in the select box shall be copied
-			$infoArray['delivery']['country_code'] = $infoArray['billing']['country_code'];
-			$result = true;
-		}
-		return $result;
-	}
+                $infoArray['delivery']['zip'] == '' ||
+                (
+                    $infoArray['delivery']['zip'] == $infoArray['billing']['zip']
+                )
+            )
+        ) {
+            // a country change in the select box shall be copied
+            $infoArray['delivery']['country_code'] = $infoArray['billing']['country_code'];
+            $result = true;
+        }
+        return $result;
+    }
 
 
-	static public function addLoginData (
-		&$infoArray,
-		$loginUserInfoAddress,
-		$useStaticInfoCountry
-	) {
+    static public function addLoginData (
+        &$infoArray,
+        $loginUserInfoAddress,
+        $useStaticInfoCountry
+    ) {
         if (
             isset($GLOBALS['TSFE']) && 
             $GLOBALS['TSFE'] instanceof TypoScriptFrontendController &&
-			\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
-			\JambageCom\TtProducts\Api\ControlApi::isOverwriteMode($infoArray)
-		) {
-			$address = '';
-			$infoArray['billing']['feusers_uid'] =
-				$GLOBALS['TSFE']->fe_user->user['uid'];
+            \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
+            \JambageCom\TtProducts\Api\ControlApi::isOverwriteMode($infoArray)
+        ) {
+            $address = '';
+            $infoArray['billing']['feusers_uid'] =
+                $GLOBALS['TSFE']->fe_user->user['uid'];
 
-			if (
-				$useStaticInfoCountry &&
-				empty($infoArray['billing']['country_code'])
-			) {
-				$infoArray['billing']['country_code'] =
-					$GLOBALS['TSFE']->fe_user->user['static_info_country'];
-			}
+            if (
+                $useStaticInfoCountry &&
+                empty($infoArray['billing']['country_code'])
+            ) {
+                $infoArray['billing']['country_code'] =
+                    $GLOBALS['TSFE']->fe_user->user['static_info_country'];
+            }
 
-			if ($loginUserInfoAddress) {
-				$address = implode(
-					chr(10),
-					GeneralUtility::trimExplode(
-						chr(10),
-						$GLOBALS['TSFE']->fe_user->user['address'] . chr(10) .
-							(
+            if ($loginUserInfoAddress) {
+                $address = implode(
+                    chr(10),
+                    GeneralUtility::trimExplode(
+                        chr(10),
+                        $GLOBALS['TSFE']->fe_user->user['address'] . chr(10) .
+                            (
                                 isset($GLOBALS['TSFE']->fe_user->user['house_no']) &&
-								$GLOBALS['TSFE']->fe_user->user['house_no'] != '' ?
-									$GLOBALS['TSFE']->fe_user->user['house_no'] . chr(10) :
-									''
-							) .
-						$GLOBALS['TSFE']->fe_user->user['zip'] . ' ' . $GLOBALS['TSFE']->fe_user->user['city'] . chr(10) .
-							(
-								$useStaticInfoCountry ?
-									$GLOBALS['TSFE']->fe_user->user['static_info_country'] :
-									$GLOBALS['TSFE']->fe_user->user['country']
-							),
-						1
-					)
-				);
-			} else {
-				$address = $GLOBALS['TSFE']->fe_user->user['address'];
-			}
-			$infoArray['billing']['address'] = $address;
-			$fields = CustomerApi::getFields() . ',' . CustomerApi::getCreditPointFields();
+                                $GLOBALS['TSFE']->fe_user->user['house_no'] != '' ?
+                                    $GLOBALS['TSFE']->fe_user->user['house_no'] . chr(10) :
+                                    ''
+                            ) .
+                        $GLOBALS['TSFE']->fe_user->user['zip'] . ' ' . $GLOBALS['TSFE']->fe_user->user['city'] . chr(10) .
+                            (
+                                $useStaticInfoCountry ?
+                                    $GLOBALS['TSFE']->fe_user->user['static_info_country'] :
+                                    $GLOBALS['TSFE']->fe_user->user['country']
+                            ),
+                        1
+                    )
+                );
+            } else {
+                $address = $GLOBALS['TSFE']->fe_user->user['address'];
+            }
+            $infoArray['billing']['address'] = $address;
+            $fields = CustomerApi::getFields() . ',' . CustomerApi::getCreditPointFields();
 
-			$fieldArray = GeneralUtility::trimExplode(',', $fields);
-			foreach ($fieldArray as $k => $field) {
+            $fieldArray = GeneralUtility::trimExplode(',', $fields);
+            foreach ($fieldArray as $k => $field) {
                 if (empty($infoArray['billing'][$field])) {
                     $infoArray['billing'][$field] = $GLOBALS['TSFE']->fe_user->user[$field];
                 }
@@ -876,89 +876,89 @@ class tx_ttproducts_control_basket {
                 }
            }
 
-			$infoArray['billing']['agb'] =
-				(
-					isset($infoArray['billing']['agb']) ?
-						$infoArray['billing']['agb'] :
-						$GLOBALS['TSFE']->fe_user->user['agb']
-				);
+            $infoArray['billing']['agb'] =
+                (
+                    isset($infoArray['billing']['agb']) ?
+                        $infoArray['billing']['agb'] :
+                        $GLOBALS['TSFE']->fe_user->user['agb']
+                );
 
-			$dateBirth = $infoArray['billing']['date_of_birth'];
-			$tmpPos =  strpos($dateBirth, '-');
+            $dateBirth = $infoArray['billing']['date_of_birth'];
+            $tmpPos =  strpos($dateBirth, '-');
 
-			if (
-				!$dateBirth ||
-				$tmpPos === false ||
-				$tmpPos == 0
-			) {
-				$infoArray['billing']['date_of_birth'] =
-					date('d-m-Y', $GLOBALS['TSFE']->fe_user->user['date_of_birth']);
-			}
-			unset($infoArray['billing']['error']);
-		}
-	}
-
-
-	static public function getTagName ($uid, $fieldname) {
-		$result = tx_ttproducts_model_control::getBasketVar() . '[' . $uid . '][' . $fieldname . ']';
-		return $result;
-	}
+            if (
+                !$dateBirth ||
+                $tmpPos === false ||
+                $tmpPos == 0
+            ) {
+                $infoArray['billing']['date_of_birth'] =
+                    date('d-m-Y', $GLOBALS['TSFE']->fe_user->user['date_of_birth']);
+            }
+            unset($infoArray['billing']['error']);
+        }
+    }
 
 
-	static public function getAjaxVariantFunction ($row, $functablename, $theCode) {
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
-			$result = 'doFetchRow(\'' . $functablename . '\',\'' . strtolower($theCode) . '\',' . $row['uid'] . ');';
-		} else {
-			$result = '';
-		}
-		return $result;
-	}
+    static public function getTagName ($uid, $fieldname) {
+        $result = tx_ttproducts_model_control::getBasketVar() . '[' . $uid . '][' . $fieldname . ']';
+        return $result;
+    }
 
 
-	static public function destruct () {
-		self::$bHasBeenInitialised = false;
-	}
+    static public function getAjaxVariantFunction ($row, $functablename, $theCode) {
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+            $result = 'doFetchRow(\'' . $functablename . '\',\'' . strtolower($theCode) . '\',' . $row['uid'] . ');';
+        } else {
+            $result = '';
+        }
+        return $result;
+    }
 
 
-	static public function getRoundFormat ($type = '') {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-
-		$result = $cnf->getBasketConf('round', $type); // check the basket rounding format
-
-		if (isset($result) && is_array($result)) {
-			$result = '';
-		}
-
-		return $result;
-	}
+    static public function destruct () {
+        self::$bHasBeenInitialised = false;
+    }
 
 
-	static public function readControl ($key = '') {
-		$result = false;
-		$ctrlArray = tx_ttproducts_control_session::readSession('ctrl');
+    static public function getRoundFormat ($type = '') {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		if (isset($ctrlArray) && is_array($ctrlArray)) {
-			if ($key != '' && isset($ctrlArray[$key])) {
-				$result = $ctrlArray[$key];
-			} else {
-				$result = $ctrlArray;
-			}
-		}
+        $result = $cnf->getBasketConf('round', $type); // check the basket rounding format
 
-		return $result;
-	}
+        if (isset($result) && is_array($result)) {
+            $result = '';
+        }
+
+        return $result;
+    }
 
 
-	static public function writeControl ($valArray) {
+    static public function readControl ($key = '') {
+        $result = false;
+        $ctrlArray = tx_ttproducts_control_session::readSession('ctrl');
 
-		if (
-			!isset($valArray) ||
-			!is_array($valArray)
-		) {
-			$valArray = [];
-		}
-		self::store('ctrl', $valArray);
-	}
+        if (isset($ctrlArray) && is_array($ctrlArray)) {
+            if ($key != '' && isset($ctrlArray[$key])) {
+                $result = $ctrlArray[$key];
+            } else {
+                $result = $ctrlArray;
+            }
+        }
+
+        return $result;
+    }
+
+
+    static public function writeControl ($valArray) {
+
+        if (
+            !isset($valArray) ||
+            !is_array($valArray)
+        ) {
+            $valArray = [];
+        }
+        self::store('ctrl', $valArray);
+    }
 }
 
 

--- a/control/class.tx_ttproducts_control_basketquantity.php
+++ b/control/class.tx_ttproducts_control_basketquantity.php
@@ -42,59 +42,59 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_control_basketquantity implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function getQuantityMarker ( // deprecated. used only for DAM
-		$marker,
-		$prodUid,
-		$uid
-	)	{
-		if ($marker != '' && $uid) {
-			$rc = 'FIELD_QTY_' . $prodUid . '_' . $marker . '_' . $uid;
-		} else {
-			$rc = 'FIELD_QTY';
-		}
-		return $rc;
-	}
+    public function getQuantityMarker ( // deprecated. used only for DAM
+        $marker,
+        $prodUid,
+        $uid
+    )	{
+        if ($marker != '' && $uid) {
+            $rc = 'FIELD_QTY_' . $prodUid . '_' . $marker . '_' . $uid;
+        } else {
+            $rc = 'FIELD_QTY';
+        }
+        return $rc;
+    }
 
 
-	public function getQuantityMarkerArray ( // deprecated. used only for DAM
-		$relatedIds,
-		$rowArray,
-		&$markerArray
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$prodViewObj = $tablesObj->get('tt_products',true);
+    public function getQuantityMarkerArray ( // deprecated. used only for DAM
+        $relatedIds,
+        $rowArray,
+        &$markerArray
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $prodViewObj = $tablesObj->get('tt_products',true);
 
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$quantityArray = $basketObj->getQuantityArray($relatedIds, $rowArray);
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $quantityArray = $basketObj->getQuantityArray($relatedIds, $rowArray);
 
-		foreach ($rowArray as $functablename => $functableRowArray) {
+        foreach ($rowArray as $functablename => $functableRowArray) {
 
-			$viewObj = $tablesObj->get($functablename, true);
-			$modelObj = $viewObj->getModelObj();
-			$marker = $viewObj->getMarker();
+            $viewObj = $tablesObj->get($functablename, true);
+            $modelObj = $viewObj->getModelObj();
+            $marker = $viewObj->getMarker();
 
-			foreach ($relatedIds as $uid) {
-				foreach ($functableRowArray as $subRow) {
-					$subuid = $subRow['uid'];
-					$quantityMarker = self::getQuantityMarker($marker, $uid, $subuid);
+            foreach ($relatedIds as $uid) {
+                foreach ($functableRowArray as $subRow) {
+                    $subuid = $subRow['uid'];
+                    $quantityMarker = self::getQuantityMarker($marker, $uid, $subuid);
 
-					if (
-						isset($quantityArray[$uid]) &&
-						is_array($quantityArray[$uid]) &&
-						isset($quantityArray[$uid][$functablename]) &&
-						is_array($quantityArray[$uid][$functablename])
-					) {
-						$count = strval($quantityArray[$uid][$functablename][$subuid]);
-						if (!isset($count)) {
-							$count = '';
-						}
-					} else {
-						$count = '';
-					}
-					$markerArray['###' . $quantityMarker . '###'] = $count;
-				}
-			}
-		}
-	}
+                    if (
+                        isset($quantityArray[$uid]) &&
+                        is_array($quantityArray[$uid]) &&
+                        isset($quantityArray[$uid][$functablename]) &&
+                        is_array($quantityArray[$uid][$functablename])
+                    ) {
+                        $count = strval($quantityArray[$uid][$functablename][$subuid]);
+                        if (!isset($count)) {
+                            $count = '';
+                        }
+                    } else {
+                        $count = '';
+                    }
+                    $markerArray['###' . $quantityMarker . '###'] = $count;
+                }
+            }
+        }
+    }
 }
 

--- a/control/class.tx_ttproducts_control_command.php
+++ b/control/class.tx_ttproducts_control_command.php
@@ -44,222 +44,222 @@ use JambageCom\Div2007\Utility\ExtensionUtility;
 
 class tx_ttproducts_control_command {
 
-	static protected $commandVar = 'cmd';
+    static protected $commandVar = 'cmd';
 
-	static public function getCommandVar () {
-		return self::$commandVar;
-	}
+    static public function getCommandVar () {
+        return self::$commandVar;
+    }
 
-	static public function getVariantVars ($piVars) {
-		$result = [];
+    static public function getVariantVars ($piVars) {
+        $result = [];
 
-		$paramsTableArray = tx_ttproducts_model_control::getParamsTableArray();
-		if (isset($piVars) && is_array($piVars)) {
-			foreach ($piVars as $piVar => $v) {
+        $paramsTableArray = tx_ttproducts_model_control::getParamsTableArray();
+        if (isset($piVars) && is_array($piVars)) {
+            foreach ($piVars as $piVar => $v) {
                 if (!isset($paramsTableArray[$piVar])) {
-					$result[$piVar] = $v;
-				}
-			}
-		}
+                    $result[$piVar] = $v;
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function doProcessing (
-		$theCode,
-		$conf,
-		$bIsAllowedBE,
-		$bValidUpdateCode,
-		$trackingCode,
-		$pid_list,
-		$recursive
-	) {
+    static public function doProcessing (
+        $theCode,
+        $conf,
+        $bIsAllowedBE,
+        $bValidUpdateCode,
+        $trackingCode,
+        $pid_list,
+        $recursive
+    ) {
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$bHasBeenOrdered = false;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $bHasBeenOrdered = false;
 
-		$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$pidListObj->applyRecursive($recursive, $pid_list, true);
-		$pidListObj->setPageArray();
+        $pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $pidListObj->applyRecursive($recursive, $pid_list, true);
+        $pidListObj->setPageArray();
 
-		$postVar = self::getCommandVar();
-		$cmdData = GeneralUtility::_GP($postVar);
+        $postVar = self::getCommandVar();
+        $cmdData = GeneralUtility::_GP($postVar);
 
-		switch ($theCode) {
-			case 'DOWNLOAD':
-				if (
-					\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('addons_em') &&
-					isset($cmdData['download']) ||
-					isset($cmdData['fal'])
-				) {
-					$falUid = intval($cmdData['fal']);
-					$downloadTable = $tablesObj->get('tt_products_downloads', false);
-					$downloadVar =
-						tx_ttproducts_model_control::getPiVar(
-							$downloadTable->getFuncTablename()
-						);
-					$piVars = tx_ttproducts_model_control::getPiVars();
-					$variantVars = self::getVariantVars($piVars);
-					$orderVar =
-						tx_ttproducts_model_control::getPiVar(
-							'sys_products_orders'
-						);
-					$orderUid = 0;
+        switch ($theCode) {
+            case 'DOWNLOAD':
+                if (
+                    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('addons_em') &&
+                    isset($cmdData['download']) ||
+                    isset($cmdData['fal'])
+                ) {
+                    $falUid = intval($cmdData['fal']);
+                    $downloadTable = $tablesObj->get('tt_products_downloads', false);
+                    $downloadVar =
+                        tx_ttproducts_model_control::getPiVar(
+                            $downloadTable->getFuncTablename()
+                        );
+                    $piVars = tx_ttproducts_model_control::getPiVars();
+                    $variantVars = self::getVariantVars($piVars);
+                    $orderVar =
+                        tx_ttproducts_model_control::getPiVar(
+                            'sys_products_orders'
+                        );
+                    $orderUid = 0;
 
-					if ($trackingCode != '') {
-						$trackingArray = explode('-', $trackingCode);
-						$count = count($trackingArray);
-						if ($count >= 2) {
-							$orderUid = intval($trackingArray[$count - 2]);
-						}
-					} else if (isset($piVars[$orderVar])) {
-						$orderUid = intval($piVars[$orderVar]);
-					}
+                    if ($trackingCode != '') {
+                        $trackingArray = explode('-', $trackingCode);
+                        $count = count($trackingArray);
+                        if ($count >= 2) {
+                            $orderUid = intval($trackingArray[$count - 2]);
+                        }
+                    } else if (isset($piVars[$orderVar])) {
+                        $orderUid = intval($piVars[$orderVar]);
+                    }
 
-					$feusers_uid = $GLOBALS['TSFE']->fe_user->user['uid'];
-					$orderObj = $tablesObj->get('sys_products_orders'); // order
-					$orderObj->getDownloadWhereClauses(
-						$feusers_uid,
-						$trackingCode,
-						$whereOrders,
-						$whereProducts
-					);
+                    $feusers_uid = $GLOBALS['TSFE']->fe_user->user['uid'];
+                    $orderObj = $tablesObj->get('sys_products_orders'); // order
+                    $orderObj->getDownloadWhereClauses(
+                        $feusers_uid,
+                        $trackingCode,
+                        $whereOrders,
+                        $whereProducts
+                    );
 
-					$uid = intval($piVars[$downloadVar]);
-					$downloadAuthorization = $cnf->getDownloadConf('authorization');
-					$validFeUser = false;
-					if (
-						$downloadAuthorization == 'FE' &&
-						$feusers_uid > 0
-					) {
-						$validFeUser = true;
-					}
+                    $uid = intval($piVars[$downloadVar]);
+                    $downloadAuthorization = $cnf->getDownloadConf('authorization');
+                    $validFeUser = false;
+                    if (
+                        $downloadAuthorization == 'FE' &&
+                        $feusers_uid > 0
+                    ) {
+                        $validFeUser = true;
+                    }
 
-					if (
-						$feusers_uid &&
-						(
-							$orderUid &&
-							(
-								$trackingCode != '' ||
-								$bIsAllowedBE && $bValidUpdateCode
-							) ||
-							$validFeUser
-						)
-					) {
-						$from = '';
-						$orderObj->getOrderedAndGainedProducts(
-							$from,
-							$whereOrders,
-							'',
-							$whereProducts,
-							false,
-							$pid_list,
-							$productRowArray,
-							$multiOrderArray
-						);
+                    if (
+                        $feusers_uid &&
+                        (
+                            $orderUid &&
+                            (
+                                $trackingCode != '' ||
+                                $bIsAllowedBE && $bValidUpdateCode
+                            ) ||
+                            $validFeUser
+                        )
+                    ) {
+                        $from = '';
+                        $orderObj->getOrderedAndGainedProducts(
+                            $from,
+                            $whereOrders,
+                            '',
+                            $whereProducts,
+                            false,
+                            $pid_list,
+                            $productRowArray,
+                            $multiOrderArray
+                        );
 
-						if (
-							$validFeUser &&
-							!$orderUid
-						) { // determine if an order exists
-							$orderUid =
-								$downloadTable->getOrderedUid(
-									$uid,
-									$falUid,
-									$multiOrderArray
-								);
-						}
+                        if (
+                            $validFeUser &&
+                            !$orderUid
+                        ) { // determine if an order exists
+                            $orderUid =
+                                $downloadTable->getOrderedUid(
+                                    $uid,
+                                    $falUid,
+                                    $multiOrderArray
+                                );
+                        }
 
-						$orderRow = [];
-						if ($orderUid) {
-							$orderRow = $orderObj->get($orderUid);
-						}
+                        $orderRow = [];
+                        if ($orderUid) {
+                            $orderRow = $orderObj->get($orderUid);
+                        }
 
-						$downloadArray = [];
+                        $downloadArray = [];
 
-						if ($orderUid && is_array($productRowArray) && count($productRowArray)) {
-							$productUidArray = [];
-							foreach ($productRowArray as $productRow) {
-								$productUidArray[$productRow['uid']] = $productRow['uid'];
-							}
-							$downloadArray =
-								$downloadTable->getRelatedUidArray(
-									implode(',', $productUidArray),
-									$downloadTagArray,
-									'tt_products'
-								);
-						}
+                        if ($orderUid && is_array($productRowArray) && count($productRowArray)) {
+                            $productUidArray = [];
+                            foreach ($productRowArray as $productRow) {
+                                $productUidArray[$productRow['uid']] = $productRow['uid'];
+                            }
+                            $downloadArray =
+                                $downloadTable->getRelatedUidArray(
+                                    implode(',', $productUidArray),
+                                    $downloadTagArray,
+                                    'tt_products'
+                                );
+                        }
 
-						foreach ($downloadArray as $downloadRow) {
-							if ($downloadRow['uid'] == $uid) {
-								$bHasBeenOrdered = true;
-								break;
-							}
-						}
-					}
+                        foreach ($downloadArray as $downloadRow) {
+                            if ($downloadRow['uid'] == $uid) {
+                                $bHasBeenOrdered = true;
+                                break;
+                            }
+                        }
+                    }
 
-					if (
+                    if (
                         (
                             $bHasBeenOrdered ||
                             $bIsAllowedBE && $bValidUpdateCode
                         ) && 
                         isset($piVars[$downloadVar])
                     ) {
-						$row = $downloadTable->get($uid, '', false);
-						if (isset($row) && is_array($row)) {
+                        $row = $downloadTable->get($uid, '', false);
+                        if (isset($row) && is_array($row)) {
 
-							if (isset($cmdData['fal'])) {
+                            if (isset($cmdData['fal'])) {
                                 tx_ttproducts_api_download::fetchFal(intval($cmdData['fal']));
-							} else {
-								$fileArray =
-									$downloadTable->getFileArray(
+                            } else {
+                                $fileArray =
+                                    $downloadTable->getFileArray(
                                         $orderObj,
-										$row,
-										$multiOrderArray
-									);
-								$filename = basename($row['path']);
-								$filenameDividerPos = strpos($filename, '-');
-								if ($filenameDividerPos !== false) {
-									$extKey = substr($filename, 0, $filenameDividerPos);
-								} else {
-									$extKey = $filename;
-								}
-								$path = $fileArray[$cmdData['download']] . $extKey . '/';
-								$extInfo = ExtensionUtility::getExtensionInfo($extKey, $path);
+                                        $row,
+                                        $multiOrderArray
+                                    );
+                                $filename = basename($row['path']);
+                                $filenameDividerPos = strpos($filename, '-');
+                                if ($filenameDividerPos !== false) {
+                                    $extKey = substr($filename, 0, $filenameDividerPos);
+                                } else {
+                                    $extKey = $filename;
+                                }
+                                $path = $fileArray[$cmdData['download']] . $extKey . '/';
+                                $extInfo = ExtensionUtility::getExtensionInfo($extKey, $path);
 
-								// Ausführen des Kommandos und EXIT
-								tx_addonsem_file_div::extBackup(
-									$extKey,
-									$path,
-									$extInfo,
-									$orderRow,
-									$variantVars
-								);
-							}
-						}
-					} else {
-						if (!$feusers_uid) {
-							$message = $languageObj->getLabel('download_requires_felogin');
-							echo $message;
-						}
+                                // Ausführen des Kommandos und EXIT
+                                tx_addonsem_file_div::extBackup(
+                                    $extKey,
+                                    $path,
+                                    $extInfo,
+                                    $orderRow,
+                                    $variantVars
+                                );
+                            }
+                        }
+                    } else {
+                        if (!$feusers_uid) {
+                            $message = $languageObj->getLabel('download_requires_felogin');
+                            echo $message;
+                        }
 
-						if (!isset($piVars[$downloadVar])) {
-							debug ($piVars, 'download command: no parameter download has been set'); // keep this
+                        if (!isset($piVars[$downloadVar])) {
+                            debug ($piVars, 'download command: no parameter download has been set'); // keep this
                             $message = $languageObj->getLabel('error_download');
                             echo $message;
-						} else if (!$bHasBeenOrdered) {
-							debug ($bHasBeenOrdered, 'DOWNLOAD is not allowed because the product has not been ordered by the FE user with uid = ' . $feusers_uid . '. Therefore nothing happens here.'); // keep this
-						} else if (!$feusers_uid) {
-							debug ($piVars, 'Internal error. No FE User has been selected'); // keep this
-						}
-					}
-					exit;
-				} else {
-					// nothing
-				}
-				break;
-		}
-	}
+                        } else if (!$bHasBeenOrdered) {
+                            debug ($bHasBeenOrdered, 'DOWNLOAD is not allowed because the product has not been ordered by the FE user with uid = ' . $feusers_uid . '. Therefore nothing happens here.'); // keep this
+                        } else if (!$feusers_uid) {
+                            debug ($piVars, 'Internal error. No FE User has been selected'); // keep this
+                        }
+                    }
+                    exit;
+                } else {
+                    // nothing
+                }
+                break;
+        }
+    }
 }
 

--- a/control/class.tx_ttproducts_control_creator.php
+++ b/control/class.tx_ttproducts_control_creator.php
@@ -45,16 +45,16 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class tx_ttproducts_control_creator implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function init (
-		&$conf,
-		&$config,
-		$pObj,
-		$cObj,
-		$ajax,
-		&$errorCode,
-		array $recs = [],
-		array $basketRec = []
-	) {
+    public function init (
+        &$conf,
+        &$config,
+        $pObj,
+        $cObj,
+        $ajax,
+        &$errorCode,
+        array $recs = [],
+        array $basketRec = []
+    ) {
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
         } else {
@@ -63,156 +63,156 @@ class tx_ttproducts_control_creator implements \TYPO3\CMS\Core\SingletonInterfac
 
         $useStaticInfoTables = $staticInfoApi->init();
 
-		if (!empty($conf['PIDstoreRoot'])) {
-			$config['storeRootPid'] = $conf['PIDstoreRoot'];
-		} else if (
+        if (!empty($conf['PIDstoreRoot'])) {
+            $config['storeRootPid'] = $conf['PIDstoreRoot'];
+        } else if (
             defined ('TYPO3_MODE') &&
             TYPO3_MODE == 'FE'
         ) {
-			foreach ($GLOBALS['TSFE']->tmpl->rootLine as $k => $row) {
-				if ($row['doktype'] == 1) {
-					$config['storeRootPid'] = $row['uid'];
-					break;
-				}
-			}
-		}
+            foreach ($GLOBALS['TSFE']->tmpl->rootLine as $k => $row) {
+                if ($row['doktype'] == 1) {
+                    $config['storeRootPid'] = $row['uid'];
+                    break;
+                }
+            }
+        }
 
         if (
             !isset($conf['pid_list']) ||
             $conf['pid_list'] == '{$plugin.tt_products.pid_list}'
         ) {
-			$conf['pid_list'] = '';
-		}
+            $conf['pid_list'] = '';
+        }
 
-		if (
+        if (
             !isset($conf['errorLog']) ||
             $conf['errorLog'] == '{$plugin.tt_products.file.errorLog}'
         ) {
-			$conf['errorLog'] = '';
-		} else if ($conf['errorLog']) {
-			$conf['errorLog'] = GeneralUtility::resolveBackPath(PATH_typo3conf . '../' . $conf['errorLog']);
-		}
+            $conf['errorLog'] = '';
+        } else if ($conf['errorLog']) {
+            $conf['errorLog'] = GeneralUtility::resolveBackPath(PATH_typo3conf . '../' . $conf['errorLog']);
+        }
 
-		$tmp = $cObj->stdWrap($conf['pid_list'] ?? '', $conf['pid_list.'] ?? '');
-		$pid_list = (!empty($cObj->data['pages']) ? $cObj->data['pages'] : (!empty($conf['pid_list.']) ? trim($tmp) : ''));
-		$pid_list = ($pid_list ? $pid_list : $conf['pid_list'] ?? '');
-		$config['pid_list'] = (isset($pid_list) ? $pid_list : $config['storeRootPid'] ?? 0);
+        $tmp = $cObj->stdWrap($conf['pid_list'] ?? '', $conf['pid_list.'] ?? '');
+        $pid_list = (!empty($cObj->data['pages']) ? $cObj->data['pages'] : (!empty($conf['pid_list.']) ? trim($tmp) : ''));
+        $pid_list = ($pid_list ? $pid_list : $conf['pid_list'] ?? '');
+        $config['pid_list'] = (isset($pid_list) ? $pid_list : $config['storeRootPid'] ?? 0);
 
-		$recursive = (!empty($cObj->data['recursive']) ? $cObj->data['recursive'] : $conf['recursive'] ?? 99);
-		$config['recursive'] = MathUtility::forceIntegerInRange($recursive, 0, 100);
+        $recursive = (!empty($cObj->data['recursive']) ? $cObj->data['recursive'] : $conf['recursive'] ?? 99);
+        $config['recursive'] = MathUtility::forceIntegerInRange($recursive, 0, 100);
 
-		if (is_object($pObj)) {
-			$pLangObj = $pObj;
-		} else {
-			$pLangObj = $this;
-		}
+        if (is_object($pObj)) {
+            $pLangObj = $pObj;
+        } else {
+            $pLangObj = $this;
+        }
         $languageObj = static::getLanguageObj($pLangObj, $cObj, $conf);
- 		$config['LLkey'] = $languageObj->getLocalLangKey();
+        $config['LLkey'] = $languageObj->getLocalLangKey();
 
         $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$result = $markerObj->init(
-			$conf,
-			tx_ttproducts_model_control::getPiVars()
-		);
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $result = $markerObj->init(
+            $conf,
+            tx_ttproducts_model_control::getPiVars()
+        );
 
-		if ($result == false) {
-			$errorCode = $markerObj->getErrorCode();
-			return false;
-		}
-		tx_ttproducts_control_basket::init(
-			$conf,
-			$tablesObj,
-			$config['pid_list'],
-			$conf['useArticles'] ?? 3,
-			$recs,
-			$basketRec
-		);
+        if ($result == false) {
+            $errorCode = $markerObj->getErrorCode();
+            return false;
+        }
+        tx_ttproducts_control_basket::init(
+            $conf,
+            $tablesObj,
+            $config['pid_list'],
+            $conf['useArticles'] ?? 3,
+            $recs,
+            $basketRec
+        );
 
-		// corrections in the Setup:
-		if (
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('voucher') &&
-			isset($conf['gift.']['type']) &&
-			$conf['gift.']['type'] == 'voucher'
-		) {
-			$conf['table.']['voucher'] = 'tx_voucher_codes';
-		}
+        // corrections in the Setup:
+        if (
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('voucher') &&
+            isset($conf['gift.']['type']) &&
+            $conf['gift.']['type'] == 'voucher'
+        ) {
+            $conf['table.']['voucher'] = 'tx_voucher_codes';
+        }
 
 
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$cnfObj->init(
-			$conf,
-			$config
-		);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $cnfObj->init(
+            $conf,
+            $config
+        );
 
-		\JambageCom\TtProducts\Api\ControlApi::init($conf, $cObj);
-		$infoArray = tx_ttproducts_control_basket::getStoredInfoArray();
-		if (!empty($conf['useStaticInfoCountry'])) {
-			tx_ttproducts_control_basket::setCountry(
-				$infoArray,
-				tx_ttproducts_control_basket::getBasketExtra()
-			);
-		}
+        \JambageCom\TtProducts\Api\ControlApi::init($conf, $cObj);
+        $infoArray = tx_ttproducts_control_basket::getStoredInfoArray();
+        if (!empty($conf['useStaticInfoCountry'])) {
+            tx_ttproducts_control_basket::setCountry(
+                $infoArray,
+                tx_ttproducts_control_basket::getBasketExtra()
+            );
+        }
 
-		tx_ttproducts_control_basket::addLoginData(
-			$infoArray,
-			$conf['loginUserInfoAddress'] ?? 0,
-			$conf['useStaticInfoCountry'] ?? 0
-		);
+        tx_ttproducts_control_basket::addLoginData(
+            $infoArray,
+            $conf['loginUserInfoAddress'] ?? 0,
+            $conf['useStaticInfoCountry'] ?? 0
+        );
 
-		tx_ttproducts_control_basket::setInfoArray($infoArray);
+        tx_ttproducts_control_basket::setInfoArray($infoArray);
 
-			// price
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$priceObj->init(
-			$cObj,
-			$conf
-		);
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$priceViewObj->init(
-			$priceObj
-		);
+            // price
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $priceObj->init(
+            $cObj,
+            $conf
+        );
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $priceViewObj->init(
+            $priceObj
+        );
 
-			// image
-		$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image');
-		$imageObj->init($cObj);
+            // image
+        $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image');
+        $imageObj->init($cObj);
 
-			// image view
-		$imageViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-		$imageViewObj->init($imageObj);
+            // image view
+        $imageViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
+        $imageViewObj->init($imageObj);
 
-		$cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
-		$cssObj->init();
+        $cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
+        $cssObj->init();
 
-		$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
-			// JavaScript
-		$javaScriptObj->init(
-			$ajax
-		);
+        $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+            // JavaScript
+        $javaScriptObj->init(
+            $ajax
+        );
 
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-		if (isset($config['templateSuffix'])) {
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+        if (isset($config['templateSuffix'])) {
             $templateObj->setTemplateSuffix($config['templateSuffix']);
         }
 
-			// Call all init hooks
-		if (
-			isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init']) &&
-			is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init'])
-		) {
-			$tableClassArray = $tablesObj->getTableClassArray();
+            // Call all init hooks
+        if (
+            isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init']) &&
+            is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init'])
+        ) {
+            $tableClassArray = $tablesObj->getTableClassArray();
 
-			foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init($languageObj, $tableClassArray);
-				}
-			}
-			$tablesObj->setTableClassArray($tableClassArray);
-		}
+            foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['init'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init($languageObj, $tableClassArray);
+                }
+            }
+            $tablesObj->setTableClassArray($tableClassArray);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
 
     static public function getLanguageObj ($pLangObj, $cObj, $conf) {
@@ -249,8 +249,8 @@ class tx_ttproducts_control_creator implements \TYPO3\CMS\Core\SingletonInterfac
         return $languageObj;
     }
 
-	public function destruct () {
-		tx_ttproducts_control_basket::destruct();
-	}
+    public function destruct () {
+        tx_ttproducts_control_basket::destruct();
+    }
 }
 

--- a/control/class.tx_ttproducts_control_memo.php
+++ b/control/class.tx_ttproducts_control_memo.php
@@ -45,268 +45,268 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_control_memo {
 
-	static protected $memoTableFieldArray = [
-		'tt_products' => 'memoItems',
-		'tx_dam' => 'memodam'
-	];
-	static protected $memoItemArray = [];
-	static protected $controlVars = [
-		'addmemo',
-		'delmemo',
-		'upmemo',
-		'downmemo'
-	];
+    static protected $memoTableFieldArray = [
+        'tt_products' => 'memoItems',
+        'tx_dam' => 'memodam'
+    ];
+    static protected $memoItemArray = [];
+    static protected $controlVars = [
+        'addmemo',
+        'delmemo',
+        'upmemo',
+        'downmemo'
+    ];
 
-	static public function getControlVars () {
-		return self::$controlVars;
-	}
+    static public function getControlVars () {
+        return self::$controlVars;
+    }
 
-	static public function getMemoTableFieldArray () {
-		return self::$memoTableFieldArray;
-	}
+    static public function getMemoTableFieldArray () {
+        return self::$memoTableFieldArray;
+    }
 
-	static public function bIsAllowed ($type, $conf) {
-		$result = false;
+    static public function bIsAllowed ($type, $conf) {
+        $result = false;
 
-		if (
-			isset($conf['memo.']) &&
-			isset($conf['memo.']['allow'])
-		) {
-			if (GeneralUtility::inList($conf['memo.']['allow'], $type)) {
-				$result = true;
-			}
-		}
-		return $result;
-	}
+        if (
+            isset($conf['memo.']) &&
+            isset($conf['memo.']['allow'])
+        ) {
+            if (GeneralUtility::inList($conf['memo.']['allow'], $type)) {
+                $result = true;
+            }
+        }
+        return $result;
+    }
 
-	static public function bUseFeuser ($conf) {
+    static public function bUseFeuser ($conf) {
 
-		$result = false;
-		$fe_user_uid = tx_div2007::getFrontEndUser('uid');
+        $result = false;
+        $fe_user_uid = tx_div2007::getFrontEndUser('uid');
 
-		if ($fe_user_uid) {
-			$result = self::bIsAllowed('fe_users', $conf);
-		}
+        if ($fe_user_uid) {
+            $result = self::bIsAllowed('fe_users', $conf);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function bUseSession ($conf) {
-		$result = self::bIsAllowed('session', $conf);
-		return $result;
-	}
+    static public function bUseSession ($conf) {
+        $result = self::bIsAllowed('session', $conf);
+        return $result;
+    }
 
-	static public function process ($functablename, $piVars, $conf) {
+    static public function process ($functablename, $piVars, $conf) {
 
-		$bMemoChanged = false;
-		self::loadMemo($functablename, $conf);
+        $bMemoChanged = false;
+        self::loadMemo($functablename, $conf);
 
-		$memoItems = self::getMemoItems($functablename);
-		if (!is_array($memoItems)) {
+        $memoItems = self::getMemoItems($functablename);
+        if (!is_array($memoItems)) {
             $memoItems = [];
-		}
-		$controlVars = self::getControlVars();
-		$memoArray = [];
-		foreach ($controlVars as $controlVar) {
-			if (!empty($piVars[$controlVar])) {
-				$memoArray[$controlVar] = explode(',', $piVars[$controlVar]);
-			}
-		}
+        }
+        $controlVars = self::getControlVars();
+        $memoArray = [];
+        foreach ($controlVars as $controlVar) {
+            if (!empty($piVars[$controlVar])) {
+                $memoArray[$controlVar] = explode(',', $piVars[$controlVar]);
+            }
+        }
 
-		if (isset($piVars['memo']) && is_array($piVars['memo'])) {
-			if (!isset($memoArray['addmemo'])) {
-				$memoArray['addmemo'] = [];
-			}
-			if (!isset($memoArray['delmemo'])) {
-				$memoArray['delmemo'] = [];
-			}
+        if (isset($piVars['memo']) && is_array($piVars['memo'])) {
+            if (!isset($memoArray['addmemo'])) {
+                $memoArray['addmemo'] = [];
+            }
+            if (!isset($memoArray['delmemo'])) {
+                $memoArray['delmemo'] = [];
+            }
 
-			foreach ($piVars['memo'] as $k => $v) {
-				if (MathUtility::canBeInterpretedAsInteger($k) && $k != '' && $v) {
-					$memoArray['addmemo'][] = intval($k);
-				} else if ($k == 'uids') {
-					$uidArray = explode(',', $v);
-					foreach ($uidArray as $uid) {
-						if (MathUtility::canBeInterpretedAsInteger($uid) && $uid != '' && in_array($uid, $memoItems)) {
-							$memoArray['delmemo'][] = $uid;
-						}
-					}
-				}
-			}
-		}
+            foreach ($piVars['memo'] as $k => $v) {
+                if (MathUtility::canBeInterpretedAsInteger($k) && $k != '' && $v) {
+                    $memoArray['addmemo'][] = intval($k);
+                } else if ($k == 'uids') {
+                    $uidArray = explode(',', $v);
+                    foreach ($uidArray as $uid) {
+                        if (MathUtility::canBeInterpretedAsInteger($uid) && $uid != '' && in_array($uid, $memoItems)) {
+                            $memoArray['delmemo'][] = $uid;
+                        }
+                    }
+                }
+            }
+        }
 
-		if (isset($memoArray['addmemo']) && is_array($memoArray['addmemo'])) {
-			foreach ($memoArray['addmemo'] as $addMemoSingle) {
-				if (!in_array($addMemoSingle, $memoItems)) {
-					$uid = intval($addMemoSingle);
-					if ($uid) {
-						$memoItems[] = $uid;
-						$bMemoChanged = true;
-					}
-				}
-			}
-		}
+        if (isset($memoArray['addmemo']) && is_array($memoArray['addmemo'])) {
+            foreach ($memoArray['addmemo'] as $addMemoSingle) {
+                if (!in_array($addMemoSingle, $memoItems)) {
+                    $uid = intval($addMemoSingle);
+                    if ($uid) {
+                        $memoItems[] = $uid;
+                        $bMemoChanged = true;
+                    }
+                }
+            }
+        }
 
-		if (isset($memoArray['delmemo']) && is_array($memoArray['delmemo'])) {
-			foreach ($memoArray['delmemo'] as $delMemoSingle) {
-				$val = intval($delMemoSingle);
-				if (in_array($val, $memoItems)) {
-					unset($memoItems[array_search($val, $memoItems)]);
-					$bMemoChanged = true;
-				}
-			}
-		}
+        if (isset($memoArray['delmemo']) && is_array($memoArray['delmemo'])) {
+            foreach ($memoArray['delmemo'] as $delMemoSingle) {
+                $val = intval($delMemoSingle);
+                if (in_array($val, $memoItems)) {
+                    unset($memoItems[array_search($val, $memoItems)]);
+                    $bMemoChanged = true;
+                }
+            }
+        }
 
-		if (isset($memoArray['upmemo']) && is_array($memoArray['upmemo'])) {
-			foreach ($memoArray['upmemo'] as $memoSingle) {
-				$val = intval($memoSingle);
-				$key = array_search($val, $memoItems);
-				if ($key !== false && $key > 0) {
-					$formerValue = $memoItems[$key - 1];
-					$memoItems[$key - 1] = $val;
-					$memoItems[$key] = $formerValue;
-					$bMemoChanged = true;
-				}
-			}
-		}
+        if (isset($memoArray['upmemo']) && is_array($memoArray['upmemo'])) {
+            foreach ($memoArray['upmemo'] as $memoSingle) {
+                $val = intval($memoSingle);
+                $key = array_search($val, $memoItems);
+                if ($key !== false && $key > 0) {
+                    $formerValue = $memoItems[$key - 1];
+                    $memoItems[$key - 1] = $val;
+                    $memoItems[$key] = $formerValue;
+                    $bMemoChanged = true;
+                }
+            }
+        }
 
-		if (isset($memoArray['downmemo']) && is_array($memoArray['downmemo'])) {
-			$maxKey = count($memoItems) - 1;
-			foreach ($memoArray['downmemo'] as $memoSingle) {
-				$val = intval($memoSingle);
-				$key = array_search($val, $memoItems);
-				if ($key !== false && $key < $maxKey) {
-					$formerValue = $memoItems[$key + 1];
-					$memoItems[$key + 1] = $val;
-					$memoItems[$key] = $formerValue;
-					$bMemoChanged = true;
-				}
-			}
-		}
+        if (isset($memoArray['downmemo']) && is_array($memoArray['downmemo'])) {
+            $maxKey = count($memoItems) - 1;
+            foreach ($memoArray['downmemo'] as $memoSingle) {
+                $val = intval($memoSingle);
+                $key = array_search($val, $memoItems);
+                if ($key !== false && $key < $maxKey) {
+                    $formerValue = $memoItems[$key + 1];
+                    $memoItems[$key + 1] = $val;
+                    $memoItems[$key] = $formerValue;
+                    $bMemoChanged = true;
+                }
+            }
+        }
 
-		if ($bMemoChanged) {
+        if ($bMemoChanged) {
 
-			self::saveMemo($functablename, $memoItems, $conf);
-			self::setMemoItems($functablename, $memoItems);
-		}
-	}
+            self::saveMemo($functablename, $memoItems, $conf);
+            self::setMemoItems($functablename, $memoItems);
+        }
+    }
 
-	static public function getMemoField ($functablename, $bFeuser) {
-		if (isset(self::$memoTableFieldArray[$functablename])) {
-			$result = ($bFeuser ? 'tt_products_' : '') . self::$memoTableFieldArray[$functablename];
-		} else {
-			$result = false;
-		}
-		return $result;
-	}
+    static public function getMemoField ($functablename, $bFeuser) {
+        if (isset(self::$memoTableFieldArray[$functablename])) {
+            $result = ($bFeuser ? 'tt_products_' : '') . self::$memoTableFieldArray[$functablename];
+        } else {
+            $result = false;
+        }
+        return $result;
+    }
 
-	static public function getMemoItems ($functablename) {
-		$result = self::$memoItemArray[$functablename];
-		return $result;
-	}
+    static public function getMemoItems ($functablename) {
+        $result = self::$memoItemArray[$functablename];
+        return $result;
+    }
 
-	static public function setMemoItems ($functablename, $v) {
-		if (!is_array($v)) {
-			if ($v == '') {
-				$v = [];
-			} else {
-				$v = explode(',', $v);
-			}
-		}
-		self::$memoItemArray[$functablename] = $v;
-	}
+    static public function setMemoItems ($functablename, $v) {
+        if (!is_array($v)) {
+            if ($v == '') {
+                $v = [];
+            } else {
+                $v = explode(',', $v);
+            }
+        }
+        self::$memoItemArray[$functablename] = $v;
+    }
 
-	static public function readSessionMemoItems ($functablename) {
-		$result = '';
-		$session = tx_ttproducts_control_session::readSessionData();
-		$tableArray = self::getMemoTableFieldArray();
-		$field = $tableArray[$functablename];
+    static public function readSessionMemoItems ($functablename) {
+        $result = '';
+        $session = tx_ttproducts_control_session::readSessionData();
+        $tableArray = self::getMemoTableFieldArray();
+        $field = $tableArray[$functablename];
 
-		if (
-			$field != '' &&
-			is_array($session) &&
-			isset($session[$field])
-		) {
-			$result = $session[$field];
-		}
+        if (
+            $field != '' &&
+            is_array($session) &&
+            isset($session[$field])
+        ) {
+            $result = $session[$field];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function readFeUserMemoItems ($functablename) {
-		$result = '';
-		$feuserField = self::getMemoField($functablename, true);
+    static public function readFeUserMemoItems ($functablename) {
+        $result = '';
+        $feuserField = self::getMemoField($functablename, true);
 
-		if ($GLOBALS['TSFE']->fe_user->user[$feuserField]) {
-			$result = explode(',', $GLOBALS['TSFE']->fe_user->user[$feuserField]);
-		}
+        if ($GLOBALS['TSFE']->fe_user->user[$feuserField]) {
+            $result = explode(',', $GLOBALS['TSFE']->fe_user->user[$feuserField]);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function loadMemo ($functablename, $conf) {
-		$memoItems = '';
+    static public function loadMemo ($functablename, $conf) {
+        $memoItems = '';
 // 		$bFeuser = self::bUseFeuser($conf);
 // 		$theField = self::getMemoField($functablename, $bFeuser);
 
-		if (self::bUseFeuser($conf)) {
+        if (self::bUseFeuser($conf)) {
 
-			$memoItems = self::readFeUserMemoItems($functablename);
-		} else {
-			$memoItems = self::readSessionMemoItems($functablename);
-		}
-		self::setMemoItems($functablename, $memoItems);
-	}
+            $memoItems = self::readFeUserMemoItems($functablename);
+        } else {
+            $memoItems = self::readSessionMemoItems($functablename);
+        }
+        self::setMemoItems($functablename, $memoItems);
+    }
 
-	static public function saveMemo ($functablename, $memoItems, $conf) {
-		$bFeuser = self::bUseFeuser($conf);
-		$feuserField = self::getMemoField($functablename, $bFeuser);
+    static public function saveMemo ($functablename, $memoItems, $conf) {
+        $bFeuser = self::bUseFeuser($conf);
+        $feuserField = self::getMemoField($functablename, $bFeuser);
 
-		$fieldsArray = [];
-		$fieldsArray[$feuserField] = implode(',', $memoItems);
+        $fieldsArray = [];
+        $fieldsArray[$feuserField] = implode(',', $memoItems);
 
-		if ($bFeuser) {
-			$fe_user_uid = tx_div2007::getFrontEndUser('uid');
-			$GLOBALS['TYPO3_DB']->exec_UPDATEquery('fe_users', 'uid=' . $fe_user_uid, $fieldsArray);
-		} else {
-			tx_ttproducts_control_session::writeSessionData($fieldsArray);
-		}
-	}
+        if ($bFeuser) {
+            $fe_user_uid = tx_div2007::getFrontEndUser('uid');
+            $GLOBALS['TYPO3_DB']->exec_UPDATEquery('fe_users', 'uid=' . $fe_user_uid, $fieldsArray);
+        } else {
+            tx_ttproducts_control_session::writeSessionData($fieldsArray);
+        }
+    }
 
-	static public function copySession2Feuser ($params, $pObj, $conf) {
+    static public function copySession2Feuser ($params, $pObj, $conf) {
 
-		$tableArray = self::getMemoTableFieldArray();
-		foreach ($tableArray as $functablename => $type) {
-			$memoItems = self::readSessionMemoItems($functablename);
+        $tableArray = self::getMemoTableFieldArray();
+        foreach ($tableArray as $functablename => $type) {
+            $memoItems = self::readSessionMemoItems($functablename);
 
-			if (!empty($memoItems) && is_array($memoItems)) {
-				$feuserMemoItems = self::readFeUserMemoItems($functablename);
-				if (isset($feuserMemoItems) && is_array($feuserMemoItems)) {
-					$memoItems = array_merge($feuserMemoItems, $memoItems);
-				}
-				self::saveMemo($functablename, $memoItems, $conf);
-			}
-		}
-	}
+            if (!empty($memoItems) && is_array($memoItems)) {
+                $feuserMemoItems = self::readFeUserMemoItems($functablename);
+                if (isset($feuserMemoItems) && is_array($feuserMemoItems)) {
+                    $memoItems = array_merge($feuserMemoItems, $memoItems);
+                }
+                self::saveMemo($functablename, $memoItems, $conf);
+            }
+        }
+    }
 
-	/**
-	 * Adds link markers to a wrapped subpart array
-	 */
-	static public function getWrappedSubpartArray (
-		&$wrappedSubpartArray,
-		$pidMemo,
-		$uid,
-		$cObj,
-		$urlObj,
-		$excludeList = '',
-		$addQueryString = [],
-		$css_current = '',
-		$useBackPid = true
-	) {
-		$cmdArray = ['add', 'del'];
+    /**
+     * Adds link markers to a wrapped subpart array
+     */
+    static public function getWrappedSubpartArray (
+        &$wrappedSubpartArray,
+        $pidMemo,
+        $uid,
+        $cObj,
+        $urlObj,
+        $excludeList = '',
+        $addQueryString = [],
+        $css_current = '',
+        $useBackPid = true
+    ) {
+        $cmdArray = ['add', 'del'];
 
-		foreach ($cmdArray as $cmd) {
-			$addQueryString[$cmd . 'memo'] = $uid;
+        foreach ($cmdArray as $cmd) {
+            $addQueryString[$cmd . 'memo'] = $uid;
 
             $pageLink = FrontendUtility::getTypoLink_URL(
                 $cObj,
@@ -319,10 +319,10 @@ class tx_ttproducts_control_memo {
                 )
             );
 
-			$wrappedSubpartArray['###LINK_MEMO_' . strtoupper($cmd) . '###'] = ['<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>', '</a>'];
-			unset($addQueryString[$cmd . 'memo']);
-		}
-	}
+            $wrappedSubpartArray['###LINK_MEMO_' . strtoupper($cmd) . '###'] = ['<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>', '</a>'];
+            unset($addQueryString[$cmd . 'memo']);
+        }
+    }
 }
 
 

--- a/control/class.tx_ttproducts_control_product.php
+++ b/control/class.tx_ttproducts_control_product.php
@@ -44,108 +44,108 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_control_product {
 
-	/**
-	 */
-	static public function getPresetVariantArray (
-		$itemTable,
-		$row,
-		$useArticles
-	) {
-		$uid = $row['uid'];
-		$functablename = $itemTable->getFuncTablename();;
-		$basketVar = tx_ttproducts_model_control::getBasketVar();
-		$presetVariantArray = [];
-		$basketArray = GeneralUtility::_GP($basketVar);
+    /**
+     */
+    static public function getPresetVariantArray (
+        $itemTable,
+        $row,
+        $useArticles
+    ) {
+        $uid = $row['uid'];
+        $functablename = $itemTable->getFuncTablename();;
+        $basketVar = tx_ttproducts_model_control::getBasketVar();
+        $presetVariantArray = [];
+        $basketArray = GeneralUtility::_GP($basketVar);
 
-		if (
-			isset($basketArray) && is_array($basketArray) &&
-			isset($basketArray[$uid]) && is_array($basketArray[$uid]) &&
-			isset($_POST[$basketVar]) && is_array($_POST[$basketVar]) &&
-			isset($_POST[$basketVar][$uid])
-		) {
-			$presetVariantArray = $_POST[$basketVar][$uid];
-		}
+        if (
+            isset($basketArray) && is_array($basketArray) &&
+            isset($basketArray[$uid]) && is_array($basketArray[$uid]) &&
+            isset($_POST[$basketVar]) && is_array($_POST[$basketVar]) &&
+            isset($_POST[$basketVar][$uid])
+        ) {
+            $presetVariantArray = $_POST[$basketVar][$uid];
+        }
 
-		$storedRecs = tx_ttproducts_control_basket::getStoredVariantRecs();
-		if (
-			isset($storedRecs) &&
-			is_array($storedRecs) &&
-			isset($storedRecs[$functablename]) &&
-			is_array($storedRecs[$functablename]) &&
-			isset($storedRecs[$functablename][$uid])
-		) {
-			$variantRow = $storedRecs[$functablename][$uid];
-			$variant =
-				$itemTable->variant->getVariantFromProductRow(
-					$row,
-					$variantRow,
-					$useArticles,
-					false
-				);
+        $storedRecs = tx_ttproducts_control_basket::getStoredVariantRecs();
+        if (
+            isset($storedRecs) &&
+            is_array($storedRecs) &&
+            isset($storedRecs[$functablename]) &&
+            is_array($storedRecs[$functablename]) &&
+            isset($storedRecs[$functablename][$uid])
+        ) {
+            $variantRow = $storedRecs[$functablename][$uid];
+            $variant =
+                $itemTable->variant->getVariantFromProductRow(
+                    $row,
+                    $variantRow,
+                    $useArticles,
+                    false
+                );
 
-			$presetVariantArray = $variant;
-		}
+            $presetVariantArray = $variant;
+        }
 
-		return $presetVariantArray;
-	} // getPresetVariantArray
-
-
-	static public function getActiveArticleNo () {
-		$result = tx_ttproducts_model_control::getPiVarValue('tt_products_articles');
-		return $result;
-	}
+        return $presetVariantArray;
+    } // getPresetVariantArray
 
 
-	static public function addAjax (
-		$tablesObj,
-		$languageObj,
-		$theCode,
-		$functablename
-	) {
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+    static public function getActiveArticleNo () {
+        $result = tx_ttproducts_model_control::getPiVarValue('tt_products_articles');
+        return $result;
+    }
 
-			$itemTable = $tablesObj->get($functablename, false);
 
-			$selectableVariantFieldArray = $itemTable->variant->getSelectableFieldArray();
-			$editFieldArray = $itemTable->editVariant->getFieldArray();
-			$fieldArray = [];
+    static public function addAjax (
+        $tablesObj,
+        $languageObj,
+        $theCode,
+        $functablename
+    ) {
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
 
-			if (
-				isset($selectableVariantFieldArray) &&
-				is_array($selectableVariantFieldArray)
-			) {
-				$fieldArray = $selectableVariantFieldArray;
-			}
+            $itemTable = $tablesObj->get($functablename, false);
 
-			if (isset($editFieldArray) && is_array($editFieldArray)) {
-				$fieldArray = array_merge($fieldArray, $editFieldArray);
-			}
+            $selectableVariantFieldArray = $itemTable->variant->getSelectableFieldArray();
+            $editFieldArray = $itemTable->editVariant->getFieldArray();
+            $fieldArray = [];
 
-			$param = [$functablename => $fieldArray];
-			$bUseColorbox = false;
-			$tableConf = $itemTable->getTableConf($theCode);
-			if (
-				is_array($tableConf) &&
-				isset($tableConf['jquery.']) &&
-				isset($tableConf['jquery.']['colorbox']) &&
-				$tableConf['jquery.']['colorbox']
-			) {
-				$bUseColorbox = true;
-			}
+            if (
+                isset($selectableVariantFieldArray) &&
+                is_array($selectableVariantFieldArray)
+            ) {
+                $fieldArray = $selectableVariantFieldArray;
+            }
 
-			$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
-			$javaScriptObj->set(
-				$languageObj,
-				'fetchdata',
-				$param
-			);
+            if (isset($editFieldArray) && is_array($editFieldArray)) {
+                $fieldArray = array_merge($fieldArray, $editFieldArray);
+            }
 
-			if (
-				$bUseColorbox
-			) {
-				$javaScriptObj->set($languageObj, 'colorbox');
-			}
-		}
-	}
+            $param = [$functablename => $fieldArray];
+            $bUseColorbox = false;
+            $tableConf = $itemTable->getTableConf($theCode);
+            if (
+                is_array($tableConf) &&
+                isset($tableConf['jquery.']) &&
+                isset($tableConf['jquery.']['colorbox']) &&
+                $tableConf['jquery.']['colorbox']
+            ) {
+                $bUseColorbox = true;
+            }
+
+            $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+            $javaScriptObj->set(
+                $languageObj,
+                'fetchdata',
+                $param
+            );
+
+            if (
+                $bUseColorbox
+            ) {
+                $javaScriptObj->set($languageObj, 'colorbox');
+            }
+        }
+    }
 }
 

--- a/control/class.tx_ttproducts_control_search.php
+++ b/control/class.tx_ttproducts_control_search.php
@@ -45,80 +45,80 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_control_search implements \TYPO3\CMS\Core\SingletonInterface, tx_ttproducts_field_int {
-	public $cObj;
-	public $conf;
-	public $config;
-	public $pibaseClass;			// class of the pibase object
-	public $codeArray;			// Codes
-	public $errorMessage;
+    public $cObj;
+    public $conf;
+    public $config;
+    public $pibaseClass;			// class of the pibase object
+    public $codeArray;			// Codes
+    public $errorMessage;
 
 
-	public function init (&$content, &$conf, &$config, $cObj, $pibaseClass, &$error_code) {
-		$pibaseObj = GeneralUtility::makeInstance($pibaseClass);
-		$this->cObj = $cObj;
-		$parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
+    public function init (&$content, &$conf, &$config, $cObj, $pibaseClass, &$error_code) {
+        $pibaseObj = GeneralUtility::makeInstance($pibaseClass);
+        $this->cObj = $cObj;
+        $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
 
-		PluginApi::initFlexform($cObj);
-		$flexformArray = \JambageCom\TtProducts\Api\PluginApi::getFlexform();
-		$flexformTyposcript = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'myTS');
-		if($flexformTyposcript) {
-			$tsparser = GeneralUtility::makeInstance(
+        PluginApi::initFlexform($cObj);
+        $flexformArray = \JambageCom\TtProducts\Api\PluginApi::getFlexform();
+        $flexformTyposcript = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'myTS');
+        if($flexformTyposcript) {
+            $tsparser = GeneralUtility::makeInstance(
                 \TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class
             );
-			// Copy conf into existing setup
-			$tsparser->setup = $conf;
-			// Parse the new Typoscript
-			$tsparser->parse($flexformTyposcript);
-			// Copy the resulting setup back into conf
-			$conf = $tsparser->setup;
-		}
-		$this->conf = $conf;
-		$this->config = $config;
-		$piVars = $parameterApi->getPiVars();
-		$this->pibaseClass = $pibaseClass;
+            // Copy conf into existing setup
+            $tsparser->setup = $conf;
+            // Parse the new Typoscript
+            $tsparser->parse($flexformTyposcript);
+            // Copy the resulting setup back into conf
+            $conf = $tsparser->setup;
+        }
+        $this->conf = $conf;
+        $this->config = $config;
+        $piVars = $parameterApi->getPiVars();
+        $this->pibaseClass = $pibaseClass;
 
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$cnf->init(
-			$conf,
-			$config
-		);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $cnf->init(
+            $conf,
+            $config
+        );
 
-		// $pibaseObj->pi_initPIflexForm();
-		$this->cObj->data['pi_flexform'] = GeneralUtility::xml2array($this->cObj->data['pi_flexform'] ?? '');
-		$newConfig = $this->getControlConfig($this->cObj, $conf, $this->cObj->data);
-		$config = array_merge($config, $newConfig);
-		$this->codeArray = GeneralUtility::trimExplode(',', $config['code'],1);
-		$config['LLkey'] = $pibaseObj->LLkey;
-		$config['templateSuffix'] = strtoupper($this->conf['templateSuffix']);
-		$templateSuffix = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'template_suffix');
-		$templateSuffix = strtoupper($templateSuffix);
-		$config['templateSuffix'] = ($templateSuffix ? $templateSuffix : $config['templateSuffix']);
-		$config['templateSuffix'] = ($config['templateSuffix'] ? '_'.$config['templateSuffix'] : '');
+        // $pibaseObj->pi_initPIflexForm();
+        $this->cObj->data['pi_flexform'] = GeneralUtility::xml2array($this->cObj->data['pi_flexform'] ?? '');
+        $newConfig = $this->getControlConfig($this->cObj, $conf, $this->cObj->data);
+        $config = array_merge($config, $newConfig);
+        $this->codeArray = GeneralUtility::trimExplode(',', $config['code'],1);
+        $config['LLkey'] = $pibaseObj->LLkey;
+        $config['templateSuffix'] = strtoupper($this->conf['templateSuffix']);
+        $templateSuffix = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'template_suffix');
+        $templateSuffix = strtoupper($templateSuffix);
+        $config['templateSuffix'] = ($templateSuffix ? $templateSuffix : $config['templateSuffix']);
+        $config['templateSuffix'] = ($config['templateSuffix'] ? '_'.$config['templateSuffix'] : '');
 
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
         $languageSubpath = '/Resources/Private/Language/';
-		$languageObj->loadLocalLang( 'EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'PiSearch/locallang.xlf');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$markerObj->init(
+        $languageObj->loadLocalLang( 'EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'PiSearch/locallang.xlf');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $markerObj->init(
             $conf,
-			$piVars
-		);
+            $piVars
+        );
 
-		$searchViewObj = GeneralUtility::makeInstance('tx_ttproducts_search_view');
-		$searchViewObj->init(
-			$this->cObj
-		);
+        $searchViewObj = GeneralUtility::makeInstance('tx_ttproducts_search_view');
+        $searchViewObj->init(
+            $this->cObj
+        );
 
-		return true;
-	} // init
+        return true;
+    } // init
 
 
-	public function getControlConfig ($cObj, &$conf, &$row) {
+    public function getControlConfig ($cObj, &$conf, &$row) {
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$ctrlArray = $parameterApi->getParameterTable();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $ctrlArray = $parameterApi->getParameterTable();
 
-		$config = [];
+        $config = [];
         $config['code'] =
             \JambageCom\Div2007\Utility\ConfigUtility::getSetupOrFFvalue(
                 $cObj,
@@ -130,158 +130,158 @@ class tx_ttproducts_control_search implements \TYPO3\CMS\Core\SingletonInterface
                 true
             );
 
-		$flexformConfigArray = [
-			'local_param',
-			'foreign_param',
-			'columns',
-			'fields',
-			'group_by_fields',
-			'url',
-			'all',
-			'parameters',
-			'delimiter',
-		];
+        $flexformConfigArray = [
+            'local_param',
+            'foreign_param',
+            'columns',
+            'fields',
+            'group_by_fields',
+            'url',
+            'all',
+            'parameters',
+            'delimiter',
+        ];
 
-		foreach ($flexformConfigArray as $flexformConfig) {
-			$tmpConfig = \JambageCom\Div2007\Utility\FlexformUtility::get($row['pi_flexform'] ?? '', $flexformConfig);
-			$config[$flexformConfig] = $tmpConfig;
-		}
-		$config['local_table'] = $cnf->getTableName($ctrlArray[$config['local_param']]);
-		$config['foreign_table'] = $cnf->getTableName($ctrlArray[$config['foreign_param']]);
-		if ($config['url'] != '') {
-			$url = str_replace('index.php?','',$config['url']);
-			$urlArray = GeneralUtility::trimExplode('=', $url);
-			if ($urlArray['0'] == 'id' && intval($urlArray['1'])) {
-				$id = $urlArray['1'];
-				$url = FrontendUtility::getTypoLink_URL($cObj, $id);
-				$config['url'] = $url;
-			}
-		}
+        foreach ($flexformConfigArray as $flexformConfig) {
+            $tmpConfig = \JambageCom\Div2007\Utility\FlexformUtility::get($row['pi_flexform'] ?? '', $flexformConfig);
+            $config[$flexformConfig] = $tmpConfig;
+        }
+        $config['local_table'] = $cnf->getTableName($ctrlArray[$config['local_param']]);
+        $config['foreign_table'] = $cnf->getTableName($ctrlArray[$config['foreign_param']]);
+        if ($config['url'] != '') {
+            $url = str_replace('index.php?','',$config['url']);
+            $urlArray = GeneralUtility::trimExplode('=', $url);
+            if ($urlArray['0'] == 'id' && intval($urlArray['1'])) {
+                $id = $urlArray['1'];
+                $url = FrontendUtility::getTypoLink_URL($cObj, $id);
+                $config['url'] = $url;
+            }
+        }
 
-		return $config;
-	}
+        return $config;
+    }
 
 
-	public function run ($cObj, $pibaseClass, &$errorCode, $content='') {
+    public function run ($cObj, $pibaseClass, &$errorCode, $content='') {
 
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$pibaseObj = GeneralUtility::makeInstance($pibaseClass);
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$searchViewObj = GeneralUtility::makeInstance('tx_ttproducts_search_view');
-		$error_code = [];
-		$errorMessage = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $pibaseObj = GeneralUtility::makeInstance($pibaseClass);
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $searchViewObj = GeneralUtility::makeInstance('tx_ttproducts_search_view');
+        $error_code = [];
+        $errorMessage = '';
 
-		foreach($this->codeArray as $theCode) {
+        foreach($this->codeArray as $theCode) {
 
-			$theCode = (string) trim($theCode);
-			$contentTmp = '';
-			$tmp = '';
-			$templateCode =
-				$templateObj->get(
-					$theCode,
-					$tmp,
-					$errorCode
-				);
+            $theCode = (string) trim($theCode);
+            $contentTmp = '';
+            $tmp = '';
+            $templateCode =
+                $templateObj->get(
+                    $theCode,
+                    $tmp,
+                    $errorCode
+                );
 
-			if ($errorCode) {
-				$errorText =
-					$languageObj->getLabel(
-						'no_template'
-					);
-				$errorMessage = str_replace('|', 'plugin.tt_products.templateFile', $errorText);
-			}
+            if ($errorCode) {
+                $errorText =
+                    $languageObj->getLabel(
+                        'no_template'
+                    );
+                $errorMessage = str_replace('|', 'plugin.tt_products.templateFile', $errorText);
+            }
 
             $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-			$theTemplateCode =
-				$templateService->getSubpart(
-					$templateCode,
-					$subpartmarkerObj->spMarker(
-						'###' . $theCode . $this->config['templateSuffix'] . '###'
-					)
-				);
+            $theTemplateCode =
+                $templateService->getSubpart(
+                    $templateCode,
+                    $subpartmarkerObj->spMarker(
+                        '###' . $theCode . $this->config['templateSuffix'] . '###'
+                    )
+                );
 
-			switch($theCode) {
-				case 'FIRSTLETTER':
-					$contentTmp = $searchViewObj->printFirstletter(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						$error_code
-					);
-				break;
-				case 'FIELD':
+            switch($theCode) {
+                case 'FIRSTLETTER':
+                    $contentTmp = $searchViewObj->printFirstletter(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        $error_code
+                    );
+                break;
+                case 'FIELD':
                     $tmp = [];
-					$contentTmp = $searchViewObj->printKeyField(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						2,
-						'field' . $this->cObj->data['uid'],
-						$tmp,
-						$error_code
-					);
-				break;
-				case 'KEYFIELD':
-					$functablename = ($this->config['foreign_table'] ?? $this->config['local_table']);
-					$tableConf = $cnf->getTableConf($functablename, $theCode);
+                    $contentTmp = $searchViewObj->printKeyField(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        2,
+                        'field' . $this->cObj->data['uid'],
+                        $tmp,
+                        $error_code
+                    );
+                break;
+                case 'KEYFIELD':
+                    $functablename = ($this->config['foreign_table'] ?? $this->config['local_table']);
+                    $tableConf = $cnf->getTableConf($functablename, $theCode);
 
-					if (isset($tableConf['view.']) && is_array($tableConf['view.']) &&
-						isset($tableConf['view.']['valueArray.']) && is_array($tableConf['view.']['valueArray.'])
-					)	{
-						$keyfieldConf = $tableConf['view.']['valueArray.'];
-					} else {
-						$keyfieldConf = [];
-					}
-					$contentTmp = $searchViewObj->printKeyField(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						1,
-						'keyfield'.$this->cObj->data['uid'],
-						$keyfieldConf,
-						$error_code
-					);
-				break;
-				case 'LASTENTRIES':
-					$contentTmp = $searchViewObj->printLastEntries(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						$error_code
-					);
-				break;
-				case 'TEXTFIELD':
-					$contentTmp = $searchViewObj->printTextField(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						'textfield'.$this->cObj->data['uid'],
-						$this->cObj->data,
-						$error_code
-					);
-				break;
-				case 'YEAR':
-					$contentTmp = $searchViewObj->printYear(
-						$pibaseObj,
-						$theTemplateCode,
-						$this->config['columns'],
-						$error_code
-					);
-				break;
-				default:	// 'HELP'
-					$contentTmp = 'error';
-				break;
-			}
+                    if (isset($tableConf['view.']) && is_array($tableConf['view.']) &&
+                        isset($tableConf['view.']['valueArray.']) && is_array($tableConf['view.']['valueArray.'])
+                    )	{
+                        $keyfieldConf = $tableConf['view.']['valueArray.'];
+                    } else {
+                        $keyfieldConf = [];
+                    }
+                    $contentTmp = $searchViewObj->printKeyField(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        1,
+                        'keyfield'.$this->cObj->data['uid'],
+                        $keyfieldConf,
+                        $error_code
+                    );
+                break;
+                case 'LASTENTRIES':
+                    $contentTmp = $searchViewObj->printLastEntries(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        $error_code
+                    );
+                break;
+                case 'TEXTFIELD':
+                    $contentTmp = $searchViewObj->printTextField(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        'textfield'.$this->cObj->data['uid'],
+                        $this->cObj->data,
+                        $error_code
+                    );
+                break;
+                case 'YEAR':
+                    $contentTmp = $searchViewObj->printYear(
+                        $pibaseObj,
+                        $theTemplateCode,
+                        $this->config['columns'],
+                        $error_code
+                    );
+                break;
+                default:	// 'HELP'
+                    $contentTmp = 'error';
+                break;
+            }
 
-			if ($error_code[0]) {
-				$contentTmp .= $errorObj->getMessage($error_code, $languageObj);
-			}
+            if ($error_code[0]) {
+                $contentTmp .= $errorObj->getMessage($error_code, $languageObj);
+            }
 
-			if ($contentTmp == 'error') {
+            if ($contentTmp == 'error') {
                 $sanitizer = GeneralUtility::makeInstance(FilePathSanitizer::class);
-				$fileName = 'EXT:' . TT_PRODUCTS_EXT . '/Resources/Public/Templates/products_help.tmpl';
+                $fileName = 'EXT:' . TT_PRODUCTS_EXT . '/Resources/Public/Templates/products_help.tmpl';
                 $pathFilename = $sanitizer->sanitize($fileName);
 //                 $GLOBALS['TSFE']->tmpl->getFileName($fileName);
                 $helpTemplate = file_get_contents($pathFilename);
@@ -296,37 +296,37 @@ class tx_ttproducts_control_search implements \TYPO3\CMS\Core\SingletonInterface
                     );
 
                 unset($errorMessage);
-				break; // while
-			} else {
-				$content .=
+                break; // while
+            } else {
+                $content .=
                     FrontendUtility::wrapContentCode(
                         $contentTmp,
                         $theCode,
                         $pibaseObj->prefixId,
                         $this->cObj->data['uid']
                     );
-			}
-		}
+            }
+        }
 
-		if ($errorMessage) {
-			$content = '<p><b>' . $errorMessage . '</b></p>';
-		}
+        if ($errorMessage) {
+            $content = '<p><b>' . $errorMessage . '</b></p>';
+        }
 
-		if ($bRunAjax || !intval($this->conf['wrapInBaseClass'])) {
-			$rc = $content;
-		} else {
-			$content = $pibaseObj->pi_wrapInBaseClass($content);
+        if ($bRunAjax || !intval($this->conf['wrapInBaseClass'])) {
+            $rc = $content;
+        } else {
+            $content = $pibaseObj->pi_wrapInBaseClass($content);
 
-			if (is_object($this->css) && ($this->css->conf['file'])) {
+            if (is_object($this->css) && ($this->css->conf['file'])) {
                 $sanitizer = GeneralUtility::makeInstance(FilePathSanitizer::class);
                 $pathFilename = $sanitizer->sanitize($this->css->conf['file']);
                 $cssContent = file_get_contents($pathFilename);
-				$rc = '<style type="text/css">' . $cssContent . '</style>' . chr(13) . $content;
-			} else {
-				$rc = $content;
-			}
-		}
-		return $rc;
-	}
+                $rc = '<style type="text/css">' . $cssContent . '</style>' . chr(13) . $content;
+            } else {
+                $rc = $content;
+            }
+        }
+        return $rc;
+    }
 }
 

--- a/control/class.tx_ttproducts_control_session.php
+++ b/control/class.tx_ttproducts_control_session.php
@@ -39,25 +39,25 @@
 
 class tx_ttproducts_control_session {
 
-	static public function filterExtensionData ($session) {
+    static public function filterExtensionData ($session) {
 
-		$result = '';
-		if (is_array($session) && isset($session['tt_products'])) {
-			$result = $session['tt_products'];
-		}
-		return $result;
-	}
+        $result = '';
+        if (is_array($session) && isset($session['tt_products'])) {
+            $result = $session['tt_products'];
+        }
+        return $result;
+    }
 
-	static public function readSession ($key) {
-		$result = [];
-		$data = $GLOBALS['TSFE']->fe_user->getKey('ses', $key);
-		if (!empty($data)) {
-			$result = $data;
-		}
-		return $result;
-	}
+    static public function readSession ($key) {
+        $result = [];
+        $data = $GLOBALS['TSFE']->fe_user->getKey('ses', $key);
+        if (!empty($data)) {
+            $result = $data;
+        }
+        return $result;
+    }
 
-	static public function writeSession ($key, $value) {
+    static public function writeSession ($key, $value) {
 
         // Storing value ONLY if there is a confirmed cookie set,
         // otherwise a shellscript could easily be spamming the fe_sessions table
@@ -69,62 +69,62 @@ class tx_ttproducts_control_session {
         ) {
             $GLOBALS['TSFE']->fe_user->setKey('ses', $key, $value);
             $GLOBALS['TSFE']->fe_user->storeSessionData();  // The basket shall not get lost when coming back from external scripts
-		}
-	}
+        }
+    }
 
-	/*************************************
-	* FE USER SESSION DATA HANDLING
-	*************************************/
-	/**
-	* Retrieves session data
-	*
-	* @param	boolean	$readAll: whether to retrieve all session data or only data for this extension key
-	* @return	array	session data
-	*/
-	static public function readSessionData ($readAll = false) {
-		$sessionData = [];
-		$extKey = TT_PRODUCTS_EXT;
-		$allSessionData = static::readSession('feuser');
+    /*************************************
+    * FE USER SESSION DATA HANDLING
+    *************************************/
+    /**
+    * Retrieves session data
+    *
+    * @param	boolean	$readAll: whether to retrieve all session data or only data for this extension key
+    * @return	array	session data
+    */
+    static public function readSessionData ($readAll = false) {
+        $sessionData = [];
+        $extKey = TT_PRODUCTS_EXT;
+        $allSessionData = static::readSession('feuser');
 
-		if (isset($allSessionData) && is_array($allSessionData)) {
-			if ($readAll) {
-				$sessionData = $allSessionData;
-			} else if (isset($allSessionData[$extKey])) {
-				$sessionData = $allSessionData[$extKey];
-			}
-		}
-		return $sessionData;
-	}
+        if (isset($allSessionData) && is_array($allSessionData)) {
+            if ($readAll) {
+                $sessionData = $allSessionData;
+            } else if (isset($allSessionData[$extKey])) {
+                $sessionData = $allSessionData[$extKey];
+            }
+        }
+        return $sessionData;
+    }
 
-	/**
-	* Writes data to FE user session data
-	*
-	* @param	array	$data: the data to be written to FE user session data
-	* @param	boolean	$keepToken: whether to keep any token
-	* @param	boolean	$keepRedirectUrl: whether to keep any redirectUrl
-	* @return	array	session data
-	*/
-	static public function writeSessionData (
-		array $data
-	) {
-		$clearSession = empty($data);
-		$extKey = TT_PRODUCTS_EXT;
-			// Read all session data
-		$allSessionData = static::readSessionData(true);
+    /**
+    * Writes data to FE user session data
+    *
+    * @param	array	$data: the data to be written to FE user session data
+    * @param	boolean	$keepToken: whether to keep any token
+    * @param	boolean	$keepRedirectUrl: whether to keep any redirectUrl
+    * @return	array	session data
+    */
+    static public function writeSessionData (
+        array $data
+    ) {
+        $clearSession = empty($data);
+        $extKey = TT_PRODUCTS_EXT;
+            // Read all session data
+        $allSessionData = static::readSessionData(true);
 
-		if (is_array($allSessionData[$extKey])) {
-			$keys = array_keys($allSessionData[$extKey]);
-			if ($clearSession) {
-				foreach ($keys as $key) {
-					unset($allSessionData[$extKey][$key]);
-				}
-			}
-			\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($allSessionData[$extKey], $data);
-		} else {
-			$allSessionData[$extKey] = $data;
-		}
-		static::writeSession('feuser', $allSessionData);
-	}
+        if (is_array($allSessionData[$extKey])) {
+            $keys = array_keys($allSessionData[$extKey]);
+            if ($clearSession) {
+                foreach ($keys as $key) {
+                    unset($allSessionData[$extKey][$key]);
+                }
+            }
+            \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($allSessionData[$extKey], $data);
+        } else {
+            $allSessionData[$extKey] = $data;
+        }
+        static::writeSession('feuser', $allSessionData);
+    }
 }
 
 

--- a/control/class.tx_ttproducts_control_single.php
+++ b/control/class.tx_ttproducts_control_single.php
@@ -40,74 +40,74 @@
 
 class tx_ttproducts_control_single implements \TYPO3\CMS\Core\SingletonInterface {
 
-	/**
-	 * Triggers events when the single view has been called
-	 *
-	 * @return	void
-	 * @access private
-	 */
-	function triggerEvents ($conf) {
-		if (
+    /**
+     * Triggers events when the single view has been called
+     *
+     * @return	void
+     * @access private
+     */
+    function triggerEvents ($conf) {
+        if (
             !empty($conf['active']) &&
             isset($conf['trigger.'])
         ) {
-			$triggerConf = $conf['trigger.'];
-			$piVars = tx_ttproducts_model_control::getPiVars();
-			$piVar = tx_ttproducts_model_control::getPiVar('tt_products');
-			$uid = $piVars[$piVar] ?? '';
+            $triggerConf = $conf['trigger.'];
+            $piVars = tx_ttproducts_model_control::getPiVars();
+            $piVar = tx_ttproducts_model_control::getPiVar('tt_products');
+            $uid = $piVars[$piVar] ?? '';
 
-			if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
-				$mmTablename = 'sys_products_fe_users_mm_visited_products';
+            if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
+                $mmTablename = 'sys_products_fe_users_mm_visited_products';
 
-				if ($uid && in_array($mmTablename, $triggerConf)) {	// check if this trigger has been activated
+                if ($uid && in_array($mmTablename, $triggerConf)) {	// check if this trigger has been activated
 
-					$where = 'uid_local=' . intval($GLOBALS['TSFE']->fe_user->user['uid']) . ' AND uid_foreign=' . intval($uid);
-					$mmArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $mmTablename, $where, '', 'tstamp', '1');
-					$time = time();
+                    $where = 'uid_local=' . intval($GLOBALS['TSFE']->fe_user->user['uid']) . ' AND uid_foreign=' . intval($uid);
+                    $mmArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $mmTablename, $where, '', 'tstamp', '1');
+                    $time = time();
 
-					if ($mmArray) {
-						$updateFields = $mmArray['0'];
-						$updateFields['uid_foreign'] = $uid;
-						$updateFields['tstamp'] = $time;
-						$updateFields['qty'] += 1;
-						$GLOBALS['TYPO3_DB']->exec_UPDATEquery($mmTablename, $where, $updateFields);
-					} else {
-						$insertFields = [
-							'tstamp' => $time,
-							'uid_local' => $GLOBALS['TSFE']->fe_user->user['uid'],
-							'uid_foreign' => $uid,
-							'qty' => 1
-						];
-						$GLOBALS['TYPO3_DB']->exec_INSERTquery($mmTablename, $insertFields);
-					}
-				}
-			}
+                    if ($mmArray) {
+                        $updateFields = $mmArray['0'];
+                        $updateFields['uid_foreign'] = $uid;
+                        $updateFields['tstamp'] = $time;
+                        $updateFields['qty'] += 1;
+                        $GLOBALS['TYPO3_DB']->exec_UPDATEquery($mmTablename, $where, $updateFields);
+                    } else {
+                        $insertFields = [
+                            'tstamp' => $time,
+                            'uid_local' => $GLOBALS['TSFE']->fe_user->user['uid'],
+                            'uid_foreign' => $uid,
+                            'qty' => 1
+                        ];
+                        $GLOBALS['TYPO3_DB']->exec_INSERTquery($mmTablename, $insertFields);
+                    }
+                }
+            }
 
-			$tablename = 'sys_products_visited_products';
+            $tablename = 'sys_products_visited_products';
 
-			if ($uid && in_array($tablename, $triggerConf)) {	// check if this trigger has been activated
+            if ($uid && in_array($tablename, $triggerConf)) {	// check if this trigger has been activated
 
-				$where = 'uid=' . intval($uid);
-				$rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $tablename, $where, '', 'tstamp', '1');
-				$time = time();
-				if ($rowArray) {
+                $where = 'uid=' . intval($uid);
+                $rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $tablename, $where, '', 'tstamp', '1');
+                $time = time();
+                if ($rowArray) {
 
-					$updateFields = $rowArray['0'];
-					$updateFields['tstamp'] = $time;
-					$updateFields['qty'] += 1;
-					$GLOBALS['TYPO3_DB']->exec_UPDATEquery($tablename, $where, $updateFields);
-				} else {
-					$insertFields = array (
-						'pid' => $GLOBALS['TSFE']->id,
-						'tstamp' => $time,
-						'uid' => $uid,
-						'qty' => 1
-					);
-					$GLOBALS['TYPO3_DB']->exec_INSERTquery($tablename, $insertFields);
-				}
-			}
-		}
-	} // triggerEvents
+                    $updateFields = $rowArray['0'];
+                    $updateFields['tstamp'] = $time;
+                    $updateFields['qty'] += 1;
+                    $GLOBALS['TYPO3_DB']->exec_UPDATEquery($tablename, $where, $updateFields);
+                } else {
+                    $insertFields = array (
+                        'pid' => $GLOBALS['TSFE']->id,
+                        'tstamp' => $time,
+                        'uid' => $uid,
+                        'qty' => 1
+                    );
+                    $GLOBALS['TYPO3_DB']->exec_INSERTquery($tablename, $insertFields);
+                }
+            }
+        }
+    } // triggerEvents
 }
 
 

--- a/control/class.tx_ttproducts_control_user_int.php
+++ b/control/class.tx_ttproducts_control_user_int.php
@@ -42,16 +42,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_control_user_int implements \TYPO3\CMS\Core\SingletonInterface {
 
-	/**
-	 * Main method for the control object for the single view
-	 */
-	public function singleCtrl ($content,$conf)	{
+    /**
+     * Main method for the control object for the single view
+     */
+    public function singleCtrl ($content,$conf)	{
 
-		$ctrlSingleObj = GeneralUtility::makeInstance('tx_ttproducts_control_single');
-		$ctrlSingleObj->triggerEvents($conf);
+        $ctrlSingleObj = GeneralUtility::makeInstance('tx_ttproducts_control_single');
+        $ctrlSingleObj->triggerEvents($conf);
 
-		return $content;
-	}
+        return $content;
+    }
 
 }
 

--- a/control/class.tx_ttproducts_javascript.php
+++ b/control/class.tx_ttproducts_javascript.php
@@ -42,24 +42,24 @@ use TYPO3\CMS\Core\Utility\PathUtility;
 use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_javascript implements \TYPO3\CMS\Core\SingletonInterface {
-	public $ajax;
-	public $bAjaxAdded;
-	public $bCopyrightShown;
-	public $copyright;
-	public $fixInternetExplorer;
-	private $bIncludedArray = [];
+    public $ajax;
+    public $bAjaxAdded;
+    public $bCopyrightShown;
+    public $copyright;
+    public $fixInternetExplorer;
+    private $bIncludedArray = [];
 
 
-	public function init ($ajax) {
-		if (
-			isset($ajax) &&
-			is_object($ajax)
-		) {
-			$this->ajax = $ajax;
-		}
-		$this->bAjaxAdded = false;
-		$this->bCopyrightShown = false;
-		$this->copyright = '
+    public function init ($ajax) {
+        if (
+            isset($ajax) &&
+            is_object($ajax)
+        ) {
+            $this->ajax = $ajax;
+        }
+        $this->bAjaxAdded = false;
+        $this->bCopyrightShown = false;
+        $this->copyright = '
 /***************************************************************
 *
 *  javascript functions for the TYPO3 Shop System tt_products
@@ -79,7 +79,7 @@ class tx_ttproducts_javascript implements \TYPO3\CMS\Core\SingletonInterface {
 *  This copyright notice MUST APPEAR in all copies of the script
 ***************************************************************/
 ';
-		$this->fixInternetExplorer = '
+        $this->fixInternetExplorer = '
 if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 	Array.prototype.indexOf = function (searchElement /*, fromIndex */ ) {
 		"use strict";
@@ -115,12 +115,12 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 
 	';
 
-	}
+    }
 
-	static public function convertHex ($params) {
-		$result = '\\x' . (ord($params[1]) < 16 ? '0' : '') . dechex(ord($params[1]));
-		return $result;
-	}
+    static public function convertHex ($params) {
+        $result = '\\x' . (ord($params[1]) < 16 ? '0' : '') . dechex(ord($params[1]));
+        return $result;
+    }
 
  /*
  * Escapes strings to be included in javascript
@@ -128,66 +128,66 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
  * @param	[type]		$s: ...
  * @return	[type]		...
  */
-	public function jsspecialchars ($s) {
-		$result = preg_replace_callback(
-			'/([\x09-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/',
-			'tx_ttproducts_javascript::convertHex',
-			$s
-		);
+    public function jsspecialchars ($s) {
+        $result = preg_replace_callback(
+            '/([\x09-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/',
+            'tx_ttproducts_javascript::convertHex',
+            $s
+        );
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/**
-	* Sets JavaScript code in the additionalJavaScript array
-	*
-	* @param		string		  $fieldname is the field in the table you want to create a JavaScript for
-	* @param		array		  category array
-	* @param		integer		  counter
-	* @return	  	void
-	* @see
-	*/
-	public function set (
-		$languageObj,
-		$fieldname,
-		$params = '',
-		$currentRecord = '',
-		$count = 0,
-		$catid = 'cat',
-		$parentFieldArray = [],
-		$piVarArray = [],
-		$fieldArray = [],
-		$method = 'clickShow'
-	) {
-		$bDirectHTML = false;
-		$code = '';
-		$bError = false;
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
+    /**
+    * Sets JavaScript code in the additionalJavaScript array
+    *
+    * @param		string		  $fieldname is the field in the table you want to create a JavaScript for
+    * @param		array		  category array
+    * @param		integer		  counter
+    * @return	  	void
+    * @see
+    */
+    public function set (
+        $languageObj,
+        $fieldname,
+        $params = '',
+        $currentRecord = '',
+        $count = 0,
+        $catid = 'cat',
+        $parentFieldArray = [],
+        $piVarArray = [],
+        $fieldArray = [],
+        $method = 'clickShow'
+    ) {
+        $bDirectHTML = false;
+        $code = '';
+        $bError = false;
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
 
-		if (
-			!$this->bCopyrightShown &&
-			$fieldname != 'xajax'
-		) {
-			$code = $this->copyright;
-			$this->bCopyrightShown = true;
-			$code .= $this->fixInternetExplorer;
-		}
+        if (
+            !$this->bCopyrightShown &&
+            $fieldname != 'xajax'
+        ) {
+            $code = $this->copyright;
+            $this->bCopyrightShown = true;
+            $code .= $this->fixInternetExplorer;
+        }
 
-		if (
-			!is_object($this->ajax) &&
-			in_array($fieldname, ['fetchdata'])
-		) {
-			$fieldname = 'error';
-		}
+        if (
+            !is_object($this->ajax) &&
+            in_array($fieldname, ['fetchdata'])
+        ) {
+            $fieldname = 'error';
+        }
 
-		$JSfieldname = $fieldname;
-		switch ($fieldname) {
-			case 'email' :
-				$message = $languageObj->getLabel('invalid_email');
-				$emailArr =  explode('|', $message);
+        $JSfieldname = $fieldname;
+        switch ($fieldname) {
+            case 'email' :
+                $message = $languageObj->getLabel('invalid_email');
+                $emailArr =  explode('|', $message);
 
-				$code .= '
+                $code .= '
 	var test = function(eing) {
 		var reg = /@/;
 		var rc = true;
@@ -221,38 +221,38 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 		return rc;
 	}
 	';
-				break;
-			case 'selectcat':
-				if (
-					!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT)
-				) {
-					return false;
-				}
+                break;
+            case 'selectcat':
+                if (
+                    !\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT)
+                ) {
+                    return false;
+                }
 
-				$name = 'tt_products[' . $fieldname . ']';
-				if (is_array($params)) {
-					$funcs = count ($params);
-					$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+                $name = 'tt_products[' . $fieldname . ']';
+                if (is_array($params)) {
+                    $funcs = count ($params);
+                    $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-					$ajaxConf = $cnf->getAJAXConf();
-					if (is_array($ajaxConf)) {
-						// TODO: make it possible that AJAX gets all the necessary configuration
-						$code .= '
+                    $ajaxConf = $cnf->getAJAXConf();
+                    if (is_array($ajaxConf)) {
+                        // TODO: make it possible that AJAX gets all the necessary configuration
+                        $code .= '
 		var conf = new Array();';
-						$code .= '
+                        $code .= '
 		';
-						foreach ($ajaxConf as $k => $actConf) {
-							$pVar = GeneralUtility::_GP($k);
-							if (isset($pVar) && is_array($actConf[$pVar . '.'])) {
-								foreach ($actConf[$pVar . '.'] as $k2 => $v2) {
-									$code .= 'conf[' . $k2 . '] = ' . $v2 . '; ';
-								}
-							}
-						}
-						$code .= '
+                        foreach ($ajaxConf as $k => $actConf) {
+                            $pVar = GeneralUtility::_GP($k);
+                            if (isset($pVar) && is_array($actConf[$pVar . '.'])) {
+                                foreach ($actConf[$pVar . '.'] as $k2 => $v2) {
+                                    $code .= 'conf[' . $k2 . '] = ' . $v2 . '; ';
+                                }
+                            }
+                        }
+                        $code .= '
 		';
-					}
-					$code .= 'var c = new Array(); // categories
+                    }
+                    $code .= 'var c = new Array(); // categories
 		var boxCount = ' . $count . '; // number of select boxes
 		var pi = new Array(); // names of pi vars;
 		var selectBoxNames = new Array(); // names of select boxes;
@@ -261,42 +261,42 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 
 		selectBoxNames[0] = "'. $name . '";
 		';
-					foreach ($piVarArray as $fnr => $pivar) {
-						$code .= 'pi[' . $fnr . '] = "' . $pivar . '";';
-					}
-					$code .= '
+                    foreach ($piVarArray as $fnr => $pivar) {
+                        $code .= 'pi[' . $fnr . '] = "' . $pivar . '";';
+                    }
+                    $code .= '
 		';
-					foreach ($params as $fnr => $catArray) {
+                    foreach ($params as $fnr => $catArray) {
                         if (!is_array($catArray)) {
                             continue;
                         }
-						$code .= 'c[' . $fnr . '] = new Array(' . count($catArray) . ');';
-						foreach ($catArray as $k => $row) {
-							$code .= 'c[' . $fnr . '][' . $k . '] = new Array(3);';
-							$code .= 'c[' . $fnr . '][' . $k . '][0] = "' . $this->jsspecialchars($row['title']) . '"; ' ;
-							$parentField = $parentFieldArray[$fnr];
-							$code .= 'c[' . $fnr . '][' . $k . '][1] = "' . intval($row[$parentField]) . '"; ' ;
-							$child_category = $row['child_category'] ?? 0;
-							if (is_array($child_category)) {
-								$code .= 'c[' . $fnr . '][' . $k . '][2] = new Array(' . count($child_category) . ');';
-								$count = 0;
-								foreach ($child_category as $k1 => $childCat) {
-									$newCode = 'c[' . $fnr . '][' . $k . '][2][' . $count . '] = "' . $childCat . '"; ';
-									$code .= $newCode;
-									$count++;
-								}
-							} else {
-								$code .= 'c[' . $fnr . '][' . $k . '][2] = "0"; ' ;
-							}
-							$code .= '
+                        $code .= 'c[' . $fnr . '] = new Array(' . count($catArray) . ');';
+                        foreach ($catArray as $k => $row) {
+                            $code .= 'c[' . $fnr . '][' . $k . '] = new Array(3);';
+                            $code .= 'c[' . $fnr . '][' . $k . '][0] = "' . $this->jsspecialchars($row['title']) . '"; ' ;
+                            $parentField = $parentFieldArray[$fnr];
+                            $code .= 'c[' . $fnr . '][' . $k . '][1] = "' . intval($row[$parentField]) . '"; ' ;
+                            $child_category = $row['child_category'] ?? 0;
+                            if (is_array($child_category)) {
+                                $code .= 'c[' . $fnr . '][' . $k . '][2] = new Array(' . count($child_category) . ');';
+                                $count = 0;
+                                foreach ($child_category as $k1 => $childCat) {
+                                    $newCode = 'c[' . $fnr . '][' . $k . '][2][' . $count . '] = "' . $childCat . '"; ';
+                                    $code .= $newCode;
+                                    $count++;
+                                }
+                            } else {
+                                $code .= 'c[' . $fnr . '][' . $k . '][2] = "0"; ' ;
+                            }
+                            $code .= '
 		';
-						}
-					}
-				}
-				$code .=
-		'
+                        }
+                    }
+                }
+                $code .=
+        '
 		' .
-	'var fillSelect = function(select, id, contentId, showSubCategories) {
+    'var fillSelect = function(select, id, contentId, showSubCategories) {
 		var sb;
 		var sbt;
 		var index;
@@ -410,31 +410,31 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 		data["' . $prefixId . '"]["' . $catid . '"] = category;
 		';
 
-				$contentPiVar = tx_ttproducts_model_control::getPiVar('tt_content');
+                $contentPiVar = tx_ttproducts_model_control::getPiVar('tt_content');
 
-				if ($currentRecord != '') {
-					$code .= '
+                if ($currentRecord != '') {
+                    $code .= '
 		data["' . $prefixId . '"]["' . $contentPiVar . '"] = contentId;
 			';
-				}
+                }
 
-				$code .= '
+                $code .= '
 				';
 
-				if ($method == 'clickShow') {
-					$code .= TT_PRODUCTS_EXT . '_showArticle(data);';
-				}
-				$code .= '
+                if ($method == 'clickShow') {
+                    $code .= TT_PRODUCTS_EXT . '_showArticle(data);';
+                }
+                $code .= '
 		} else {
 			/* nothing */
 		}
 		';
-				$code .= '
+                $code .= '
 		inAction = false;
 		return true;
 	}
 		';
-				$code .= '
+                $code .= '
 	var doFetchData = function(contentId) {
 		var data = new Array();
 		var func;
@@ -473,39 +473,39 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 		}
 
 			';
-				if (
-					$method == 'submitShow'
-				) {
-					$code .= $prefixId . '_showList(data);';
-				}
-				$code .= '
+                if (
+                    $method == 'submitShow'
+                ) {
+                    $code .= $prefixId . '_showList(data);';
+                }
+                $code .= '
 		return true;
 	}
-	'		;
-				break;
+	'        ;
+                break;
 
-			case 'fetchdata':
-				if (
-					!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT) ||
-					!is_array($params)
-				) {
-					return false;
-				}
-				$code .= 'var vBoxCount = new Array(' . count($params) . '); // number of select boxes'.chr(13);
-				$code .= 'var v = new Array(); // variants'.chr(13).chr(13);
-				foreach ($params as $tablename => $selectableVariantFieldArray) {
-					if (is_array($selectableVariantFieldArray)) {
-						$code .= 'vBoxCount["' . $tablename . '"] = ' . (count($selectableVariantFieldArray)) . ';' . chr(13);
-						$code .= 'v["' . $tablename . '"] = new Array(' . count($selectableVariantFieldArray) . ');' . chr(13);
-						$k = 0;
-						foreach ($selectableVariantFieldArray as $variant => $field) {
-							$code .= 'v["' . $tablename . '"][' . $k . '] = "' . str_replace('_', '-', $field)  . '";' . chr(13);
-							$k++;
-						}
-					}
-				}
+            case 'fetchdata':
+                if (
+                    !\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT) ||
+                    !is_array($params)
+                ) {
+                    return false;
+                }
+                $code .= 'var vBoxCount = new Array(' . count($params) . '); // number of select boxes'.chr(13);
+                $code .= 'var v = new Array(); // variants'.chr(13).chr(13);
+                foreach ($params as $tablename => $selectableVariantFieldArray) {
+                    if (is_array($selectableVariantFieldArray)) {
+                        $code .= 'vBoxCount["' . $tablename . '"] = ' . (count($selectableVariantFieldArray)) . ';' . chr(13);
+                        $code .= 'v["' . $tablename . '"] = new Array(' . count($selectableVariantFieldArray) . ');' . chr(13);
+                        $k = 0;
+                        foreach ($selectableVariantFieldArray as $variant => $field) {
+                            $code .= 'v["' . $tablename . '"][' . $k . '] = "' . str_replace('_', '-', $field)  . '";' . chr(13);
+                            $k++;
+                        }
+                    }
+                }
 
-				$code .= '
+                $code .= '
 
 	var doFetchRow = function(table, view, uid) {
 		var data = new Array();
@@ -513,7 +513,7 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 		var temp = table.split("_");
 		var feTable = temp.join("-");';
 
-				$code .= '
+                $code .= '
 		data["view"] = view;
 		data[table] = new Array();
 		data[table]["uid"] = uid;
@@ -548,68 +548,68 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
 		}
 	';
 
-				$code .= '	' . TT_PRODUCTS_EXT . '_fetchRow(data);';
+                $code .= '	' . TT_PRODUCTS_EXT . '_fetchRow(data);';
 
-				$code .= '
+                $code .= '
 		return true;
 	}';
-				break;
+                break;
 
-			case 'direct':
-				if (is_array($params)) {
-					reset($params);
-					$code .= current($params);
-					$JSfieldname = $fieldname . '-' . key($params);
-				}
-				break;
+            case 'direct':
+                if (is_array($params)) {
+                    reset($params);
+                    $code .= current($params);
+                    $JSfieldname = $fieldname . '-' . key($params);
+                }
+                break;
 
-			case 'xajax':
-				// XAJAX part
-				if (
-					!$this->bAjaxAdded &&
-					is_object($this->ajax) &&
-					is_object($this->ajax->taxajax)
-				) {
+            case 'xajax':
+                // XAJAX part
+                if (
+                    !$this->bAjaxAdded &&
+                    is_object($this->ajax) &&
+                    is_object($this->ajax->taxajax)
+                ) {
                     $path =
                         PathUtility::stripPathSitePrefix(
                             \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath(TAXAJAX_EXT)
                         );
-					$code = $this->ajax->taxajax->getJavascript($path);
-					$this->bXajaxAdded = true;
-				}
-				$JSfieldname = 'tx_ttproducts-xajax';
-				$bDirectHTML = true;
-				break;
+                    $code = $this->ajax->taxajax->getJavascript($path);
+                    $this->bXajaxAdded = true;
+                }
+                $JSfieldname = 'tx_ttproducts-xajax';
+                $bDirectHTML = true;
+                break;
 
             case 'colorbox':
-				$JSfieldname = 'tx_ttproducts-colorbox';
-				$colorboxFile = \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(PATH_BE_TTPRODUCTS . 'Resources/Public/JavaScript/tt_products_colorbox.js');
+                $JSfieldname = 'tx_ttproducts-colorbox';
+                $colorboxFile = \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(PATH_BE_TTPRODUCTS . 'Resources/Public/JavaScript/tt_products_colorbox.js');
 
-				FrontendUtility::addJavascriptFile($colorboxFile,
-					$JSfieldname
-				);
-				break;
+                FrontendUtility::addJavascriptFile($colorboxFile,
+                    $JSfieldname
+                );
+                break;
 
-			default:
-				$bError = true;
-				break;
-		} // switch
+            default:
+                $bError = true;
+                break;
+        } // switch
 
-		if (!$bError) {
-			if (
-				$code != '' &&
-				$JSfieldname != ''
-			) {
-				if ($bDirectHTML)	{
+        if (!$bError) {
+            if (
+                $code != '' &&
+                $JSfieldname != ''
+            ) {
+                if ($bDirectHTML)	{
                     $pageRenderer = $this->getPageRenderer();
                     $pageRenderer->addHeaderData($code);
-				} else {
+                } else {
                     $assetCollector = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\AssetCollector::class);
                     $assetCollector->addInlineJavaScript($JSfieldname, $code, [], ['priority' => true]);
-				}
-			}
-		}
-	} // setJS
+                }
+            }
+        }
+    } // setJS
 
     /**
      * @return PageRenderer
@@ -619,14 +619,14 @@ if (!Array.prototype.indexOf) { // published by developer.mozilla.org
         return GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
     }
 
-	public function setIncluded ($filename) {
-		$this->bIncludedArray[$filename] = true;
-	}
+    public function setIncluded ($filename) {
+        $this->bIncludedArray[$filename] = true;
+    }
 
 
-	public function getIncluded ($filename) {
-		return $this->bIncludedArray[$filename];
-	}
+    public function getIncluded ($filename) {
+        return $this->bIncludedArray[$filename];
+    }
 }
 
 

--- a/control/class.tx_ttproducts_main.php
+++ b/control/class.tx_ttproducts_main.php
@@ -46,48 +46,48 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 use JambageCom\TtProducts\Api\PluginApi;
 
 class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
-		// Internal
-	public $uid_list = '';			// List of existing uid's from the basket, set by initBasket()
-	public $orderRecord = [];		// Will hold the order record if fetched.
+        // Internal
+    public $uid_list = '';			// List of existing uid's from the basket, set by initBasket()
+    public $orderRecord = [];		// Will hold the order record if fetched.
 
-		// Internal: init():
-	public $conf;
-	public $tt_product_single = [];
-	public $control;			// object for the control of the application
-	public $singleView;			// single view object
-	public $memoView;			// memo view and data object
+        // Internal: init():
+    public $conf;
+    public $tt_product_single = [];
+    public $control;			// object for the control of the application
+    public $singleView;			// single view object
+    public $memoView;			// memo view and data object
 
-	public $pid;				// the page to which the script shall go
-	public $ajax;				// ajax object
-	public $codeArray;			// Codes
-	public $pageAsCategory;		// > 0 if pages are used as categories
+    public $pid;				// the page to which the script shall go
+    public $ajax;				// ajax object
+    public $codeArray;			// Codes
+    public $pageAsCategory;		// > 0 if pages are used as categories
 
-	protected $bSingleFromList = false;	// if the single view shall be shown instead of a list view
-	public $pibaseClass;			// class of the pibase object
-	/**
-	 * The list of codes that must run uncached. Note that if you combine any
-	 * of these codes with cached codes in TS or flexform, those cached will
-	 * be rendered uncached too! Better insert two or more instances of
-	 * tt_products where cached and uncached codes are separate.
-	 *
-	 * @var array
-	 */
-	static protected $uncachedCodes = [
-		'BASKET',
-		'BILL',
-		'DELIVERY',
-		'FINALIZE',
-		'HELP',
-		'INFO',
-		'MEMO',
-		'MEMODAM',
-		'MEMODAMOVERVIEW',
-		'ORDERS',
-		'OVERVIEW',
-		'PAYMENT',
-		'SEARCH',
-		'TRACKING'
-	];
+    protected $bSingleFromList = false;	// if the single view shall be shown instead of a list view
+    public $pibaseClass;			// class of the pibase object
+    /**
+     * The list of codes that must run uncached. Note that if you combine any
+     * of these codes with cached codes in TS or flexform, those cached will
+     * be rendered uncached too! Better insert two or more instances of
+     * tt_products where cached and uncached codes are separate.
+     *
+     * @var array
+     */
+    static protected $uncachedCodes = [
+        'BASKET',
+        'BILL',
+        'DELIVERY',
+        'FINALIZE',
+        'HELP',
+        'INFO',
+        'MEMO',
+        'MEMODAM',
+        'MEMODAMOVERVIEW',
+        'ORDERS',
+        'OVERVIEW',
+        'PAYMENT',
+        'SEARCH',
+        'TRACKING'
+    ];
 
     public $cObj;
 
@@ -96,881 +96,881 @@ class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * does the initialization stuff
-	 *
-	 * @param	string		content string
-	 * @param	string		configuration array
-	 * @param	string		modified configuration array
-	 * @return	  bool		if true processing should be done
-	 */
-	public function init (
-		&$conf,
-		&$config,
-		&$cObj,
-		$pibaseClass,
-		&$errorCode,
-		$bRunAjax = false
-	) {
-		$result = true;
-		$this->setSingleFromList(false);
-		$this->tt_product_single = [];
+    /**
+     * does the initialization stuff
+     *
+     * @param	string		content string
+     * @param	string		configuration array
+     * @param	string		modified configuration array
+     * @return	  bool		if true processing should be done
+     */
+    public function init (
+        &$conf,
+        &$config,
+        &$cObj,
+        $pibaseClass,
+        &$errorCode,
+        $bRunAjax = false
+    ) {
+        $result = true;
+        $this->setSingleFromList(false);
+        $this->tt_product_single = [];
         $piVars = tx_ttproducts_model_control::getPiVars();
 
-		$pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
+        $pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
 
-		// Save the original flexform in case if we need it later as USER_INT
-		$cObj->data['_original_pi_flexform'] = $cObj->data['pi_flexform'] ?? '';
-		PluginApi::initFlexform($cObj);
+        // Save the original flexform in case if we need it later as USER_INT
+        $cObj->data['_original_pi_flexform'] = $cObj->data['pi_flexform'] ?? '';
+        PluginApi::initFlexform($cObj);
 
-		$flexformArray = PluginApi::getFlexform();
-		$flexformTyposcript = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'myTS');
+        $flexformArray = PluginApi::getFlexform();
+        $flexformTyposcript = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'myTS');
 
-		if($flexformTyposcript) {
-			$tsparser = GeneralUtility::makeInstance(
+        if($flexformTyposcript) {
+            $tsparser = GeneralUtility::makeInstance(
                 \TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class
             );
-			// Copy conf into existing setup
-			$tsparser->setup = $conf;
-			// Parse the new Typoscript
-			$tsparser->parse($flexformTyposcript);
-			// Copy the resulting setup back into conf
-			$conf = $tsparser->setup;
-		}
-		$this->pibaseClass = $pibaseClass;
+            // Copy conf into existing setup
+            $tsparser->setup = $conf;
+            // Parse the new Typoscript
+            $tsparser->parse($flexformTyposcript);
+            // Copy the resulting setup back into conf
+            $conf = $tsparser->setup;
+        }
+        $this->pibaseClass = $pibaseClass;
         $conf['code'] = $conf['code'] ?? '';
         $conf['code.'] = $conf['code.'] ?? [];
 
-		$config['code'] =
+        $config['code'] =
             \JambageCom\Div2007\Utility\ConfigUtility::getSetupOrFFvalue(
-				$cObj,
-	 			$conf['code'],
-	 			$conf['code.'],
-				$conf['defaultCode'],
-				$flexformArray,
-				'display_mode',
-				true
-			);
+                $cObj,
+                $conf['code'],
+                $conf['code.'],
+                $conf['defaultCode'],
+                $flexformArray,
+                'display_mode',
+                true
+            );
 
-		$this->codeArray = GeneralUtility::trimExplode(',', $config['code'], 1);
+        $this->codeArray = GeneralUtility::trimExplode(',', $config['code'], 1);
 
-		$required_pivars =
-			\JambageCom\Div2007\Utility\FlexformUtility::get(
-				$flexformArray,
-				'required_pivars'
-			);
+        $required_pivars =
+            \JambageCom\Div2007\Utility\FlexformUtility::get(
+                $flexformArray,
+                'required_pivars'
+            );
 
-		$requiredArray = GeneralUtility::trimExplode(',', $required_pivars);
+        $requiredArray = GeneralUtility::trimExplode(',', $required_pivars);
 
-		$bDoProcessing = true;
-		if (count($requiredArray)) {
-			foreach ($requiredArray as $k => $pivar) {
-				if ($pivar && $pivar != 'empty') {
-					$gpVar = GeneralUtility::_GP($pivar);
-					if (
-						!isset($piVars[$pivar]) &&
-						!isset($gpVar)
-					) {
-						$bDoProcessing = false;
-						break;
-					}
-				}
-			}
-		}
+        $bDoProcessing = true;
+        if (count($requiredArray)) {
+            foreach ($requiredArray as $k => $pivar) {
+                if ($pivar && $pivar != 'empty') {
+                    $gpVar = GeneralUtility::_GP($pivar);
+                    if (
+                        !isset($piVars[$pivar]) &&
+                        !isset($gpVar)
+                    ) {
+                        $bDoProcessing = false;
+                        break;
+                    }
+                }
+            }
+        }
 
-		if (
-			$bDoProcessing &&
-			(
-				method_exists($cObj, 'getUserObjectType') &&
-				$cObj->getUserObjectType() == TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::OBJECTTYPE_USER
-			)
-		) {
-			$intersection =
-				array_intersect(
-					self::$uncachedCodes,
-					$this->codeArray
-				);
-			if (count($intersection)) {
-				if ($this->convertToUserInt($cObj)) {
+        if (
+            $bDoProcessing &&
+            (
+                method_exists($cObj, 'getUserObjectType') &&
+                $cObj->getUserObjectType() == TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::OBJECTTYPE_USER
+            )
+        ) {
+            $intersection =
+                array_intersect(
+                    self::$uncachedCodes,
+                    $this->codeArray
+                );
+            if (count($intersection)) {
+                if ($this->convertToUserInt($cObj)) {
                     $bDoProcessing = false;
-				}
-			}
-		}
+                }
+            }
+        }
 
-		if (!$bDoProcessing) {
-			return false;
-		}
+        if (!$bDoProcessing) {
+            return false;
+        }
 
-		PluginApi::initUrl(
-			$urlObj,
-			$cObj,
-			$conf
-		);
+        PluginApi::initUrl(
+            $urlObj,
+            $cObj,
+            $conf
+        );
 
-			// initialise AJAX at the beginning because the AJAX functions can set piVars
-		if (!$bRunAjax) {
-			$result = PluginApi::initAjax(
-				$this->ajax,
-				$urlObj,
-				$cObj,
-				$conf['ajaxDebug']
-			);
+            // initialise AJAX at the beginning because the AJAX functions can set piVars
+        if (!$bRunAjax) {
+            $result = PluginApi::initAjax(
+                $this->ajax,
+                $urlObj,
+                $cObj,
+                $conf['ajaxDebug']
+            );
 
-			if (!$result) {
-				return false;
-			}
-		}
+            if (!$result) {
+                return false;
+            }
+        }
 
-		$result = PluginApi::initConfig(
-			$config,
-			$conf,
-			$this->pid,
-			$this->pageAsCategory,
-			$errorCode,
-			$piVars['backPID'] ?? ''
-		);
+        $result = PluginApi::initConfig(
+            $config,
+            $conf,
+            $this->pid,
+            $this->pageAsCategory,
+            $errorCode,
+            $piVars['backPID'] ?? ''
+        );
 
-		if (!$result) {
-			return false;
-		}
+        if (!$result) {
+            return false;
+        }
 
-		// ### central initialization ###
-		if (!$bRunAjax) {
-			$db = GeneralUtility::makeInstance('tx_ttproducts_db');
-			$result =
-				$db->init(
-					$conf,
-					$config,
-					$this->ajax,
-					$pibaseObj,
-					$cObj,
-					$errorCode
-				); // this initializes tx_ttproducts_config inside of creator class tx_ttproducts_model_creator
-		}
+        // ### central initialization ###
+        if (!$bRunAjax) {
+            $db = GeneralUtility::makeInstance('tx_ttproducts_db');
+            $result =
+                $db->init(
+                    $conf,
+                    $config,
+                    $this->ajax,
+                    $pibaseObj,
+                    $cObj,
+                    $errorCode
+                ); // this initializes tx_ttproducts_config inside of creator class tx_ttproducts_model_creator
+        }
 
-		if (!$result) {
-			return false;
-		}
+        if (!$result) {
+            return false;
+        }
 
-		if (!$bRunAjax && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
-			if(!empty($_POST['xajax'])) {
-				global $trans;
-				$trans = $this;
-				$this->ajax->taxajax->processRequests();
-				exit();
-			}
-		}
+        if (!$bRunAjax && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+            if(!empty($_POST['xajax'])) {
+                global $trans;
+                $trans = $this;
+                $this->ajax->taxajax->processRequests();
+                exit();
+            }
+        }
 
-		// *************************************
-		// *** getting configuration values:
-		// *************************************
+        // *************************************
+        // *** getting configuration values:
+        // *************************************
 
-		if ($config['displayCurrentRecord']) {
-			// $config['code']='SINGLE';
-			$row = $cObj->data;
-			$this->tt_product_single['product'] = $row['uid'];
-		} else {
-			$error_detail = '';
-			$paramArray = ['product', 'article', 'dam', 'fal'];
-			$paramVal = '';
+        if ($config['displayCurrentRecord']) {
+            // $config['code']='SINGLE';
+            $row = $cObj->data;
+            $this->tt_product_single['product'] = $row['uid'];
+        } else {
+            $error_detail = '';
+            $paramArray = ['product', 'article', 'dam', 'fal'];
+            $paramVal = '';
 
-			foreach ($paramArray as $param) {
-				$paramVal = ($piVars[$param] ?? '');
-				if ($paramVal) {
-					$bParamValIsInt = MathUtility::canBeInterpretedAsInteger($paramVal);
+            foreach ($paramArray as $param) {
+                $paramVal = ($piVars[$param] ?? '');
+                if ($paramVal) {
+                    $bParamValIsInt = MathUtility::canBeInterpretedAsInteger($paramVal);
 
-					if ($bParamValIsInt) {
-						$this->tt_product_single[$param] = intval($paramVal);
-					} else if (!is_array($paramVal)) {
-						$error_detail = $param;
-						break;
-					}
-				}
-			}
+                    if ($bParamValIsInt) {
+                        $this->tt_product_single[$param] = intval($paramVal);
+                    } else if (!is_array($paramVal)) {
+                        $error_detail = $param;
+                        break;
+                    }
+                }
+            }
 
-			if ($error_detail != '') {
-				$errorCode[0] = 'wrong_' . $error_detail;
-				$errorCode[1] = htmlspecialchars($paramVal);
-				return false;
-			}
-		}
+            if ($error_detail != '') {
+                $errorCode[0] = 'wrong_' . $error_detail;
+                $errorCode[1] = htmlspecialchars($paramVal);
+                return false;
+            }
+        }
 
-		// if t3jquery is loaded and the custom library had been created
-		if (
+        // if t3jquery is loaded and the custom library had been created
+        if (
             defined('T3JQUERY') &&
             T3JQUERY === true
         ) {
-			tx_t3jquery::addJqJS();
-		} else if (!empty($conf['pathToJquery'])) {
-		// if none of the previous is true, you need to include your own library
-			$GLOBALS['TSFE']->additionalHeaderData[TT_PRODUCTS_EXT . '-jquery'] = '<script src="' . GeneralUtility::getFileAbsFileName($conf['pathToJquery']) . '" type="text/javascript" ></script>';
-		}
+            tx_t3jquery::addJqJS();
+        } else if (!empty($conf['pathToJquery'])) {
+        // if none of the previous is true, you need to include your own library
+            $GLOBALS['TSFE']->additionalHeaderData[TT_PRODUCTS_EXT . '-jquery'] = '<script src="' . GeneralUtility::getFileAbsFileName($conf['pathToJquery']) . '" type="text/javascript" ></script>';
+        }
 
-		return $result;
-	} // init
-
-
-	public function destruct () {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$tablesObj->destruct();
-
-		$db = GeneralUtility::makeInstance('tx_ttproducts_db');
-		if (is_object($db)) {
-			$db->destruct();
-		}
-	}
+        return $result;
+    } // init
 
 
-	public function run (&$cObj, $pibaseClass, &$errorCode, $content = '', $bRunAjax = false) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
+    public function destruct () {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tablesObj->destruct();
+
+        $db = GeneralUtility::makeInstance('tx_ttproducts_db');
+        if (is_object($db)) {
+            $db->destruct();
+        }
+    }
+
+
+    public function run (&$cObj, $pibaseClass, &$errorCode, $content = '', $bRunAjax = false) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
         $piVars = tx_ttproducts_model_control::getPiVars();
         $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
 
-		if (!empty($conf['no_cache']) && $this->convertToUserInt($cObj)) {
-			// Compatibility with previous versions where users could set
-			// 'no_cache' TS option. This option does not exist anymore and we
-			// simply convert the plugin to USER_INT if that old option is set.
-			return false;
-		}
+        if (!empty($conf['no_cache']) && $this->convertToUserInt($cObj)) {
+            // Compatibility with previous versions where users could set
+            // 'no_cache' TS option. This option does not exist anymore and we
+            // simply convert the plugin to USER_INT if that old option is set.
+            return false;
+        }
 
-		$bStoreBasket = true;
-		$errorMessage = '';
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-		$showAmount = $cnf->getBasketConf('view', 'showAmount');
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $bStoreBasket = true;
+        $errorMessage = '';
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+        $showAmount = $cnf->getBasketConf('view', 'showAmount');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
 
-		if (!count($this->codeArray) && !$bRunAjax) {
-			$this->codeArray = ['HELP'];
-		}
+        if (!count($this->codeArray) && !$bRunAjax) {
+            $this->codeArray = ['HELP'];
+        }
 
-		if ((\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax'))) {
-			if ($bRunAjax) {
-				// TODO: get AJAX configuration
-			} else {
-				$javaScriptObj->set($languageObj, 'xajax');
-			}
-		}
-		$updateMode = 0;
-		if (GeneralUtility::_GP('mode_update')) {
-			$updateMode = 1;
-		}
+        if ((\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax'))) {
+            if ($bRunAjax) {
+                // TODO: get AJAX configuration
+            } else {
+                $javaScriptObj->set($languageObj, 'xajax');
+            }
+        }
+        $updateMode = 0;
+        if (GeneralUtility::_GP('mode_update')) {
+            $updateMode = 1;
+        }
 
-		if (
-			(
-				isset($conf['basket.']) &&
-				$conf['basket.']['store'] == '0'
-			) ||
-			(
-				count($this->codeArray) == 1 &&
-				$this->codeArray[0] == 'OVERVIEW' &&
-				isset($conf['basket.']) &&
-				isset($conf['basket.']['activity.']) &&
-				isset($conf['basket.']['activity.']['overview.']) &&
-				$conf['basket.']['activity.']['overview.']['store'] == '0'
-			)
-		) {
-			$bStoreBasket = false;
-		}
+        if (
+            (
+                isset($conf['basket.']) &&
+                $conf['basket.']['store'] == '0'
+            ) ||
+            (
+                count($this->codeArray) == 1 &&
+                $this->codeArray[0] == 'OVERVIEW' &&
+                isset($conf['basket.']) &&
+                isset($conf['basket.']['activity.']) &&
+                isset($conf['basket.']['activity.']['overview.']) &&
+                $conf['basket.']['activity.']['overview.']['store'] == '0'
+            )
+        ) {
+            $bStoreBasket = false;
+        }
 
-		tx_ttproducts_control_basket::doProcessing();
+        tx_ttproducts_control_basket::doProcessing();
 
-		$basketObj->init(
-			$pibaseClass,
-			$updateMode,
-			$bStoreBasket
-		);
+        $basketObj->init(
+            $pibaseClass,
+            $updateMode,
+            $bStoreBasket
+        );
 
-		// *************************************
-		// *** Listing items:
-		// *************************************
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
-		$basketRecs = tx_ttproducts_control_basket::getRecs();
+        // *************************************
+        // *** Listing items:
+        // *************************************
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $basketRecs = tx_ttproducts_control_basket::getRecs();
         $basketObj->create(
-			'BASKET',
-			$basketExt,
-			$basketExtra,
-			$basketRecs,
-			$conf['useArticles'],
-			$conf['priceTAXnotVarying'],
-			tx_ttproducts_control_basket::getFuncTablename()
-		);
+            'BASKET',
+            $basketExt,
+            $basketExtra,
+            $basketRecs,
+            $conf['useArticles'],
+            $conf['priceTAXnotVarying'],
+            tx_ttproducts_control_basket::getFuncTablename()
+        );
 
-		$itemArray = $basketObj->getItemArray();
-		$basketObj->calculate($itemArray); // get the calculated arrays
-		$basketObj->setItemArray($itemArray);
+        $itemArray = $basketObj->getItemArray();
+        $basketObj->calculate($itemArray); // get the calculated arrays
+        $basketObj->setItemArray($itemArray);
 
-		$voucher = $tablesObj->get('voucher');
-		if (is_object($voucher) && $voucher->isEnabled()) {
-			$recs = tx_ttproducts_control_basket::getRecs();
-			$voucher->doProcessing($recs);
-		}
+        $voucher = $tablesObj->get('voucher');
+        if (is_object($voucher) && $voucher->isEnabled()) {
+            $recs = tx_ttproducts_control_basket::getRecs();
+            $voucher->doProcessing($recs);
+        }
 
-		$basketObj->calculateSums();
-		$basketObj->addVoucherSums();
-		$templateFile = '';
-		$templateCode = '';
+        $basketObj->calculateSums();
+        $basketObj->addVoucherSums();
+        $templateFile = '';
+        $templateCode = '';
 
-		if (!$errorMessage && !count($errorCode)) {
-			$functablename = 'tt_products';
-			tx_ttproducts_control_memo::process(
-				$functablename,
-				$piVars,
-				$conf
-			);
+        if (!$errorMessage && !count($errorCode)) {
+            $functablename = 'tt_products';
+            tx_ttproducts_control_memo::process(
+                $functablename,
+                $piVars,
+                $conf
+            );
 
-			$controlObj = GeneralUtility::makeInstance('tx_ttproducts_control');
-			$controlObj->init(
-				$pibaseClass,
-				tx_ttproducts_control_basket::getFuncTablename(),
-				$conf['useArticles'],
-				$errorCode
-			);
+            $controlObj = GeneralUtility::makeInstance('tx_ttproducts_control');
+            $controlObj->init(
+                $pibaseClass,
+                tx_ttproducts_control_basket::getFuncTablename(),
+                $conf['useArticles'],
+                $errorCode
+            );
 
-			if ($errorCode) {
+            if ($errorCode) {
                 $errorText =
-					$languageObj->getLabel(
-						'no_template'
-					);
-				$errorMessage = str_replace('|', 'plugin.tt_products.templateFile', $errorText);
-			}
+                    $languageObj->getLabel(
+                        'no_template'
+                    );
+                $errorMessage = str_replace('|', 'plugin.tt_products.templateFile', $errorText);
+            }
 
-			$addressArray = [];
-			$addressObj = $tablesObj->get('address', false);
-			if (is_object($addressObj)) {
-				$addressArray = $addressObj->fetchAddressArray($itemArray);
-			}
-			$content .= $controlObj->doProcessing(
-				$this->codeArray,
-				$basketObj->getCalculatedSums(),
-				$basketExtra,
-				$basketRecs,
-				$basketExt,
-				$addressArray,
-				$errorCode,
-				$errorMessage
-			);
-		}
+            $addressArray = [];
+            $addressObj = $tablesObj->get('address', false);
+            if (is_object($addressObj)) {
+                $addressArray = $addressObj->fetchAddressArray($itemArray);
+            }
+            $content .= $controlObj->doProcessing(
+                $this->codeArray,
+                $basketObj->getCalculatedSums(),
+                $basketExtra,
+                $basketRecs,
+                $basketExt,
+                $addressArray,
+                $errorCode,
+                $errorMessage
+            );
+        }
 
-		$bErrorFound = false;
-		$contentBasket = $content;
-		$content = '';
-		$tableArray = array_keys($tablesObj->getTableClassArray());
+        $bErrorFound = false;
+        $contentBasket = $content;
+        $content = '';
+        $tableArray = array_keys($tablesObj->getTableClassArray());
 
-		foreach($this->codeArray as $theCode) {
-			$theCode = (string) trim($theCode);
-			$contentTmp = '';
-			if ($conf['fe']) {
-				$templateCode =
-					$templateObj->get(
-						$theCode,
-						$templateFile,
-						$errorCode
-					);
-			}
-			if ($errorMessage || !empty($errorCode)) {
+        foreach($this->codeArray as $theCode) {
+            $theCode = (string) trim($theCode);
+            $contentTmp = '';
+            if ($conf['fe']) {
+                $templateCode =
+                    $templateObj->get(
+                        $theCode,
+                        $templateFile,
+                        $errorCode
+                    );
+            }
+            if ($errorMessage || !empty($errorCode)) {
                 $bErrorFound = true;
-			}
+            }
 
-			$bHidePlugin = false;
+            $bHidePlugin = false;
 
-			foreach($tableArray as $functablename) {
-				$tableConf = $cnf->getTableConf($functablename, $theCode);
-				if (!empty($tableConf)) {
-					$hideIds = '';
-					$hideChildless = false;
-					$hideZero = false;
+            foreach($tableArray as $functablename) {
+                $tableConf = $cnf->getTableConf($functablename, $theCode);
+                if (!empty($tableConf)) {
+                    $hideIds = '';
+                    $hideChildless = false;
+                    $hideZero = false;
 
-					if (isset($tableConf['hideID'])) {
-						$hideIds = $tableConf['hideID'];
-					}
+                    if (isset($tableConf['hideID'])) {
+                        $hideIds = $tableConf['hideID'];
+                    }
 
-					if ($functablename == 'tt_products_cat') {
-						if (isset($tableConf['hideChildless'])) {
-							$hideChildless = (boolean) $tableConf['hideChildless'];
-						}
-						if (isset($tableConf['hideZero'])) {
-							$hideZero = (boolean) $tableConf['hideZero'];
-						}
-					}
+                    if ($functablename == 'tt_products_cat') {
+                        if (isset($tableConf['hideChildless'])) {
+                            $hideChildless = (boolean) $tableConf['hideChildless'];
+                        }
+                        if (isset($tableConf['hideZero'])) {
+                            $hideZero = (boolean) $tableConf['hideZero'];
+                        }
+                    }
 
-					if (
-						$hideIds != '' ||
-						$hideChildless ||
-						$hideZero
-					) {
-						$hideIdArray = GeneralUtility::trimExplode(',', $hideIds);
-						$piVar = tx_ttproducts_model_control::getPiVar($functablename);
+                    if (
+                        $hideIds != '' ||
+                        $hideChildless ||
+                        $hideZero
+                    ) {
+                        $hideIdArray = GeneralUtility::trimExplode(',', $hideIds);
+                        $piVar = tx_ttproducts_model_control::getPiVar($functablename);
 
-						if (isset($piVars[$piVar])) {
-							$currentArray = GeneralUtility::trimExplode(',', $piVars[$piVar]);
-						} else {
-							$currentArray = ['0'];
-						}
+                        if (isset($piVars[$piVar])) {
+                            $currentArray = GeneralUtility::trimExplode(',', $piVars[$piVar]);
+                        } else {
+                            $currentArray = ['0'];
+                        }
 
-						if ($hideIds != '') {
-							$hideCurrentArray = array_diff($currentArray, $hideIdArray);
-							if (count($hideCurrentArray) < count($currentArray)) {
-								$bHidePlugin = true;
-							}
-						}
+                        if ($hideIds != '') {
+                            $hideCurrentArray = array_diff($currentArray, $hideIdArray);
+                            if (count($hideCurrentArray) < count($currentArray)) {
+                                $bHidePlugin = true;
+                            }
+                        }
 
-						if (!$bHidePlugin) {
-							if (isset($piVars[$piVar])) {
-								if ($hideChildless) {
-									$categoryfunctablename = 'tt_products_cat';
-									$categoryTable = $tablesObj->get($categoryfunctablename, false);
-									foreach ($currentArray as $currentUid) {
-										$childs =
-											$categoryTable->getAllChildCats (
-												$config['pid_list'],
-												'',
-												$currentUid
-											);
-										if ($childs == '') {
-											$bHidePlugin = true;
-											break;
-										}
-									}
-								}
-							} else {
-								if ($hideZero) {
-									$bHidePlugin = true;
-								}
-							}
-						}
-					}
-				}
-			}
+                        if (!$bHidePlugin) {
+                            if (isset($piVars[$piVar])) {
+                                if ($hideChildless) {
+                                    $categoryfunctablename = 'tt_products_cat';
+                                    $categoryTable = $tablesObj->get($categoryfunctablename, false);
+                                    foreach ($currentArray as $currentUid) {
+                                        $childs =
+                                            $categoryTable->getAllChildCats (
+                                                $config['pid_list'],
+                                                '',
+                                                $currentUid
+                                            );
+                                        if ($childs == '') {
+                                            $bHidePlugin = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            } else {
+                                if ($hideZero) {
+                                    $bHidePlugin = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			if ($bHidePlugin) {
-				continue;
-			}
+            if ($bHidePlugin) {
+                continue;
+            }
 
-			switch($theCode) {
+            switch($theCode) {
                 case 'CONTROL': // this will come with tt_products 3.1
                     continue 2;
                     break;
-				case 'SEARCH':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					// no break!
-				case 'LIST':
-				case 'LISTAFFORDABLE':
-				case 'LISTARTICLES':
-				case 'LISTDAM':
-				case 'LISTGIFTS':
-				case 'LISTHIGHLIGHTS':
-				case 'LISTNEWITEMS':
-				case 'LISTOFFERS':
-				case 'LISTORDERED':
-				case 'LISTVIEWEDITEMS':
-				case 'LISTVIEWEDMOST':
-				case 'LISTVIEWEDMOSTOTHERS':
-					if (
-						count($this->tt_product_single) &&
-						!$conf['NoSingleViewOnList']
-					) {
-						if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-							return '';
-						}
-					}
+                case 'SEARCH':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    // no break!
+                case 'LIST':
+                case 'LISTAFFORDABLE':
+                case 'LISTARTICLES':
+                case 'LISTDAM':
+                case 'LISTGIFTS':
+                case 'LISTHIGHLIGHTS':
+                case 'LISTNEWITEMS':
+                case 'LISTOFFERS':
+                case 'LISTORDERED':
+                case 'LISTVIEWEDITEMS':
+                case 'LISTVIEWEDMOST':
+                case 'LISTVIEWEDMOSTOTHERS':
+                    if (
+                        count($this->tt_product_single) &&
+                        !$conf['NoSingleViewOnList']
+                    ) {
+                        if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                            return '';
+                        }
+                    }
 
-					$contentTmp =
-						$this->products_display(
-							$cObj,
-							$basketExtra,
-							$basketRecs,
-							$templateCode,
-							$theCode,
-							$errorMessage,
-							$errorCode
-						);
-				break;
-				case 'LISTCAT':
-				case 'LISTDAMCAT':
-				case 'LISTAD':
-				case 'MENUCAT':
-				case 'MENUDAMCAT':
-				case 'MENUAD':
-				case 'SELECTCAT':
-				case 'SELECTDAMCAT':
-				case 'SELECTAD':
-					$codeTemplateArray = [
-						'SELECTCAT' => 'ITEM_CATEGORY_SELECT_TEMPLATE',
-						'SELECTDAMCAT' => 'ITEM_DAMCATSELECT_TEMPLATE',
-						'SELECTAD' => 'ITEM_ADDRESS_SELECT_TEMPLATE',
-						'LISTCAT' => 'ITEM_CATLIST_TEMPLATE',
-						'LISTDAMCAT' => 'ITEM_DAMCATLIST_TEMPLATE',
-						'LISTAD' => 'ITEM_ADLIST_TEMPLATE',
-						'MENUCAT' => 'ITEM_CATEGORY_MENU_TEMPLATE',
-						'MENUDAMCAT' => 'ITEM_DAMCATMENU_TEMPLATE',
-						'MENUAD' => 'ITEM_ADDRESS_MENU_TEMPLATE',
-					];
-
-					if (substr($theCode, -2, 2) == 'AD') {
-						$tablename = '';
-						$functablename = 'address';
-						if (is_array($conf['table.'])) {
-							$tablename = $conf['table.'][$functablename];
-						}
-
-						if (!isset($GLOBALS['TCA'][$tablename]['columns'])) {
-							GeneralUtility::loadTCA($tablename);
-						}
-
-						$addressExtKeyTable = tx_ttproducts_control_address::getAddressExtKeyTable();
-
-						if (
-							isset($addressExtKeyTable[$tablename]) &&
-							!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($addressExtKeyTable[$tablename])
-						) {
-							$languageObj->getLabel('extension_missing');
-							$messageArr =  explode('|', $message);
-							$errorMessage = $messageArr[0] . $addressExtKeyTable[$tablename] . $messageArr[1];
-						} else if (!$tablename) {
-							$message = $languageObj->getLabel('setup_missing');
-							$messageArr =  explode('|', $message);
-							$errorMessage = $messageArr[0] . 'table.address' . $messageArr[1];
-						}
-					} else if (substr($theCode, -6, 6) == 'DAMCAT') {
-						$functablename = 'tx_dam_cat';
-					} else if (substr($theCode, -3, 3) == 'CAT') {
-						if ($this->pageAsCategory)	{
-							$functablename = 'pages';
-						} else {
-							$functablename = 'tt_products_cat';
-						}
-					}
-
-					if (!$errorMessage) {
-						$templateArea = $codeTemplateArray[$theCode];
-						if (substr($theCode, 0, 6) == 'SELECT') {
-							$categoryClass = 'tx_ttproducts_selectcat_view';
-						} else if (substr($theCode, 0, 4) == 'LIST') {
-							$categoryClass = 'tx_ttproducts_catlist_view';
-						} else if (substr($theCode, 0, 4) == 'MENU') {
-							$categoryClass = 'tx_ttproducts_menucat_view';
-						}
-
-							// category view
-						$categoryView = GeneralUtility::makeInstance($categoryClass);
-						$categoryView->init(
+                    $contentTmp =
+                        $this->products_display(
                             $cObj,
-							$pibaseClass,
-							$config['pid_list'],
-							$config['recursive'],
-							$this->pid
-						);
+                            $basketExtra,
+                            $basketRecs,
+                            $templateCode,
+                            $theCode,
+                            $errorMessage,
+                            $errorCode
+                        );
+                break;
+                case 'LISTCAT':
+                case 'LISTDAMCAT':
+                case 'LISTAD':
+                case 'MENUCAT':
+                case 'MENUDAMCAT':
+                case 'MENUAD':
+                case 'SELECTCAT':
+                case 'SELECTDAMCAT':
+                case 'SELECTAD':
+                    $codeTemplateArray = [
+                        'SELECTCAT' => 'ITEM_CATEGORY_SELECT_TEMPLATE',
+                        'SELECTDAMCAT' => 'ITEM_DAMCATSELECT_TEMPLATE',
+                        'SELECTAD' => 'ITEM_ADDRESS_SELECT_TEMPLATE',
+                        'LISTCAT' => 'ITEM_CATLIST_TEMPLATE',
+                        'LISTDAMCAT' => 'ITEM_DAMCATLIST_TEMPLATE',
+                        'LISTAD' => 'ITEM_ADLIST_TEMPLATE',
+                        'MENUCAT' => 'ITEM_CATEGORY_MENU_TEMPLATE',
+                        'MENUDAMCAT' => 'ITEM_DAMCATMENU_TEMPLATE',
+                        'MENUAD' => 'ITEM_ADDRESS_MENU_TEMPLATE',
+                    ];
 
-						$contentTmp = $categoryView->printView(
-							$functablename,
-							$templateCode,
-							$theCode,
-							$errorCode,
-							$templateArea,
-							$this->pageAsCategory,
-							$config['templateSuffix'],
-							$basketExtra,
-							$basketRecs
-						);
-					}
-				break;
-				case 'SINGLE':
-					$contentTmp =
-						$this->products_display(
-							$cObj,
-							$basketExtra,
-							$basketRecs,
-							$templateCode,
-							$theCode,
-							$errorMessage,
-							$errorCode
-						);
-				break;
-				case 'BASKET':
-				case 'FINALIZE':
-				case 'INFO':
-				case 'PAYMENT':
-				case 'OVERVIEW':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					$contentTmp = $contentBasket;
-					$contentBasket = '';
-						// nothing here any more. This work is done in the control processing before
-						// This line is necessary because some activities might have overriden these CODEs
-					break;
-				case 'BILL':
-				case 'DELIVERY':
-				case 'TRACKING':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					$contentTmp =
-						$this->products_tracking(
-							$errorCode,
-							$templateCode,
-							$theCode,
-							$conf
-						);
-				break;
-				case 'MEMO':
-				case 'MEMODAM':
-				case 'MEMODAMOVERVIEW':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					// memo view: has to be called always because it reads parameters from the list
-					$this->memoView = GeneralUtility::makeInstance('tx_ttproducts_memo_view');
-					$this->memoView->init(
-						$theCode,
-						$config['pid_list'],
-						$conf,
-						$conf['useArticles']
-					);
-					$contentTmp =
-						$this->memoView->printView(
-							$templateCode,
-							$theCode,
-							$conf,
-							$this->pid,
-							$errorCode
-						);
-				break;
-				case 'DOWNLOAD':
-					tx_ttproducts_control_access::getVariables(
-						$conf,
-						$updateCode,
-						$bIsAllowed,
-						$bValidUpdateCode,
-						$trackingCode
-					);
+                    if (substr($theCode, -2, 2) == 'AD') {
+                        $tablename = '';
+                        $functablename = 'address';
+                        if (is_array($conf['table.'])) {
+                            $tablename = $conf['table.'][$functablename];
+                        }
 
-					tx_ttproducts_control_command::doProcessing(
-						$theCode,
-						$conf,
-						$bIsAllowed,
-						$bValidUpdateCode,
-						$trackingCode,
-						$config['pid_list'],
-						$config['recursive']
-					);
+                        if (!isset($GLOBALS['TCA'][$tablename]['columns'])) {
+                            GeneralUtility::loadTCA($tablename);
+                        }
+
+                        $addressExtKeyTable = tx_ttproducts_control_address::getAddressExtKeyTable();
+
+                        if (
+                            isset($addressExtKeyTable[$tablename]) &&
+                            !\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($addressExtKeyTable[$tablename])
+                        ) {
+                            $languageObj->getLabel('extension_missing');
+                            $messageArr =  explode('|', $message);
+                            $errorMessage = $messageArr[0] . $addressExtKeyTable[$tablename] . $messageArr[1];
+                        } else if (!$tablename) {
+                            $message = $languageObj->getLabel('setup_missing');
+                            $messageArr =  explode('|', $message);
+                            $errorMessage = $messageArr[0] . 'table.address' . $messageArr[1];
+                        }
+                    } else if (substr($theCode, -6, 6) == 'DAMCAT') {
+                        $functablename = 'tx_dam_cat';
+                    } else if (substr($theCode, -3, 3) == 'CAT') {
+                        if ($this->pageAsCategory)	{
+                            $functablename = 'pages';
+                        } else {
+                            $functablename = 'tt_products_cat';
+                        }
+                    }
+
+                    if (!$errorMessage) {
+                        $templateArea = $codeTemplateArray[$theCode];
+                        if (substr($theCode, 0, 6) == 'SELECT') {
+                            $categoryClass = 'tx_ttproducts_selectcat_view';
+                        } else if (substr($theCode, 0, 4) == 'LIST') {
+                            $categoryClass = 'tx_ttproducts_catlist_view';
+                        } else if (substr($theCode, 0, 4) == 'MENU') {
+                            $categoryClass = 'tx_ttproducts_menucat_view';
+                        }
+
+                            // category view
+                        $categoryView = GeneralUtility::makeInstance($categoryClass);
+                        $categoryView->init(
+                            $cObj,
+                            $pibaseClass,
+                            $config['pid_list'],
+                            $config['recursive'],
+                            $this->pid
+                        );
+
+                        $contentTmp = $categoryView->printView(
+                            $functablename,
+                            $templateCode,
+                            $theCode,
+                            $errorCode,
+                            $templateArea,
+                            $this->pageAsCategory,
+                            $config['templateSuffix'],
+                            $basketExtra,
+                            $basketRecs
+                        );
+                    }
+                break;
+                case 'SINGLE':
+                    $contentTmp =
+                        $this->products_display(
+                            $cObj,
+                            $basketExtra,
+                            $basketRecs,
+                            $templateCode,
+                            $theCode,
+                            $errorMessage,
+                            $errorCode
+                        );
+                break;
+                case 'BASKET':
+                case 'FINALIZE':
+                case 'INFO':
+                case 'PAYMENT':
+                case 'OVERVIEW':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    $contentTmp = $contentBasket;
+                    $contentBasket = '';
+                        // nothing here any more. This work is done in the control processing before
+                        // This line is necessary because some activities might have overriden these CODEs
+                    break;
+                case 'BILL':
+                case 'DELIVERY':
+                case 'TRACKING':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    $contentTmp =
+                        $this->products_tracking(
+                            $errorCode,
+                            $templateCode,
+                            $theCode,
+                            $conf
+                        );
+                break;
+                case 'MEMO':
+                case 'MEMODAM':
+                case 'MEMODAMOVERVIEW':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    // memo view: has to be called always because it reads parameters from the list
+                    $this->memoView = GeneralUtility::makeInstance('tx_ttproducts_memo_view');
+                    $this->memoView->init(
+                        $theCode,
+                        $config['pid_list'],
+                        $conf,
+                        $conf['useArticles']
+                    );
+                    $contentTmp =
+                        $this->memoView->printView(
+                            $templateCode,
+                            $theCode,
+                            $conf,
+                            $this->pid,
+                            $errorCode
+                        );
+                break;
+                case 'DOWNLOAD':
+                    tx_ttproducts_control_access::getVariables(
+                        $conf,
+                        $updateCode,
+                        $bIsAllowed,
+                        $bValidUpdateCode,
+                        $trackingCode
+                    );
+
+                    tx_ttproducts_control_command::doProcessing(
+                        $theCode,
+                        $conf,
+                        $bIsAllowed,
+                        $bValidUpdateCode,
+                        $trackingCode,
+                        $config['pid_list'],
+                        $config['recursive']
+                    );
                     $onlyProductsWithFalOrders = $conf['downloadViewOnlyProductsFal'];
 
-						// order view
-					$orderView = $tablesObj->get('sys_products_orders', true);
-					$contentTmp = $orderView->printDownloadView(
-						$pibaseClass,
-						$templateCode,
-						$theCode,
-						$config['pid_list'],
-						$config['recursive'],
-						$this->pageAsCategory,
-						$updateCode,
-						$bIsAllowed,
-						$bValidUpdateCode,
-						$trackingCode,
-						$onlyProductsWithFalOrders,
-						$errorCode
-					);
-				break;
-				case 'ORDERS':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					tx_ttproducts_control_access::getVariables(
-						$conf,
-						$updateCode,
-						$bIsAllowed,
-						$bValidUpdateCode,
-						$trackingCode
-					);
+                        // order view
+                    $orderView = $tablesObj->get('sys_products_orders', true);
+                    $contentTmp = $orderView->printDownloadView(
+                        $pibaseClass,
+                        $templateCode,
+                        $theCode,
+                        $config['pid_list'],
+                        $config['recursive'],
+                        $this->pageAsCategory,
+                        $updateCode,
+                        $bIsAllowed,
+                        $bValidUpdateCode,
+                        $trackingCode,
+                        $onlyProductsWithFalOrders,
+                        $errorCode
+                    );
+                break;
+                case 'ORDERS':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    tx_ttproducts_control_access::getVariables(
+                        $conf,
+                        $updateCode,
+                        $bIsAllowed,
+                        $bValidUpdateCode,
+                        $trackingCode
+                    );
 
-						// order view
-					$orderView = $tablesObj->get('sys_products_orders', true);
-					$contentTmp = $orderView->printView(
-						$pibaseClass,
-						$templateCode,
-						$theCode,
-						$config['pid_list'],
-						$config['recursive'],
-						$this->pageAsCategory,
-						$updateCode,
-						$bIsAllowed,
-						$bValidUpdateCode,
-						$trackingCode,
-						$errorCode
-					);
-				break;
-				case 'SINGLECAT':
-				case 'SINGLEDAMCAT':
-				case 'SINGLEAD':
-					$catView = GeneralUtility::makeInstance('tx_ttproducts_cat_view');
-					$catView->init(
-						$pibaseObj,
-						$this->pid,
-						$config['pid_list'],
-						$config['recursive']
-					);
-					$tableInfoArray = ['SINGLECAT' => 'tt_products_cat', 'SINGLEDAMCAT' => 'tx_dam_cat', 'SINGLEAD' => 'address'];
-					$functablename = $tableInfoArray[$theCode];
-					$uid = $piVars[tx_ttproducts_model_control::getPivar($functablename)];
+                        // order view
+                    $orderView = $tablesObj->get('sys_products_orders', true);
+                    $contentTmp = $orderView->printView(
+                        $pibaseClass,
+                        $templateCode,
+                        $theCode,
+                        $config['pid_list'],
+                        $config['recursive'],
+                        $this->pageAsCategory,
+                        $updateCode,
+                        $bIsAllowed,
+                        $bValidUpdateCode,
+                        $trackingCode,
+                        $errorCode
+                    );
+                break;
+                case 'SINGLECAT':
+                case 'SINGLEDAMCAT':
+                case 'SINGLEAD':
+                    $catView = GeneralUtility::makeInstance('tx_ttproducts_cat_view');
+                    $catView->init(
+                        $pibaseObj,
+                        $this->pid,
+                        $config['pid_list'],
+                        $config['recursive']
+                    );
+                    $tableInfoArray = ['SINGLECAT' => 'tt_products_cat', 'SINGLEDAMCAT' => 'tx_dam_cat', 'SINGLEAD' => 'address'];
+                    $functablename = $tableInfoArray[$theCode];
+                    $uid = $piVars[tx_ttproducts_model_control::getPivar($functablename)];
 
-					if ($uid) {
-						$contentTmp = $catView->printView(
-							$templateCode,
-							$functablename,
-							$uid,
-							$theCode,
-							$errorCode,
-							$config['templateSuffix']
-						);
-					}
-				break;
-				case 'SCRIPT':
-					$contentTmp = '';
-				break;
-				case 'TEST':
-					$contentTmp = '';
+                    if ($uid) {
+                        $contentTmp = $catView->printView(
+                            $templateCode,
+                            $functablename,
+                            $uid,
+                            $theCode,
+                            $errorCode,
+                            $config['templateSuffix']
+                        );
+                    }
+                break;
+                case 'SCRIPT':
+                    $contentTmp = '';
+                break;
+                case 'TEST':
+                    $contentTmp = '';
 
-					$test = 0;
-					if (!$test) continue 2;
+                    $test = 0;
+                    if (!$test) continue 2;
 
-					$scriptPath = '';
-					$defaultSettings = [];
+                    $scriptPath = '';
+                    $defaultSettings = [];
 
-					$buildScriptOptions = $defaultSettings;
-					$paramString = '';
-					foreach($buildScriptOptions as $param => $value) {
-						if(strlen($value) > 0) {
-							$value = '"' . $value . '"';
-						}
-						$paramsString .= ' ' . $param . ' ' . $value;
-					}
+                    $buildScriptOptions = $defaultSettings;
+                    $paramString = '';
+                    foreach($buildScriptOptions as $param => $value) {
+                        if(strlen($value) > 0) {
+                            $value = '"' . $value . '"';
+                        }
+                        $paramsString .= ' ' . $param . ' ' . $value;
+                    }
 
-					$outputPath = GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT');
-					$outputPath .= '/typo3temp/tt_products/';
-					$filename = $outputPath . 'testseite.pdf';
+                    $outputPath = GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT');
+                    $outputPath .= '/typo3temp/tt_products/';
+                    $filename = $outputPath . 'testseite.pdf';
 
-					$urls = ['https://demosite.jambage.com/index.php?id=5'];
-					$scriptCall =
-						$scriptPath . 'wkhtmltopdf ' .
-							$paramsString . ' ' .
-							implode(' ', $urls) . ' ' .
-							$filename .
-							' 2>&1';
+                    $urls = ['https://demosite.jambage.com/index.php?id=5'];
+                    $scriptCall =
+                        $scriptPath . 'wkhtmltopdf ' .
+                            $paramsString . ' ' .
+                            implode(' ', $urls) . ' ' .
+                            $filename .
+                            ' 2>&1';
 
-					$commandOut = exec($scriptCall, $output);
-					$contentTmp = '<br>TEST:' . $scriptCall . '</br><br/><br>' . $commandOut . '<br/>';
+                    $commandOut = exec($scriptCall, $output);
+                    $contentTmp = '<br>TEST:' . $scriptCall . '</br><br/><br>' . $commandOut . '<br/>';
 
-						// Call all test hooks
-					if (
+                        // Call all test hooks
+                    if (
                         isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['test']) &&
                         is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['test'])
                     ) {
-						foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['test'] as $classRef) {
-							if (count($errorCode)) {
-								break;
-							}
-							$hookObj= GeneralUtility::makeInstance($classRef);
-							if (method_exists($hookObj, 'test')) {
-								$contentTmp .= $hookObj->test(
-									$this,
-									$cObj,
-									$pibaseClass,
-									$basketObj,
-									$controlObj,
-									$errorCode,
-									$errorMessage,
-									$content,
-									$contentTmp,
-									$bRunAjax
-								);
-							}
-						}
-					}
-				break;
-				case 'USER1':
-				case 'USER2':
-				case 'USER3':
-				case 'USER4':
-				case 'USER5':
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					$viewObj = GeneralUtility::makeInstance('tx_ttproducts_user_view');
-					$contentTmp =
-						$viewObj->printView(
-							$this->pibaseClass,
-							$templateCode,
-							$theCode
-						);
-				break;
-				default:	// 'HELP'
-					if (!$bRunAjax && $this->convertToUserInt($cObj)) {
-						return '';
-					}
-					$contentTmp = 'error';
-			} // switch
+                        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['test'] as $classRef) {
+                            if (count($errorCode)) {
+                                break;
+                            }
+                            $hookObj= GeneralUtility::makeInstance($classRef);
+                            if (method_exists($hookObj, 'test')) {
+                                $contentTmp .= $hookObj->test(
+                                    $this,
+                                    $cObj,
+                                    $pibaseClass,
+                                    $basketObj,
+                                    $controlObj,
+                                    $errorCode,
+                                    $errorMessage,
+                                    $content,
+                                    $contentTmp,
+                                    $bRunAjax
+                                );
+                            }
+                        }
+                    }
+                break;
+                case 'USER1':
+                case 'USER2':
+                case 'USER3':
+                case 'USER4':
+                case 'USER5':
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    $viewObj = GeneralUtility::makeInstance('tx_ttproducts_user_view');
+                    $contentTmp =
+                        $viewObj->printView(
+                            $this->pibaseClass,
+                            $templateCode,
+                            $theCode
+                        );
+                break;
+                default:	// 'HELP'
+                    if (!$bRunAjax && $this->convertToUserInt($cObj)) {
+                        return '';
+                    }
+                    $contentTmp = 'error';
+            } // switch
 
-			if ($contentTmp != '') {
-				$contentTmp =
-					$templateService->substituteMarkerArray(
-						$contentTmp,
-						$globalMarkerArray
-					);
-			}
+            if ($contentTmp != '') {
+                $contentTmp =
+                    $templateService->substituteMarkerArray(
+                        $contentTmp,
+                        $globalMarkerArray
+                    );
+            }
 
-			if (!empty($errorCode[0])) {
+            if (!empty($errorCode[0])) {
 
-				$errorConf = [];
-				if (isset($this->conf['error.'])) {
-					$errorConf = $this->conf['error.'];
-				}
+                $errorConf = [];
+                if (isset($this->conf['error.'])) {
+                    $errorConf = $this->conf['error.'];
+                }
 
-				foreach ($errorCode as $key => $indice) {
+                foreach ($errorCode as $key => $indice) {
 
-					if (
-						isset($errorConf[$indice . '.']) &&
-						isset($errorConf[$indice . '.']['redirect.']) &&
-						isset($errorConf[$indice . '.']['redirect.']['pid'])
-					) {
-						$pid = $errorConf[$indice . '.']['redirect.']['pid'];
-						$url = FrontendUtility::getTypoLink_URL(
-							$cObj,
-							$pid,
-							$urlObj->getLinkParams(
-								'product,article,dam',
-								'',
-								true,
-								false
-							),
-							'',
-							[]
-						);
+                    if (
+                        isset($errorConf[$indice . '.']) &&
+                        isset($errorConf[$indice . '.']['redirect.']) &&
+                        isset($errorConf[$indice . '.']['redirect.']['pid'])
+                    ) {
+                        $pid = $errorConf[$indice . '.']['redirect.']['pid'];
+                        $url = FrontendUtility::getTypoLink_URL(
+                            $cObj,
+                            $pid,
+                            $urlObj->getLinkParams(
+                                'product,article,dam',
+                                '',
+                                true,
+                                false
+                            ),
+                            '',
+                            []
+                        );
 
-						if ($url != '') {
-							\TYPO3\CMS\Core\Utility\HttpUtility::redirect($url);
-						}
-					}
-				}
+                        if ($url != '') {
+                            \TYPO3\CMS\Core\Utility\HttpUtility::redirect($url);
+                        }
+                    }
+                }
 
-				$contentTmp .= \JambageCom\Div2007\Utility\ErrorUtility::getMessage($languageObj, $errorCode);
-				$errorCode = [];
-			}
+                $contentTmp .= \JambageCom\Div2007\Utility\ErrorUtility::getMessage($languageObj, $errorCode);
+                $errorCode = [];
+            }
 
-			if ($contentTmp == 'error') {
+            if ($contentTmp == 'error') {
                 $fileName = 'EXT:' . TT_PRODUCTS_EXT . '/Resources/Public/Templates/products_help.tmpl';
                 $sanitizer = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class);
                 $fileName = $sanitizer->sanitize($fileName);
@@ -986,24 +986,24 @@ class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
                         $theCode
                     );
 
-				$bErrorFound = true;
-				unset($errorMessage);
-			}
+                $bErrorFound = true;
+                unset($errorMessage);
+            }
 
-			if (!$bRunAjax && intval($conf['wrapInCode'])) {
-				$content .=
-					FrontendUtility::wrapContentCode(
-						$contentTmp,
-						$theCode,
-						$pibaseObj->prefixId,
-						$cObj->data['uid'] ?? ''
-					);
-			} else if (!$bErrorFound) {
-				$content .= $contentTmp;
-			}
+            if (!$bRunAjax && intval($conf['wrapInCode'])) {
+                $content .=
+                    FrontendUtility::wrapContentCode(
+                        $contentTmp,
+                        $theCode,
+                        $pibaseObj->prefixId,
+                        $cObj->data['uid'] ?? ''
+                    );
+            } else if (!$bErrorFound) {
+                $content .= $contentTmp;
+            }
 
-			$javaScriptConf = $cnf->getJsConf($theCode);
-			if (!empty($javaScriptConf['file'])) {
+            $javaScriptConf = $cnf->getJsConf($theCode);
+            if (!empty($javaScriptConf['file'])) {
                 $fileName = $javaScriptConf['file'];
                 $incFile = '';
 
@@ -1016,83 +1016,83 @@ class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
                     $javaScriptObj->setIncluded($incFile);
                 }
             }
-		} // foreach
+        } // foreach
 
-		if ($errorMessage) {
-			$content = '<p><b>' . $errorMessage . '</b></p>';
-		}
+        if ($errorMessage) {
+            $content = '<p><b>' . $errorMessage . '</b></p>';
+        }
 
-		if ($bRunAjax || !intval($conf['wrapInBaseClass'])) {
-			$result = $content;
-		} else {
-			$content = FrontendUtility::wrapInBaseClass($content, $pibaseObj->prefixId, $pibaseObj->extKey);
-			$cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
-			$result = '';
+        if ($bRunAjax || !intval($conf['wrapInBaseClass'])) {
+            $result = $content;
+        } else {
+            $content = FrontendUtility::wrapInBaseClass($content, $pibaseObj->prefixId, $pibaseObj->extKey);
+            $cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
+            $result = '';
 
-			if ($cssObj->isCSSStyled() && !$cssObj->getIncluded() && !empty($cssObj->conf['file'])) {
+            if ($cssObj->isCSSStyled() && !$cssObj->getIncluded() && !empty($cssObj->conf['file'])) {
                 $fileName = $cssObj->conf['file'];
                 $incFile = '';
 
                 $sanitizer = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class);
                 $incFile = $sanitizer->sanitize($fileName);
 
-				if ($incFile != '') {
-					$result = '<style type="text/css">@import "' . $incFile . '"</style>' . chr(13) . $content;
-					$cssObj->setIncluded();
-				}
-			}
+                if ($incFile != '') {
+                    $result = '<style type="text/css">@import "' . $incFile . '"</style>' . chr(13) . $content;
+                    $cssObj->setIncluded();
+                }
+            }
 
-			if ($result == '') {
-				$result = $content;
-			}
-		}
+            if ($result == '') {
+                $result = $content;
+            }
+        }
 
-		if (!$conf['fe']) {
-			$result = '';
-		}
+        if (!$conf['fe']) {
+            $result = '';
+        }
 
         $showConfigurationError = 
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['error']['configuration'];
 
 
-		if ($showConfigurationError && !$conf['defaultSetup']) {
-			$result .= '<h1>Error: The default tt_products setup is missing.</h1>';
-		}
+        if ($showConfigurationError && !$conf['defaultSetup']) {
+            $result .= '<h1>Error: The default tt_products setup is missing.</h1>';
+        }
 
-		$control = tx_ttproducts_control_basket::readControl();
-		if ($control) {
+        $control = tx_ttproducts_control_basket::readControl();
+        if ($control) {
 
-			$control['pid'] = $GLOBALS['TSFE']->id;
-			tx_ttproducts_control_basket::writeControl($control);
-		}
+            $control['pid'] = $GLOBALS['TSFE']->id;
+            tx_ttproducts_control_basket::writeControl($control);
+        }
 
-		$this->destruct();
+        $this->destruct();
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/**
-	 * Converts the plugin to USER_INT if it is not USER_INT already. After
-	 * calling this function the plugin should return if the function returns
-	 * true. The content will be ignored and the plugin will be called again
-	 * later as USER_INT.
-	 *
-	 * @return boolean true if the plugin should return immediately
-	 */
-	protected function convertToUserInt (&$cObj) {
-		$result = false;
-		if (
-			method_exists($cObj, 'getUserObjectType') &&
-			$cObj->getUserObjectType() == TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::OBJECTTYPE_USER
-		) {
-			$cObj->convertToUserIntObject();
-			$cObj->data['pi_flexform'] = $cObj->data['_original_pi_flexform'];
-			unset($cObj->data['_original_pi_flexform']);
-			$result = true;
-		}
-		return $result;
-	}
+    /**
+     * Converts the plugin to USER_INT if it is not USER_INT already. After
+     * calling this function the plugin should return if the function returns
+     * true. The content will be ignored and the plugin will be called again
+     * later as USER_INT.
+     *
+     * @return boolean true if the plugin should return immediately
+     */
+    protected function convertToUserInt (&$cObj) {
+        $result = false;
+        if (
+            method_exists($cObj, 'getUserObjectType') &&
+            $cObj->getUserObjectType() == TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::OBJECTTYPE_USER
+        ) {
+            $cObj->convertToUserIntObject();
+            $cObj->data['pi_flexform'] = $cObj->data['_original_pi_flexform'];
+            unset($cObj->data['_original_pi_flexform']);
+            $result = true;
+        }
+        return $result;
+    }
 
 
     public function set_no_cache () {
@@ -1100,138 +1100,138 @@ class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
     }
 
 
-	/**
-	 * Order tracking
-	 *
-	 *
-	 * @param	integer		Code: TRACKING, BILL or DELIVERY
-	 * @return	void
-	 */
-	public function products_tracking (
-		&$errorCode,
-		$templateCode,
-		$theCode,
-		$conf
-	) { // GeneralUtility::_GP('tracking')
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-		$updateCode = '';
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+    /**
+     * Order tracking
+     *
+     *
+     * @param	integer		Code: TRACKING, BILL or DELIVERY
+     * @return	void
+     */
+    public function products_tracking (
+        &$errorCode,
+        $templateCode,
+        $theCode,
+        $conf
+    ) { // GeneralUtility::_GP('tracking')
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $updateCode = '';
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
 
         $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
 
-		$trackingTemplateCode = $templateCode;
+        $trackingTemplateCode = $templateCode;
 
-		tx_ttproducts_control_access::getVariables(
-			$conf,
-			$updateCode,
-			$bIsAllowed,
-			$bValidUpdateCode,
-			$trackingCode
-		);
+        tx_ttproducts_control_access::getVariables(
+            $conf,
+            $updateCode,
+            $bIsAllowed,
+            $bValidUpdateCode,
+            $trackingCode
+        );
 
-		$subpartMarker = '';
+        $subpartMarker = '';
 
-		if ($trackingCode || $bValidUpdateCode) {	// Tracking number must be set
-			$orderObj = $tablesObj->get('sys_products_orders');
-			$orderRow = $orderObj->getRecord('', $trackingCode);
+        if ($trackingCode || $bValidUpdateCode) {	// Tracking number must be set
+            $orderObj = $tablesObj->get('sys_products_orders');
+            $orderRow = $orderObj->getRecord('', $trackingCode);
 
-			if (
-				isset($orderRow) &&
-				is_array($orderRow) ||
-				$bValidUpdateCode
-			) {	// If order is associated with tracking id.
-				$type = strtolower($theCode);
-				switch ($theCode) {
-					case 'TRACKING':
-				 		$tracking = GeneralUtility::makeInstance('tx_ttproducts_tracking');
-				 		$tracking->init(
-				 			$cObj
-				 		);
-						$orderRecord = GeneralUtility::_GP('orderRecord');
-						if (
-							!empty($_REQUEST['userNotification']) &&
-							isset($orderRecord) &&
-							is_array($orderRecord)
-						) {
-							$orderRecord['email_notify'] = intval($orderRecord['email_notify']);
-						}
-						$content =
-							$tracking->getTrackingInformation(
-								$orderRow,
-								$trackingTemplateCode,
-								$trackingCode,
-								$updateCode,
-								$orderRecord,
-								$bValidUpdateCode
-							);
-						break;
-					case 'BILL':
-					case 'DELIVERY':
-						$billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
-						$content =
-							$billdeliveryObj->getInformation(
-								$theCode,
-								$orderRow,
-								$trackingTemplateCode,
-								$trackingCode,
-								$type
-							);
-						$absFileName =
-							$billdeliveryObj->getFileAbsFileName(
-								$type,
-								$trackingCode,
-								'html'
-							);
-						$billdeliveryObj->writeFile(
-							$absFileName,
-							$content
-						);
-						$relfilename =
-							$billdeliveryObj->getRelFilename(
-								$trackingCode,
-								$type
-							);
+            if (
+                isset($orderRow) &&
+                is_array($orderRow) ||
+                $bValidUpdateCode
+            ) {	// If order is associated with tracking id.
+                $type = strtolower($theCode);
+                switch ($theCode) {
+                    case 'TRACKING':
+                        $tracking = GeneralUtility::makeInstance('tx_ttproducts_tracking');
+                        $tracking->init(
+                            $cObj
+                        );
+                        $orderRecord = GeneralUtility::_GP('orderRecord');
+                        if (
+                            !empty($_REQUEST['userNotification']) &&
+                            isset($orderRecord) &&
+                            is_array($orderRecord)
+                        ) {
+                            $orderRecord['email_notify'] = intval($orderRecord['email_notify']);
+                        }
+                        $content =
+                            $tracking->getTrackingInformation(
+                                $orderRow,
+                                $trackingTemplateCode,
+                                $trackingCode,
+                                $updateCode,
+                                $orderRecord,
+                                $bValidUpdateCode
+                            );
+                        break;
+                    case 'BILL':
+                    case 'DELIVERY':
+                        $billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
+                        $content =
+                            $billdeliveryObj->getInformation(
+                                $theCode,
+                                $orderRow,
+                                $trackingTemplateCode,
+                                $trackingCode,
+                                $type
+                            );
+                        $absFileName =
+                            $billdeliveryObj->getFileAbsFileName(
+                                $type,
+                                $trackingCode,
+                                'html'
+                            );
+                        $billdeliveryObj->writeFile(
+                            $absFileName,
+                            $content
+                        );
+                        $relfilename =
+                            $billdeliveryObj->getRelFilename(
+                                $trackingCode,
+                                $type
+                            );
 
-						$message = $languageObj->getLabel('open_' . $type);
-						$content = '<a href="' . $relfilename . '" >' . $message . '</a>';
-						break;
-					default:
-						debug ('error in '.TT_PRODUCTS_EXT.' calling function products_tracking with $theCode = "' . $theCode . '"'); // keep this
-				}
-			} else {	// ... else output error page
-				$subpartMarker = '###TRACKING_WRONG_NUMBER###';
-			}
-		} else {	// No tracking number - show form with tracking number
-			$subpartMarker = '###TRACKING_ENTER_NUMBER###';
-		}
+                        $message = $languageObj->getLabel('open_' . $type);
+                        $content = '<a href="' . $relfilename . '" >' . $message . '</a>';
+                        break;
+                    default:
+                        debug ('error in '.TT_PRODUCTS_EXT.' calling function products_tracking with $theCode = "' . $theCode . '"'); // keep this
+                }
+            } else {	// ... else output error page
+                $subpartMarker = '###TRACKING_WRONG_NUMBER###';
+            }
+        } else {	// No tracking number - show form with tracking number
+            $subpartMarker = '###TRACKING_ENTER_NUMBER###';
+        }
 
-		if ($subpartMarker) {
-			$content =
-				$templateService->getSubpart(
-					$trackingTemplateCode,
-					$subpartmarkerObj->spMarker($subpartMarker)
-				);
-			if ($content == '') {
-				$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-				$errorCode[0] = 'no_subtemplate';
-				$errorCode[1] = '###' . $subpartMarker . $templateObj->getTemplateSuffix() . '###';
-				$errorCode[2] = $templateObj->getTemplateFile();
-				return '';
-			}
+        if ($subpartMarker) {
+            $content =
+                $templateService->getSubpart(
+                    $trackingTemplateCode,
+                    $subpartmarkerObj->spMarker($subpartMarker)
+                );
+            if ($content == '') {
+                $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+                $errorCode[0] = 'no_subtemplate';
+                $errorCode[1] = '###' . $subpartMarker . $templateObj->getTemplateSuffix() . '###';
+                $errorCode[2] = $templateObj->getTemplateFile();
+                return '';
+            }
 
-			if (!$bIsAllowed) {
-				$content = $templateService->substituteSubpart($content, '###ADMIN_CONTROL###', '');
-			}
-		}
+            if (!$bIsAllowed) {
+                $content = $templateService->substituteSubpart($content, '###ADMIN_CONTROL###', '');
+            }
+        }
 
-		$markerArray = $globalMarkerArray;
+        $markerArray = $globalMarkerArray;
         $markerArray['###FORM_URL###'] =
             FrontendUtility::getTypoLink_URL(
                 $cObj,
@@ -1239,154 +1239,154 @@ class tx_ttproducts_main implements \TYPO3\CMS\Core\SingletonInterface {
                 $urlObj->getLinkParams('', [], true)
             );
 
-		$content = $templateService->substituteMarkerArray($content, $markerArray);
-		return $content;
-	}  // products_tracking
+        $content = $templateService->substituteMarkerArray($content, $markerArray);
+        return $content;
+    }  // products_tracking
 
 
-	public function setSingleFromList ($bValue) {
-		$this->bSingleFromList = $bValue;
-	}
+    public function setSingleFromList ($bValue) {
+        $this->bSingleFromList = $bValue;
+    }
 
 
-	public function getSingleFromList () {
-		return $this->bSingleFromList;
-	}
+    public function getSingleFromList () {
+        return $this->bSingleFromList;
+    }
 
 
-	/**
-	 * Displaying single products/ the products list / searching
-	 */
-	public function products_display (
-		$cObj,
-		$basketExtra,
-		$basketRecs,
-		$templateCode,
-		$theCode,
-		&$errorMessage,
-		&$errorCode
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$bSingleFromList = false;
-		$piVars = tx_ttproducts_model_control::getPiVars();
+    /**
+     * Displaying single products/ the products list / searching
+     */
+    public function products_display (
+        $cObj,
+        $basketExtra,
+        $basketRecs,
+        $templateCode,
+        $theCode,
+        &$errorMessage,
+        &$errorCode
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $bSingleFromList = false;
+        $piVars = tx_ttproducts_model_control::getPiVars();
 
-		if (
-			(
-				(
-					($theCode == 'SEARCH') && $conf['listViewOnSearch'] == '1' ||
-					(strpos($theCode, 'LIST') !== false)
-				) &&
-				$theCode != 'LISTARTICLES' &&
-				count($this->tt_product_single) &&
-				!$conf['NoSingleViewOnList'] &&
-				!$this->getSingleFromList()
-			)
-		) {
-			$this->setSingleFromList(true);
-			$bSingleFromList = true;
-		}
+        if (
+            (
+                (
+                    ($theCode == 'SEARCH') && $conf['listViewOnSearch'] == '1' ||
+                    (strpos($theCode, 'LIST') !== false)
+                ) &&
+                $theCode != 'LISTARTICLES' &&
+                count($this->tt_product_single) &&
+                !$conf['NoSingleViewOnList'] &&
+                !$this->getSingleFromList()
+            )
+        ) {
+            $this->setSingleFromList(true);
+            $bSingleFromList = true;
+        }
 
-		if (
-			($theCode == 'SINGLE') ||
-			$bSingleFromList
-		) {
-			$extVars = $piVars['variants'] ?? '';
-			$extVars = ($extVars ? $extVars : GeneralUtility::_GP('ttp_extvars'));
-			$showAmount = $cnf->getBasketConf('view', 'showAmount');
+        if (
+            ($theCode == 'SINGLE') ||
+            $bSingleFromList
+        ) {
+            $extVars = $piVars['variants'] ?? '';
+            $extVars = ($extVars ? $extVars : GeneralUtility::_GP('ttp_extvars'));
+            $showAmount = $cnf->getBasketConf('view', 'showAmount');
 
-			if (!count($this->tt_product_single)) {
-				if ($conf['defaultProductID']) {
-					$this->tt_product_single['product'] = $conf['defaultProductID'];
-				} else if ($conf['defaultArticleID']) {
-					$this->tt_product_single['article'] = $conf['defaultArticleID'];
-				}
-			}
+            if (!count($this->tt_product_single)) {
+                if ($conf['defaultProductID']) {
+                    $this->tt_product_single['product'] = $conf['defaultProductID'];
+                } else if ($conf['defaultArticleID']) {
+                    $this->tt_product_single['article'] = $conf['defaultArticleID'];
+                }
+            }
 
-			if (
-				empty($conf['NoSingleViewOnList']) &&
-				empty($conf['PIDitemDisplay']) &&
-				empty($conf['PIDitemDisplay.'])
-			) {
-				if ($this->convertToUserInt($cObj)) {
-					return '';
-				}
-			}
+            if (
+                empty($conf['NoSingleViewOnList']) &&
+                empty($conf['PIDitemDisplay']) &&
+                empty($conf['PIDitemDisplay.'])
+            ) {
+                if ($this->convertToUserInt($cObj)) {
+                    return '';
+                }
+            }
 
-			if (!is_object($this->singleView)) {
+            if (!is_object($this->singleView)) {
 
-				// List single product:
-				$this->singleView = GeneralUtility::makeInstance('tx_ttproducts_single_view');
-			}
+                // List single product:
+                $this->singleView = GeneralUtility::makeInstance('tx_ttproducts_single_view');
+            }
 
-			$this->singleView->init(
-				$this->tt_product_single,
-				$extVars,
-				$this->pid,
-				$conf['useArticles'],
-				$config['pid_list'],
-				$config['recursive']
-			);
+            $this->singleView->init(
+                $this->tt_product_single,
+                $extVars,
+                $this->pid,
+                $conf['useArticles'],
+                $config['pid_list'],
+                $config['recursive']
+            );
 
-			$content = $this->singleView->printView(
-				$templateCode,
-				$errorCode,
-				$this->pageAsCategory,
-				$config['templateSuffix']
-			);
+            $content = $this->singleView->printView(
+                $templateCode,
+                $errorCode,
+                $this->pageAsCategory,
+                $config['templateSuffix']
+            );
 
-			$ctrlContent = $cObj->cObjGetSingle($conf['SINGLECTRL'], $conf['SINGLECTRL.']);
-			$content .= $ctrlContent;
-		} else {
-	// page where to usually go
-			$pid = ($conf['PIDbasket'] && $conf['clickIntoBasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id);
+            $ctrlContent = $cObj->cObjGetSingle($conf['SINGLECTRL'], $conf['SINGLECTRL.']);
+            $content .= $ctrlContent;
+        } else {
+    // page where to usually go
+            $pid = ($conf['PIDbasket'] && $conf['clickIntoBasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id);
 
-			// List all products:
-			$listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
-			$listView->init (
-				$pid,
-				$this->tt_product_single,
-				$config['pid_list'],
-				$config['recursive']
-			);
+            // List all products:
+            $listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
+            $listView->init (
+                $pid,
+                $this->tt_product_single,
+                $config['pid_list'],
+                $config['recursive']
+            );
 
-			if ($theCode == 'LISTARTICLES' && $conf['useArticles']) {
-				$templateArea = 'ARTICLE_LIST_TEMPLATE';
-			} else {
-				$templateArea = 'ITEM_LIST_TEMPLATE';
-			}
+            if ($theCode == 'LISTARTICLES' && $conf['useArticles']) {
+                $templateArea = 'ARTICLE_LIST_TEMPLATE';
+            } else {
+                $templateArea = 'ITEM_LIST_TEMPLATE';
+            }
 
-			if ($theCode == 'LISTARTICLES' && $conf['useArticles']) {
-				$functablename = 'tt_products_articles';
-			} else if ($theCode == 'LISTDAM') {
-				$functablename = 'tx_dam';
-			} else {
-				$functablename = 'tt_products';
-			}
-			$allowedItems = \JambageCom\Div2007\Utility\FlexformUtility::get(PluginApi::getFlexform(), 'productSelection');
+            if ($theCode == 'LISTARTICLES' && $conf['useArticles']) {
+                $functablename = 'tt_products_articles';
+            } else if ($theCode == 'LISTDAM') {
+                $functablename = 'tx_dam';
+            } else {
+                $functablename = 'tt_products';
+            }
+            $allowedItems = \JambageCom\Div2007\Utility\FlexformUtility::get(PluginApi::getFlexform(), 'productSelection');
 
-			$bAllPages = false;
-			$templateArea = $templateArea . $config['templateSuffix'];
-			$content = $listView->printView(
-				$templateCode,
-				$theCode,
-				$functablename,
-				$allowedItems,
-				$bAllPages,
-				'',
-				$errorCode,
-				$templateArea,
-				$this->pageAsCategory,
-				$basketExtra,
-				$basketRecs,
-				[]
-			);
-		}
+            $bAllPages = false;
+            $templateArea = $templateArea . $config['templateSuffix'];
+            $content = $listView->printView(
+                $templateCode,
+                $theCode,
+                $functablename,
+                $allowedItems,
+                $bAllPages,
+                '',
+                $errorCode,
+                $templateArea,
+                $this->pageAsCategory,
+                $basketExtra,
+                $basketRecs,
+                []
+            );
+        }
 
-		return $content;
-	}	// products_display
+        return $content;
+    }	// products_display
 }
 
 

--- a/eid/class.tx_ttproducts_ajax.php
+++ b/eid/class.tx_ttproducts_ajax.php
@@ -44,94 +44,94 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_ajax implements \TYPO3\CMS\Core\SingletonInterface {
-	public $taxajax;	// xajax object
-	public $conf; 	// conf coming from JavaScript via Ajax
+    public $taxajax;	// xajax object
+    public $conf; 	// conf coming from JavaScript via Ajax
 
 
-	public function init () {
-		$result = false;
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT)) {
+    public function init () {
+        $result = false;
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TAXAJAX_EXT)) {
  
-			$this->taxajax = GeneralUtility::makeInstance('tx_taxajax');
+            $this->taxajax = GeneralUtility::makeInstance('tx_taxajax');
 
-			// Encoding of the response to FE charset
-			$this->taxajax->setCharEncoding('utf-8');
-			$result = true;
-		}
-		return $result;
-	}
-
-
-	public function setConf ($conf) {
-		$this->conf = $conf;
-	}
+            // Encoding of the response to FE charset
+            $this->taxajax->setCharEncoding('utf-8');
+            $result = true;
+        }
+        return $result;
+    }
 
 
-	public function getConf () {
-		return $this->conf;
-	}
+    public function setConf ($conf) {
+        $this->conf = $conf;
+    }
 
 
-	static public function getStoredRecs () {
-		$result = tx_ttproducts_control_session::readSession('ajax');
-		return $result;
-	}
+    public function getConf () {
+        return $this->conf;
+    }
 
-	static public function setStoredRecs ($valArray) {
-		tx_ttproducts_control_basket::store('ajax', $valArray);
-	}
 
-	public function main (
-		$cObj,
-		$urlObj,
-		$debug,
-		$piVarSingle = 'product',
-		$piVarCat = 'cat'
-	) {
-			// Do you want messages in the status bar?
-		// $this->taxajax->statusMessagesOn();
+    static public function getStoredRecs () {
+        $result = tx_ttproducts_control_session::readSession('ajax');
+        return $result;
+    }
 
-			// Turn only on during testing
-		if ($debug) {
-			$this->taxajax->debugOn();
-			$filepath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/log/taxajax.log';
-			$this->taxajax->setLogFile($filepath);
-			$this->taxajax->errorHandlerOn();
-		} else {
-			$this->taxajax->debugOff();
-		}
+    static public function setStoredRecs ($valArray) {
+        tx_ttproducts_control_basket::store('ajax', $valArray);
+    }
 
-		$this->taxajax->setWrapperPrefix('');
+    public function main (
+        $cObj,
+        $urlObj,
+        $debug,
+        $piVarSingle = 'product',
+        $piVarCat = 'cat'
+    ) {
+            // Do you want messages in the status bar?
+        // $this->taxajax->statusMessagesOn();
+
+            // Turn only on during testing
+        if ($debug) {
+            $this->taxajax->debugOn();
+            $filepath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/log/taxajax.log';
+            $this->taxajax->setLogFile($filepath);
+            $this->taxajax->errorHandlerOn();
+        } else {
+            $this->taxajax->debugOff();
+        }
+
+        $this->taxajax->setWrapperPrefix('');
 
         $addQueryString = [
             'taxajax' => TT_PRODUCTS_EXT
         ];
 
-		$excludeList = '';
-		$queryString = $urlObj->getLinkParams(
-			$excludeList,
-			[],
-			true,
-			false,
-			0,
-			$piVarSingle,
-			$piVarCat
-		);
+        $excludeList = '';
+        $queryString = $urlObj->getLinkParams(
+            $excludeList,
+            [],
+            true,
+            false,
+            0,
+            $piVarSingle,
+            $piVarCat
+        );
 
-		$queryString = array_merge($queryString, $addQueryString);
+        $queryString = array_merge($queryString, $addQueryString);
 
-		$linkConf = [];
+        $linkConf = [];
 
-		$target = '';
-		$reqURI = FrontendUtility::getTypoLink_URL(
-			$cObj,
-			$GLOBALS['TSFE']->id,
-			$queryString,
-			$target,
-			$linkConf
-		);
+        $target = '';
+        $reqURI = FrontendUtility::getTypoLink_URL(
+            $cObj,
+            $GLOBALS['TSFE']->id,
+            $queryString,
+            $target,
+            $linkConf
+        );
 
-		$this->taxajax->setRequestURI($reqURI);
-	}
+        $this->taxajax->setRequestURI($reqURI);
+    }
 }
 

--- a/eid/class.tx_ttproducts_db.php
+++ b/eid/class.tx_ttproducts_db.php
@@ -41,37 +41,37 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_db implements \TYPO3\CMS\Core\SingletonInterface {
-	protected $extKey = TT_PRODUCTS_EXT;	// The extension key.
-	protected $conf;			// configuration from template
-	protected $config;
-	protected $ajax;
-	protected $LLkey;
-	protected $cObj;
-	public $LOCAL_LANG = [];		// Local Language content
-	public $LOCAL_LANG_charset = [];	// Local Language content charset for individual labels (overriding)
-	public $LOCAL_LANG_loaded = 0;		// Flag that tells if the locallang file has been fetch (or tried to be fetched) already.
+    protected $extKey = TT_PRODUCTS_EXT;	// The extension key.
+    protected $conf;			// configuration from template
+    protected $config;
+    protected $ajax;
+    protected $LLkey;
+    protected $cObj;
+    public $LOCAL_LANG = [];		// Local Language content
+    public $LOCAL_LANG_charset = [];	// Local Language content charset for individual labels (overriding)
+    public $LOCAL_LANG_loaded = 0;		// Flag that tells if the locallang file has been fetch (or tried to be fetched) already.
 
 
-	public function init (&$conf, &$config, $ajax, $pObj, $cObj, &$errorCode) {
-		$this->conf = $conf;
+    public function init (&$conf, &$config, $ajax, $pObj, $cObj, &$errorCode) {
+        $this->conf = $conf;
 
-		if (isset($ajax) && is_object($ajax)) {
-			$this->ajax = $ajax;
+        if (isset($ajax) && is_object($ajax)) {
+            $this->ajax = $ajax;
 
-			$ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_fetchRow', $this, 'fetchRow']);
-			$ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_commands', $this, 'commands']);
-			$ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_showArticle', $this, 'showArticle']);
-		}
+            $ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_fetchRow', $this, 'fetchRow']);
+            $ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_commands', $this, 'commands']);
+            $ajax->taxajax->registerFunction([TT_PRODUCTS_EXT . '_showArticle', $this, 'showArticle']);
+        }
 
-		if (
-			is_object($cObj)
+        if (
+            is_object($cObj)
         ) {
-			$this->cObj = $cObj;
-		} else {
-		    $this->cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
-		    $this->cObj->start([]);
-		}
-		$controlCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_control_creator');
+            $this->cObj = $cObj;
+        } else {
+            $this->cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
+            $this->cObj->start([]);
+        }
+        $controlCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_control_creator');
 
         if (
             defined ('TYPO3_MODE') &&
@@ -84,845 +84,845 @@ class tx_ttproducts_db implements \TYPO3\CMS\Core\SingletonInterface {
         if (empty($recs)) {
             $recs = [];
         }
-		$result =
-			$controlCreatorObj->init(
-				$conf,
-				$config,
-				$pObj,
-				$this->cObj,
-				$ajax,
-				$errorCode,
-				$recs
-			);
-		if (!$result) {
-			return false;
-		}
-		$modelCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_model_creator');
-		$modelCreatorObj->init($conf, $config, $this->cObj);
+        $result =
+            $controlCreatorObj->init(
+                $conf,
+                $config,
+                $pObj,
+                $this->cObj,
+                $ajax,
+                $errorCode,
+                $recs
+            );
+        if (!$result) {
+            return false;
+        }
+        $modelCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_model_creator');
+        $modelCreatorObj->init($conf, $config, $this->cObj);
 
-		return true;
-	}
-
-
-	public function main () {
-	}
+        return true;
+    }
 
 
-	public function printContent () {
-	}
+    public function main () {
+    }
 
 
-	public function fetchRow ($data) {
+    public function printContent () {
+    }
 
-		$result = '';
-		$view = '';
-		$rowArray = [];
-		$variantArray = [];
-		$theCode = 'ALL';
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
 
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
-		$basketRecs = tx_ttproducts_control_basket::getRecs();
-		$funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+    public function fetchRow ($data) {
 
-			// price
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$priceObj->init(
-			$this->cObj,
-			$this->conf
-		);
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$priceViewObj->init(
-			$priceObj
-		);
+        $result = '';
+        $view = '';
+        $rowArray = [];
+        $variantArray = [];
+        $theCode = 'ALL';
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
 
-		$discount = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'];
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $basketRecs = tx_ttproducts_control_basket::getRecs();
+        $funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+
+            // price
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $priceObj->init(
+            $this->cObj,
+            $this->conf
+        );
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $priceViewObj->init(
+            $priceObj
+        );
+
+        $discount = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'];
 
         // We put our incomming data to the regular piVars
-		$itemTable = $tablesObj->get('tt_products', false);
-		$externalRowArray = [];
-		$variantSeparator = $itemTable->variant->getSplitSeparator();
+        $itemTable = $tablesObj->get('tt_products', false);
+        $externalRowArray = [];
+        $variantSeparator = $itemTable->variant->getSplitSeparator();
 
-		if (is_array($data)) {
-			$validEditVariant = true;
-			$useArticles = $itemTable->variant->getUseArticles();
-			$variantFieldArray = $itemTable->variant->getSelectableFieldArray();
+        if (is_array($data)) {
+            $validEditVariant = true;
+            $useArticles = $itemTable->variant->getUseArticles();
+            $variantFieldArray = $itemTable->variant->getSelectableFieldArray();
 
-			foreach ($data as $k => $dataRow) {
+            foreach ($data as $k => $dataRow) {
 
-				if ($k == 'view') {
-					$view = $dataRow;
-					$theCode = strtoupper($view);
-				} else if(is_array($dataRow)) {
-					$table = $k;
-					$uid = intval($dataRow['uid']);
+                if ($k == 'view') {
+                    $view = $dataRow;
+                    $theCode = strtoupper($view);
+                } else if(is_array($dataRow)) {
+                    $table = $k;
+                    $uid = intval($dataRow['uid']);
 
-					if ($uid) {
-						$row = $itemTable->get($uid);
+                    if ($uid) {
+                        $row = $itemTable->get($uid);
 
-						if ($row) {
-							if ($useArticles == 3) {
-								$itemTable->fillVariantsFromArticles($row);
-								$articleRows = $itemTable->getArticleRows(intval($row['uid']));
-							}
-							$rowArray[$table] = $row;
+                        if ($row) {
+                            if ($useArticles == 3) {
+                                $itemTable->fillVariantsFromArticles($row);
+                                $articleRows = $itemTable->getArticleRows(intval($row['uid']));
+                            }
+                            $rowArray[$table] = $row;
 
-							foreach ($dataRow as $field => $v) {
-								$field = str_replace('-', '_', $field);
+                            foreach ($dataRow as $field => $v) {
+                                $field = str_replace('-', '_', $field);
 
-								if (isset($row[$field])) {
-									if ($field != 'uid') {
-										$variantArray[] = $field;
-										$variantValues =
-											preg_split(
-												'/[\h]*' . $variantSeparator . '[\h]*/',
-												$row[$field],
-												-1,
-												PREG_SPLIT_NO_EMPTY
-											);
-										$theValue = $variantValues[$v];
-										$rowArray[$table][$field] = $theValue;
-									}
-								} else if (strpos($field, 'edit_') === 0) {
-									$rowArray[$table][$field] = $v;
-								}
-							}
-							$modifiedRow = $rowArray[$table];
-							$editConfig = $itemTable->editVariant->getValidConfig($modifiedRow);
-							$editVariantFieldArray = $itemTable->editVariant->getFieldArray();
-							if (
-								isset($editVariantFieldArray) && is_array($editVariantFieldArray)
-							) {
-								$storeRowArray = [];
-								$storedRecs = $this->ajax->getStoredRecs();
-								if (isset($storedRecs) && is_array($storedRecs)) {
-									$storeRowArray = $storedRecs;
-								}
+                                if (isset($row[$field])) {
+                                    if ($field != 'uid') {
+                                        $variantArray[] = $field;
+                                        $variantValues =
+                                            preg_split(
+                                                '/[\h]*' . $variantSeparator . '[\h]*/',
+                                                $row[$field],
+                                                -1,
+                                                PREG_SPLIT_NO_EMPTY
+                                            );
+                                        $theValue = $variantValues[$v];
+                                        $rowArray[$table][$field] = $theValue;
+                                    }
+                                } else if (strpos($field, 'edit_') === 0) {
+                                    $rowArray[$table][$field] = $v;
+                                }
+                            }
+                            $modifiedRow = $rowArray[$table];
+                            $editConfig = $itemTable->editVariant->getValidConfig($modifiedRow);
+                            $editVariantFieldArray = $itemTable->editVariant->getFieldArray();
+                            if (
+                                isset($editVariantFieldArray) && is_array($editVariantFieldArray)
+                            ) {
+                                $storeRowArray = [];
+                                $storedRecs = $this->ajax->getStoredRecs();
+                                if (isset($storedRecs) && is_array($storedRecs)) {
+                                    $storeRowArray = $storedRecs;
+                                }
 
-								foreach ($editVariantFieldArray as $field) {
-									if (isset($rowArray[$table][$field])) {
-										$row[$field] = $storeRowArray[$table][$uid][$field] = $rowArray[$table][$field];
-									}
-								}
-								if (count($storeRowArray)) {
-									$this->ajax->setStoredRecs($storeRowArray);
-								}
-							}
+                                foreach ($editVariantFieldArray as $field) {
+                                    if (isset($rowArray[$table][$field])) {
+                                        $row[$field] = $storeRowArray[$table][$uid][$field] = $rowArray[$table][$field];
+                                    }
+                                }
+                                if (count($storeRowArray)) {
+                                    $this->ajax->setStoredRecs($storeRowArray);
+                                }
+                            }
 
-							if ($editConfig && is_array($editConfig)) {
-								$validEditVariant =
-									$itemTable->editVariant->checkValid(
-										$editConfig,
-										$modifiedRow
-									);
-							}
+                            if ($editConfig && is_array($editConfig)) {
+                                $validEditVariant =
+                                    $itemTable->editVariant->checkValid(
+                                        $editConfig,
+                                        $modifiedRow
+                                    );
+                            }
 
-							if ($validEditVariant !== true) {
-								break;
-							}
-							$storeRowArray = [];
-							$storedRecs = tx_ttproducts_control_basket::getStoredVariantRecs();
-							if (isset($storedRecs) && is_array($storedRecs)) {
-								$storeRowArray = $storedRecs;
-							}
+                            if ($validEditVariant !== true) {
+                                break;
+                            }
+                            $storeRowArray = [];
+                            $storedRecs = tx_ttproducts_control_basket::getStoredVariantRecs();
+                            if (isset($storedRecs) && is_array($storedRecs)) {
+                                $storeRowArray = $storedRecs;
+                            }
 
-							foreach ($variantFieldArray as $field) {
-								if (isset($rowArray[$table][$field])) {
-									$storeRowArray[$table][$uid][$field] = $rowArray[$table][$field];
-								}
-							}
+                            foreach ($variantFieldArray as $field) {
+                                if (isset($rowArray[$table][$field])) {
+                                    $storeRowArray[$table][$uid][$field] = $rowArray[$table][$field];
+                                }
+                            }
 
-							tx_ttproducts_control_basket::setStoredVariantRecs($storeRowArray);
+                            tx_ttproducts_control_basket::setStoredVariantRecs($storeRowArray);
 
-							$allVariants =
-								$basketObj->getAllVariants(
-									$funcTablename,
-									$row,
-									$modifiedRow
-								);
-
-							$currRow =
-								$basketObj->getItemRow(
-									$row,
-									$allVariants,
-									$useArticles,
-									$funcTablename,
-									true
-								);
-
-							$basketExt1 = tx_ttproducts_control_basket::generatedBasketExtFromRow($currRow, '1');
-
-							$itemArray =
-								$basketObj->getItemArrayFromRow(
-									$currRow,
-									$basketExt1,
-									$basketExtra,
-									$basketRecs,
+                            $allVariants =
+                                $basketObj->getAllVariants(
                                     $funcTablename,
-									$externalRowArray
-								);
-							$basketObj->setMaxTax($modifiedRow['tax']);
-							$basketObj->calculate($itemArray); // get the calculated arrays
+                                    $row,
+                                    $modifiedRow
+                                );
 
-							$modifiedRow =
-								$basketObj->getMergedRowFromItemArray(
-									$itemArray,
-									$basketExtra
-								);
+                            $currRow =
+                                $basketObj->getItemRow(
+                                    $row,
+                                    $allVariants,
+                                    $useArticles,
+                                    $funcTablename,
+                                    true
+                                );
 
-							$totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
-							$itemTable->getTotalDiscount($modifiedRow);
-							$priceTaxArray = [];
-							$taxInfoArray = [];
+                            $basketExt1 = tx_ttproducts_control_basket::generatedBasketExtFromRow($currRow, '1');
 
-							$priceTaxArray = $priceObj->getPriceTaxArray(
-								$taxInfoArray,
-								$this->conf['discountPriceMode'] ?? '',
-								tx_ttproducts_control_basket::getBasketExtra(),
-								tx_ttproducts_control_basket::getRecs(),
-								'price',
-								tx_ttproducts_control_basket::getRoundFormat(),
-								tx_ttproducts_control_basket::getRoundFormat('discount'),
-								$modifiedRow,
-								$totalDiscountField,
-								false,
-								false
-							);
+                            $itemArray =
+                                $basketObj->getItemArrayFromRow(
+                                    $currRow,
+                                    $basketExt1,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $funcTablename,
+                                    $externalRowArray
+                                );
+                            $basketObj->setMaxTax($modifiedRow['tax']);
+                            $basketObj->calculate($itemArray); // get the calculated arrays
 
-							$field = 'price';
-							foreach ($priceTaxArray as $priceKey => $priceValue) {
-								$displayTax =
-									$priceViewObj->convertKey($priceKey, $field);
-								$displaySuffixId = str_replace('_', '', strtolower($displayTax));
-								$modifiedRow[$displaySuffixId] = $priceValue;
-							}
+                            $modifiedRow =
+                                $basketObj->getMergedRowFromItemArray(
+                                    $itemArray,
+                                    $basketExtra
+                                );
 
-							if ($useArticles == 1) {
-								$rowArticle =
-									$itemTable->getArticleRow(
-										$modifiedRow, /*$rowArray[$table],*/
-										$theCode
-									);
-							} else if ($useArticles == 3) {
-								$rowArticle =
-									$itemTable->getMatchingArticleRows(
-										$modifiedRow,
-										$articleRows
-									);
-							}
+                            $totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
+                            $itemTable->getTotalDiscount($modifiedRow);
+                            $priceTaxArray = [];
+                            $taxInfoArray = [];
 
- 							$itemTable->getTableObj()->substituteMarkerArray(
-								$modifiedRow
-							);
-							$rowArray[$table] = $modifiedRow;
-						} // if ($row ...)
-					}
-				} // foreach ($data
-				if ($validEditVariant !== true) {
-					break;
-				}
-			}
+                            $priceTaxArray = $priceObj->getPriceTaxArray(
+                                $taxInfoArray,
+                                $this->conf['discountPriceMode'] ?? '',
+                                tx_ttproducts_control_basket::getBasketExtra(),
+                                tx_ttproducts_control_basket::getRecs(),
+                                'price',
+                                tx_ttproducts_control_basket::getRoundFormat(),
+                                tx_ttproducts_control_basket::getRoundFormat('discount'),
+                                $modifiedRow,
+                                $totalDiscountField,
+                                false,
+                                false
+                            );
 
-			$this->ajax->setConf($data['conf'] ?? []);
-		}
+                            $field = 'price';
+                            foreach ($priceTaxArray as $priceKey => $priceValue) {
+                                $displayTax =
+                                    $priceViewObj->convertKey($priceKey, $field);
+                                $displaySuffixId = str_replace('_', '', strtolower($displayTax));
+                                $modifiedRow[$displaySuffixId] = $priceValue;
+                            }
 
-		if ($validEditVariant === true) {
-			$result = $this->generateResponse($view, $rowArray, $rowArticle, $variantArray);
-		} else {
-			$result = $this->generateErrorResponse($uid, $validEditVariant);
-		}
+                            if ($useArticles == 1) {
+                                $rowArticle =
+                                    $itemTable->getArticleRow(
+                                        $modifiedRow, /*$rowArray[$table],*/
+                                        $theCode
+                                    );
+                            } else if ($useArticles == 3) {
+                                $rowArticle =
+                                    $itemTable->getMatchingArticleRows(
+                                        $modifiedRow,
+                                        $articleRows
+                                    );
+                            }
 
-		return $result;
-	}
+                            $itemTable->getTableObj()->substituteMarkerArray(
+                                $modifiedRow
+                            );
+                            $rowArray[$table] = $modifiedRow;
+                        } // if ($row ...)
+                    }
+                } // foreach ($data
+                if ($validEditVariant !== true) {
+                    break;
+                }
+            }
+
+            $this->ajax->setConf($data['conf'] ?? []);
+        }
+
+        if ($validEditVariant === true) {
+            $result = $this->generateResponse($view, $rowArray, $rowArticle, $variantArray);
+        } else {
+            $result = $this->generateErrorResponse($uid, $validEditVariant);
+        }
+
+        return $result;
+    }
 
 
-	protected function generateErrorResponse ($uid, $editErrorArray) {
+    protected function generateErrorResponse ($uid, $editErrorArray) {
         $bUseXHTML = \JambageCom\Div2007\Utility\HtmlUtility::useXHTML();
 
-		// Instantiate the tx_xajax_response object
-		$objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding(), true);
+        // Instantiate the tx_xajax_response object
+        $objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding(), true);
 
-		$editVariant = key($editErrorArray);
-		$errorText = current($editErrorArray);
-		$fieldname = str_replace('edit_', '', $editVariant);
+        $editVariant = key($editErrorArray);
+        $errorText = current($editErrorArray);
+        $fieldname = str_replace('edit_', '', $editVariant);
 
-		$errorId = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $uid;
-		$objResponse->addAssign($errorId, 'innerHTML', $errorText);
-		$basketIntoId = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $uid;
+        $errorId = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $uid;
+        $objResponse->addAssign($errorId, 'innerHTML', $errorText);
+        $basketIntoId = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $uid;
 
-		$disabledText = ($bUseXHTML ? 'disabled' : '');
-		$objResponse->addPrepend($basketIntoId, 'disabled', $disabledText);
+        $disabledText = ($bUseXHTML ? 'disabled' : '');
+        $objResponse->addPrepend($basketIntoId, 'disabled', $disabledText);
 
-		$result = $objResponse->getXML();
+        $result = $objResponse->getXML();
 
-		//return the XML response generated by the tx_taxajax_response object
-		return $result;
-	}
+        //return the XML response generated by the tx_taxajax_response object
+        return $result;
+    }
 
 
-	protected function generateResponse (
-		$view,
-		$rowArray,
-		$rowArticle,
-		$variantArray
-	) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$config = $cnfObj->getConfig();
-		$conf =  $cnfObj->getConf();
+    protected function generateResponse (
+        $view,
+        $rowArray,
+        $rowArticle,
+        $variantArray
+    ) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $config = $cnfObj->getConfig();
+        $conf =  $cnfObj->getConf();
         $bUseXHTML = \JambageCom\Div2007\Utility\HtmlUtility::useXHTML();
 
-		$theCode = strtoupper($view);
-		$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image');
-		$imageViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $theCode = strtoupper($view);
+        $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image');
+        $imageViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
 
-		$imageObj->init($this->cObj);
-		$imageViewObj->init($imageObj);
+        $imageObj->init($this->cObj);
+        $imageViewObj->init($imageObj);
 
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-			// price
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+            // price
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
         $priceFieldArray = $priceViewObj->getConvertedPriceFieldArray('price');
 
-		$tableObjArray = [];
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tableObjArray = [];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		// Instantiate the tx_xajax_response object
-		$objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding(), true);
+        // Instantiate the tx_xajax_response object
+        $objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding(), true);
 
-		$articleTcaColumns = $GLOBALS['TCA']['tt_products_articles']['columns'];
+        $articleTcaColumns = $GLOBALS['TCA']['tt_products_articles']['columns'];
 
-		foreach ($rowArray as $functablename => $row) { // tt-products-list-1-size
-			if (
+        foreach ($rowArray as $functablename => $row) { // tt-products-list-1-size
+            if (
                 !isset($tableObjArray[$functablename]) ||
                 !is_object($tableObjArray[$functablename])
             ) {
-				$suffix = '-from-tt-products-articles';
-			} else {
-				$suffix = '';
-			}
+                $suffix = '-from-tt-products-articles';
+            } else {
+                $suffix = '';
+            }
 
-			$itemTableView = $tablesObj->get($functablename, true);
-			$itemTable = $itemTableView->getModelObj();
-			$tablename = $itemTable->getTablename();
-			$tableconf = $itemTable->getTableConf($theCode);
+            $itemTableView = $tablesObj->get($functablename, true);
+            $itemTable = $itemTableView->getModelObj();
+            $tablename = $itemTable->getTablename();
+            $tableconf = $itemTable->getTableConf($theCode);
 
-			$useCategories = true;
+            $useCategories = true;
 
-			if ($useCategories) {
-				$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-				$pidListObj->applyRecursive($config['recursive'], $config['pid_list'], true);
+            if ($useCategories) {
+                $pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+                $pidListObj->applyRecursive($config['recursive'], $config['pid_list'], true);
 
-				$categoryfunctablename = 'tt_products_cat';
-				$categoryTableView = $tablesObj->get($categoryfunctablename, true);
-				$categoryTable = $categoryTableView->getModelObj();
-				$piVars = tx_ttproducts_model_control::getPiVars();
-				$categoryPivar = tx_ttproducts_model_control::getPiVar($categoryfunctablename);
+                $categoryfunctablename = 'tt_products_cat';
+                $categoryTableView = $tablesObj->get($categoryfunctablename, true);
+                $categoryTable = $categoryTableView->getModelObj();
+                $piVars = tx_ttproducts_model_control::getPiVars();
+                $categoryPivar = tx_ttproducts_model_control::getPiVar($categoryfunctablename);
 
-				$currentCat =
-					$categoryTable->getParamDefault(
-						$theCode,
-						$piVars[$categoryPivar] ?? ''
-					);
-				$rootCat = $categoryTable->getRootCat();
-				$relatedArray =
-					$categoryTable->getRelated(
-						$rootCat,
-						$currentCat,
-						$pidListObj->getPidlist()
-					);	// read only related categories;
-				$excludeCat = 0;
-				$categoryArray =
-					$categoryTable->getRelationArray(
-						$relatedArray,
-						$excludeCat,
-						$rootCat,
-						implode(',', array_keys($relatedArray))
-					);
-			}
+                $currentCat =
+                    $categoryTable->getParamDefault(
+                        $theCode,
+                        $piVars[$categoryPivar] ?? ''
+                    );
+                $rootCat = $categoryTable->getRootCat();
+                $relatedArray =
+                    $categoryTable->getRelated(
+                        $rootCat,
+                        $currentCat,
+                        $pidListObj->getPidlist()
+                    );	// read only related categories;
+                $excludeCat = 0;
+                $categoryArray =
+                    $categoryTable->getRelationArray(
+                        $relatedArray,
+                        $excludeCat,
+                        $rootCat,
+                        implode(',', array_keys($relatedArray))
+                    );
+            }
 
-			$jsTableNamesId = str_replace('_', '-', $functablename) . $suffix;
-			$uid = $row['uid'];
-			$errorId = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $uid;
+            $jsTableNamesId = str_replace('_', '-', $functablename) . $suffix;
+            $uid = $row['uid'];
+            $errorId = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $uid;
             $objResponse->addAssign($errorId, 'innerHTML', '');
-			$basketIntoId = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $uid;
+            $basketIntoId = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $uid;
             $objResponse->addClear($basketIntoId, 'disabled');
 
-			$markerKey = $itemTableView->getMarkerKey('');
-			$markerPrefix = $markerKey . '_';
-			$suffix = '';
+            $markerKey = $itemTableView->getMarkerKey('');
+            $markerPrefix = $markerKey . '_';
+            $suffix = '';
 
-			$fieldMarkerArray =
-				$itemTableView->createFieldMarkerArray(
-					$row,
-					$markerPrefix,
-					$suffix
-				);
+            $fieldMarkerArray =
+                $itemTableView->createFieldMarkerArray(
+                    $row,
+                    $markerPrefix,
+                    $suffix
+                );
 
-			$modifiedRow = [];
+            $modifiedRow = [];
 
-			foreach ($row as $field => $v) {
+            foreach ($row as $field => $v) {
 
-				if (
-					empty($field) ||
-					(
-						!isset($articleTcaColumns[$field]) &&
-						!in_array($field, $priceFieldArray)
-					) ||
-					$field == 'additional'
-				) {
-					continue;
-				}
-				$fieldId = $field;
-				$bSkip = false;
+                if (
+                    empty($field) ||
+                    (
+                        !isset($articleTcaColumns[$field]) &&
+                        !in_array($field, $priceFieldArray)
+                    ) ||
+                    $field == 'additional'
+                ) {
+                    continue;
+                }
+                $fieldId = $field;
+                $bSkip = false;
 
-				if (
-					($field == 'title') ||
-					($field == 'subtitle') ||
-					($field == 'note') ||
-					($field == 'note2')
-				) {
-					if (
-						($field == 'note') ||
-						($field == 'note2')
-					) {
-						$noteObj = GeneralUtility::makeInstance('tx_ttproducts_field_note_view');
-						$class = $itemTable->getFieldClass($field);
+                if (
+                    ($field == 'title') ||
+                    ($field == 'subtitle') ||
+                    ($field == 'note') ||
+                    ($field == 'note2')
+                ) {
+                    if (
+                        ($field == 'note') ||
+                        ($field == 'note2')
+                    ) {
+                        $noteObj = GeneralUtility::makeInstance('tx_ttproducts_field_note_view');
+                        $class = $itemTable->getFieldClass($field);
 
-						if (
-							$class
-						) {
-							$tmpArray = [];
-							$tmp = '';
-							$fieldViewObj = $itemTableView->getObj($class);
-							$linkWrap = false;
-							$modifiedValue =
-								$fieldViewObj->getRowMarkerArray(
-									$functablename,
-									$field,
-									$row,
-									$tmp,
-									$tmpArray,
-									$tmpArray,
-									$tmpArray,
-									$theCode,
-									'',
-									tx_ttproducts_control_basket::getBasketExtra(),
-									tx_ttproducts_control_basket::getRecs(),
-									$bSkip,
-									true,
-									'',
-									'',
-									'',
-									0,
-									'',
-									$linkWrap,
-									false
+                        if (
+                            $class
+                        ) {
+                            $tmpArray = [];
+                            $tmp = '';
+                            $fieldViewObj = $itemTableView->getObj($class);
+                            $linkWrap = false;
+                            $modifiedValue =
+                                $fieldViewObj->getRowMarkerArray(
+                                    $functablename,
+                                    $field,
+                                    $row,
+                                    $tmp,
+                                    $tmpArray,
+                                    $tmpArray,
+                                    $tmpArray,
+                                    $theCode,
+                                    '',
+                                    tx_ttproducts_control_basket::getBasketExtra(),
+                                    tx_ttproducts_control_basket::getRecs(),
+                                    $bSkip,
+                                    true,
+                                    '',
+                                    '',
+                                    '',
+                                    0,
+                                    '',
+                                    $linkWrap,
+                                    false
                                 );
-							$v = $modifiedValue;
-						}
-					}
-				}
+                            $v = $modifiedValue;
+                        }
+                    }
+                }
 
-				if (!in_array($field, $variantArray)) {
+                if (!in_array($field, $variantArray)) {
 
-					if (($position = strpos($field, '_uid')) !== false) {
-						$fieldId = substr($field, 0, $position);
-					} else {
-						if (
-							in_array($field, ['image', 'smallimage'])
-						) {
-							continue;
-						}
-					}
+                    if (($position = strpos($field, '_uid')) !== false) {
+                        $fieldId = substr($field, 0, $position);
+                    } else {
+                        if (
+                            in_array($field, ['image', 'smallimage'])
+                        ) {
+                            continue;
+                        }
+                    }
 
-					$tagId = $jsTableNamesId . '-' . $view . '-' . $uid . '-' . $field;
-					switch ($field) {
-						case 'image':
-						case 'image_uid':
-						case 'smallimage':
-						case 'smallimage_uid':
-							$imageRow = $row;
-							$imageTablename = $tablename;
-							if (
-								isset($rowArticle) &&
-								is_array($rowArticle) &&
-								isset($rowArticle[$field]) &&
-								$rowArticle[$field]
-							) {
-								$imageTablename = 'tt_products_articles';
-								$imageRow[$field] = $rowArticle[$field];
-								$imageRow['uid'] = $rowArticle['uid'];
-								$imageRow['pid'] = $rowArticle['pid'];
-							}
-							$imageRenderObj = 'image';
-							if ($theCode == 'LIST' || $theCode == 'SEARCH') {
-								$imageRenderObj = 'listImage';
+                    $tagId = $jsTableNamesId . '-' . $view . '-' . $uid . '-' . $field;
+                    switch ($field) {
+                        case 'image':
+                        case 'image_uid':
+                        case 'smallimage':
+                        case 'smallimage_uid':
+                            $imageRow = $row;
+                            $imageTablename = $tablename;
+                            if (
+                                isset($rowArticle) &&
+                                is_array($rowArticle) &&
+                                isset($rowArticle[$field]) &&
+                                $rowArticle[$field]
+                            ) {
+                                $imageTablename = 'tt_products_articles';
+                                $imageRow[$field] = $rowArticle[$field];
+                                $imageRow['uid'] = $rowArticle['uid'];
+                                $imageRow['pid'] = $rowArticle['pid'];
+                            }
+                            $imageRenderObj = 'image';
+                            if ($theCode == 'LIST' || $theCode == 'SEARCH') {
+                                $imageRenderObj = 'listImage';
 
-								if (
-									isset($categoryArray) &&
-									is_array($categoryArray) &&
-									!isset($categoryArray[$currentCat]) &&
-									isset($conf['listImageRoot.'])
-								) {
-									$imageRenderObj = 'listImageRoot';
-								}
-							} else if (
-								$theCode == 'SINGLE' &&
-								strpos($field, 'smallimage') !== false
-							) {
-								$imageRenderObj = 'smallImage';
-							}
+                                if (
+                                    isset($categoryArray) &&
+                                    is_array($categoryArray) &&
+                                    !isset($categoryArray[$currentCat]) &&
+                                    isset($conf['listImageRoot.'])
+                                ) {
+                                    $imageRenderObj = 'listImageRoot';
+                                }
+                            } else if (
+                                $theCode == 'SINGLE' &&
+                                strpos($field, 'smallimage') !== false
+                            ) {
+                                $imageRenderObj = 'smallImage';
+                            }
 
-							$imageArray =
-								$imageObj->getFileArray(
-									$imageTablename,
-									$imageRow,
-									$field,
-									false
-								);
+                            $imageArray =
+                                $imageObj->getFileArray(
+                                    $imageTablename,
+                                    $imageRow,
+                                    $field,
+                                    false
+                                );
 
                             if (
-								is_array($imageArray) &&
-								count($imageArray)
-							) {
-								$dirname = '';
-								if ($fieldId == $field) {
-									$dirname = $imageObj->getDirname($imageRow);
-								}
-								$theImgDAM = [];
-								$markerArray = [];
-								$linkWrap = '';
+                                is_array($imageArray) &&
+                                count($imageArray)
+                            ) {
+                                $dirname = '';
+                                if ($fieldId == $field) {
+                                    $dirname = $imageObj->getDirname($imageRow);
+                                }
+                                $theImgDAM = [];
+                                $markerArray = [];
+                                $linkWrap = '';
 
-								$mediaNum = $imageObj->getMediaNum(
-									'tt_products_articles',
-									'image',
-									$theCode
-								);
-								$specialConf = [];
-								$tmpArray = [];
+                                $mediaNum = $imageObj->getMediaNum(
+                                    'tt_products_articles',
+                                    'image',
+                                    $theCode
+                                );
+                                $specialConf = [];
+                                $tmpArray = [];
 
-								$imgCodeArray = $imageViewObj->getCodeMarkerArray(
-									'tt_products_articles',
-									'ARTICLE_IMAGE',
-									$theCode,
-									$imageRow,
-									$imageArray,
-									$fieldMarkerArray,
-									$dirname,
-									$mediaNum,
-									$imageRenderObj,
-									$linkWrap,
-									$markerArray,
-									$theImgDAM,
-									$specialConf
-								);
-								$v = $imgCodeArray;
-							} else {
-								$v = '';
-							}
-							break;
+                                $imgCodeArray = $imageViewObj->getCodeMarkerArray(
+                                    'tt_products_articles',
+                                    'ARTICLE_IMAGE',
+                                    $theCode,
+                                    $imageRow,
+                                    $imageArray,
+                                    $fieldMarkerArray,
+                                    $dirname,
+                                    $mediaNum,
+                                    $imageRenderObj,
+                                    $linkWrap,
+                                    $markerArray,
+                                    $theImgDAM,
+                                    $specialConf
+                                );
+                                $v = $imgCodeArray;
+                            } else {
+                                $v = '';
+                            }
+                            break;
 
-						case 'inStock':
-							$basketIntoPrefix = tx_ttproducts_model_control::getBasketIntoIdPrefix();
+                        case 'inStock':
+                            $basketIntoPrefix = tx_ttproducts_model_control::getBasketIntoIdPrefix();
 
                             if ($v > 0) {
-								$objResponse->addClear(
-									$basketIntoPrefix . '-' . $uid ,
-									'disabled'
-								);
-							} else {
-								$objResponse->addAssign(
-									$basketIntoPrefix . '-' . $uid,
-									'disabled',
-									'disabled'
-								);
-							}
-							$objResponse->addAssign(
-								'in-stock-id-' . $uid,
-								'innerHTML',
-								$languageObj->getLabel(
+                                $objResponse->addClear(
+                                    $basketIntoPrefix . '-' . $uid ,
+                                    'disabled'
+                                );
+                            } else {
+                                $objResponse->addAssign(
+                                    $basketIntoPrefix . '-' . $uid,
+                                    'disabled',
+                                    'disabled'
+                                );
+                            }
+                            $objResponse->addAssign(
+                                'in-stock-id-' . $uid,
+                                'innerHTML',
+                                $languageObj->getLabel(
                                     ($v > 0 ? 'in_stock' : 'not_in_stock')
                                 )
                             );
-							break;
+                            break;
 
-						default:
-							// nothing
-							break;
-					}
+                        default:
+                            // nothing
+                            break;
+                    }
 
-					if (in_array($field, $priceFieldArray)) {
-						$v = $priceViewObj->priceFormat($v);
-					}
+                    if (in_array($field, $priceFieldArray)) {
+                        $v = $priceViewObj->priceFormat($v);
+                    }
 
-					$modifiedRow[$fieldId] = $v;
-				}
-			}
+                    $modifiedRow[$fieldId] = $v;
+                }
+            }
 
-			$markerArray = [];
-			$theMarkerArray = [];
-			$newRow = $itemTableView->modifyFieldObject(
-				$row,
-				$modifiedRow,
-				$tableconf,
-				$markerPrefix,
-				$suffix,
-				$fieldMarkerArray,
-				$markerArray,
-				$theMarkerArray
-			);
+            $markerArray = [];
+            $theMarkerArray = [];
+            $newRow = $itemTableView->modifyFieldObject(
+                $row,
+                $modifiedRow,
+                $tableconf,
+                $markerPrefix,
+                $suffix,
+                $fieldMarkerArray,
+                $markerArray,
+                $theMarkerArray
+            );
 
-			foreach ($newRow as $field => $v) {
-				$tagId = $jsTableNamesId . '-' . $view . '-' . $uid . '-' . $field;
+            foreach ($newRow as $field => $v) {
+                $tagId = $jsTableNamesId . '-' . $view . '-' . $uid . '-' . $field;
 
-				if (is_array($v)) {
-					reset($v);
-					$vFirst = current($v);
-					$objResponse->addAssign($tagId, 'innerHTML', $vFirst);
-					$c = 0;
-					foreach ($v as $k => $v2) {
-						$c++;
-						$tagId2 = $tagId . '-' . $c;
-						$objResponse->addAssign($tagId2, 'innerHTML', $v2);
-					}
-				} else {
-					$objResponse->addAssign($tagId, 'innerHTML', $v);
-				}
-			}
-		}
+                if (is_array($v)) {
+                    reset($v);
+                    $vFirst = current($v);
+                    $objResponse->addAssign($tagId, 'innerHTML', $vFirst);
+                    $c = 0;
+                    foreach ($v as $k => $v2) {
+                        $c++;
+                        $tagId2 = $tagId . '-' . $c;
+                        $objResponse->addAssign($tagId2, 'innerHTML', $v2);
+                    }
+                } else {
+                    $objResponse->addAssign($tagId, 'innerHTML', $v);
+                }
+            }
+        }
 
-		$result = $objResponse->getXML();
+        $result = $objResponse->getXML();
 
-		// neu: Ausgabepuffer löschen ist neuerdings in Funktion getXML enthalten
+        // neu: Ausgabepuffer löschen ist neuerdings in Funktion getXML enthalten
         // 	ob_clean(); 
 
-	    //return the XML response generated by the tx_taxajax_response object
-		return $result;
-	}
+        //return the XML response generated by the tx_taxajax_response object
+        return $result;
+    }
 
 
-	public function &commands ($cmd, $param1 = '', $param2 = '', $param3 = '') {
-		$objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding());
+    public function &commands ($cmd, $param1 = '', $param2 = '', $param3 = '') {
+        $objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding());
 
-		switch ($cmd) {
-			default:
-				$hookVar = 'ajaxCommands';
-				if ($hookVar && isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])) {
-					foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
-						$hookObj= GeneralUtility::makeInstance($classRef);
-						if (method_exists($hookObj, 'init')) {
-							$hookObj->init($this);
-						}
-						if (method_exists($hookObj, 'commands')) {
-							$tmpArray =
-								$hookObj->commands(
-									$cmd,
-									$param1,
-									$param2,
-									$param3,
-									$objResponse
-								);
-						}
-					}
-				}
-			break;
-		}
+        switch ($cmd) {
+            default:
+                $hookVar = 'ajaxCommands';
+                if ($hookVar && isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])) {
+                    foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
+                        $hookObj= GeneralUtility::makeInstance($classRef);
+                        if (method_exists($hookObj, 'init')) {
+                            $hookObj->init($this);
+                        }
+                        if (method_exists($hookObj, 'commands')) {
+                            $tmpArray =
+                                $hookObj->commands(
+                                    $cmd,
+                                    $param1,
+                                    $param2,
+                                    $param3,
+                                    $objResponse
+                                );
+                        }
+                    }
+                }
+            break;
+        }
 
-		return $objResponse->getXML();
-	}
-
-
-
-	public function showArticle ($data) {
-		if (
-			isset($data[TT_PRODUCTS_EXT]) &&
-			is_array($data[TT_PRODUCTS_EXT])
-		) {
-			$data = $data[TT_PRODUCTS_EXT];
-		} else {
-			return false;
-		}
-
-		if (
-			isset($data['content']) &&
-			$data['content'] != ''
-		) {
-			$contentRow =
-				$GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow(
-					'*',
-					'tt_content',
-					'uid = ' . intval($data['content']));
-			$this->cObj->start($contentRow, 'tt_content');
-		} else {
-			return false;
-		}
-
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$result = '';
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
-		$mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');
-
-		$pibaseObj->cObj = $this->cObj;
-
-		if (
-			isset($data) &&
-			is_array($data) &&
-			isset($data[$pibaseObj->prefixId]) &&
-			is_array($data[$pibaseObj->prefixId])
-		) {
-			foreach($data[$pibaseObj->prefixId] as $k => $v) {
-				tx_ttproducts_model_control::setAndVar($k, $v);
-			}
-		}
-
-		$this->ajax->conf = $data['conf'];
-		$objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding());
-
-		$content = '';
-		$bDoProcessing =
-			$mainObj->init(
-				$content,
-				$cnfObj->getConf(),
-				$cnfObj->getConfig(),
-				$this->cObj,
-				'tx_ttproducts_pi1_base',
-				$errorCode,
-				true
-			);
-
-		if (
-			isset($contentRow) &&
-			is_array($contentRow) &&
-			isset($contentRow['uid'])
-		) {
-			$code = 'LIST';
-			$mainObj->codeArray = [$code];
-			$tagId = 'tt-products-' . strtolower($code) . '-' . $contentRow['uid'];
-		} else {
-			$content = 'Missing content data row';
-			$bDoProcessing = false;
-		}
-
-		if ($bDoProcessing || !empty($errorCode)) {
-
-			$content =
-				$mainObj->run(
-					$this->cObj,
-					'tx_ttproducts_pi1_base',
-					$errorCode,
-					$content,
-					true
-				);
-		}
-
-		$objResponse->addAssign($tagId, 'innerHTML', $content);
-		$result = $objResponse->getXML();
-	    //return the XML response generated by the tx_taxajax_response object
-		return $result;
-	}
+        return $objResponse->getXML();
+    }
 
 
-		// XAJAX functions
-	public function showList ($data) {
 
-		$tagId = '';
-		$result = '';
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
-		$mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');
+    public function showArticle ($data) {
+        if (
+            isset($data[TT_PRODUCTS_EXT]) &&
+            is_array($data[TT_PRODUCTS_EXT])
+        ) {
+            $data = $data[TT_PRODUCTS_EXT];
+        } else {
+            return false;
+        }
 
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
+        if (
+            isset($data['content']) &&
+            $data['content'] != ''
+        ) {
+            $contentRow =
+                $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow(
+                    '*',
+                    'tt_content',
+                    'uid = ' . intval($data['content']));
+            $this->cObj->start($contentRow, 'tt_content');
+        } else {
+            return false;
+        }
 
-		if (isset($piVars) && is_array($piVars)) {
-			if (
-				isset($data) &&
-				is_array($data) &&
-				isset($data[$prefixId]) &&
-				is_array($data[$prefixId])
-			) {
-				foreach($data[$prefixId] as $k => $v) {
-					if (isset($piVars[$k])) {
-						$piVars[$k] .= ',' . $v;
-					} else {
-						$piVars[$k] = $v;
-					}
-				}
-			}
-		}
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $result = '';
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
+        $mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');
+
+        $pibaseObj->cObj = $this->cObj;
+
+        if (
+            isset($data) &&
+            is_array($data) &&
+            isset($data[$pibaseObj->prefixId]) &&
+            is_array($data[$pibaseObj->prefixId])
+        ) {
+            foreach($data[$pibaseObj->prefixId] as $k => $v) {
+                tx_ttproducts_model_control::setAndVar($k, $v);
+            }
+        }
+
+        $this->ajax->conf = $data['conf'];
+        $objResponse = new tx_taxajax_response($this->ajax->taxajax->getCharEncoding());
+
+        $content = '';
+        $bDoProcessing =
+            $mainObj->init(
+                $content,
+                $cnfObj->getConf(),
+                $cnfObj->getConfig(),
+                $this->cObj,
+                'tx_ttproducts_pi1_base',
+                $errorCode,
+                true
+            );
+
+        if (
+            isset($contentRow) &&
+            is_array($contentRow) &&
+            isset($contentRow['uid'])
+        ) {
+            $code = 'LIST';
+            $mainObj->codeArray = [$code];
+            $tagId = 'tt-products-' . strtolower($code) . '-' . $contentRow['uid'];
+        } else {
+            $content = 'Missing content data row';
+            $bDoProcessing = false;
+        }
+
+        if ($bDoProcessing || !empty($errorCode)) {
+
+            $content =
+                $mainObj->run(
+                    $this->cObj,
+                    'tx_ttproducts_pi1_base',
+                    $errorCode,
+                    $content,
+                    true
+                );
+        }
+
+        $objResponse->addAssign($tagId, 'innerHTML', $content);
+        $result = $objResponse->getXML();
+        //return the XML response generated by the tx_taxajax_response object
+        return $result;
+    }
+
+
+        // XAJAX functions
+    public function showList ($data) {
+
+        $tagId = '';
+        $result = '';
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
+        $mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');
+
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
+
+        if (isset($piVars) && is_array($piVars)) {
+            if (
+                isset($data) &&
+                is_array($data) &&
+                isset($data[$prefixId]) &&
+                is_array($data[$prefixId])
+            ) {
+                foreach($data[$prefixId] as $k => $v) {
+                    if (isset($piVars[$k])) {
+                        $piVars[$k] .= ',' . $v;
+                    } else {
+                        $piVars[$k] = $v;
+                    }
+                }
+            }
+        }
 
         // We put our incomming data to the regular piVars
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
         $parameterApi->setPiVars($piVars);
         // We put our incomming data to the regular piVars
         tx_ttproducts_model_control::setPiVars($piVars);
-		$pibaseObj->cObj = $this->cObj;
+        $pibaseObj->cObj = $this->cObj;
 
-	    // Instantiate the tx_xajax_response object
-	    $objResponse = new tx_xajax_response();
+        // Instantiate the tx_xajax_response object
+        $objResponse = new tx_xajax_response();
 
-		$bDoProcessing =
-			$mainObj->init(
-				$content,
-				$cnfObj->getConf(),
-				$cnfObj->getConfig(),
-				$this->cObj,
-				'tx_ttproducts_pi1_base',
-				$errorCode,
-				true
-			);
-
-
-		if (count($this->codeArray)) {
-			foreach ($this->codeArray as $k => $code) {
-				if ($code != 'LISTARTICLES') {
-					unset($this->codeArray[$k]);
-				} else {
-					$tagId = 'tx-ttproducts-pi1-' . strtolower($code);
-				}
-			}
-		}
-
-		if ($tagId != '') {
-			if ($bDoProcessing || !empty($errorCode)) {
-
-				$content =
-					$mainObj->run(
-						$this->cObj,
-						'tx_ttproducts_pi1_base',
-						$errorCode,
-						$content,
-						true
-					);
-
-				$objResponse->addAssign(
-					$tagId,
-					'innerHTML',
-					$content
-				);
-
-				//return the XML response generated by the tx_xajax_response object
-				$result = $objResponse->getXML();
-			}
-		}
-	    return $result;
-	}
+        $bDoProcessing =
+            $mainObj->init(
+                $content,
+                $cnfObj->getConf(),
+                $cnfObj->getConfig(),
+                $this->cObj,
+                'tx_ttproducts_pi1_base',
+                $errorCode,
+                true
+            );
 
 
-	public function destruct () {
-		$controlCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_control_creator');
-		$controlCreatorObj->destruct();
+        if (count($this->codeArray)) {
+            foreach ($this->codeArray as $k => $code) {
+                if ($code != 'LISTARTICLES') {
+                    unset($this->codeArray[$k]);
+                } else {
+                    $tagId = 'tx-ttproducts-pi1-' . strtolower($code);
+                }
+            }
+        }
 
-		$modelCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_model_creator');
-		$modelCreatorObj->destruct();
+        if ($tagId != '') {
+            if ($bDoProcessing || !empty($errorCode)) {
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$tablesObj->destruct();
-	}
+                $content =
+                    $mainObj->run(
+                        $this->cObj,
+                        'tx_ttproducts_pi1_base',
+                        $errorCode,
+                        $content,
+                        true
+                    );
+
+                $objResponse->addAssign(
+                    $tagId,
+                    'innerHTML',
+                    $content
+                );
+
+                //return the XML response generated by the tx_xajax_response object
+                $result = $objResponse->getXML();
+            }
+        }
+        return $result;
+    }
+
+
+    public function destruct () {
+        $controlCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_control_creator');
+        $controlCreatorObj->destruct();
+
+        $modelCreatorObj = GeneralUtility::makeInstance('tx_ttproducts_model_creator');
+        $modelCreatorObj->destruct();
+
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tablesObj->destruct();
+    }
 }
 
 

--- a/hooks/class.tx_ttproducts_hooks_pool.php
+++ b/hooks/class.tx_ttproducts_hooks_pool.php
@@ -41,49 +41,49 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_hooks_pool extends tx_pool_hooks_base {
-	public $extKey = TT_PRODUCTS_EXT;
-	public $prefixId = 'tx_ttproducts_hooks_pool';	// Same as class name
-	public $LLFileArray =
-		[
-			'hooks/locallang_pool.xml',
-			DIV2007_LANGUAGE_PATH . 'locallang_mod_web_list.xlf'
-		];
-	public $modMenu = ['function' => ['search']];
-	public $headerText = 'header_search';
+    public $extKey = TT_PRODUCTS_EXT;
+    public $prefixId = 'tx_ttproducts_hooks_pool';	// Same as class name
+    public $LLFileArray =
+        [
+            'hooks/locallang_pool.xml',
+            DIV2007_LANGUAGE_PATH . 'locallang_mod_web_list.xlf'
+        ];
+    public $modMenu = ['function' => ['search']];
+    public $headerText = 'header_search';
 
-	public function getViewData (
-		&$content,
-		&$header,
-		&$docHeaderButtons,
-		&$markerArray,
-		$pOb
-	) {
-		$content = '<b>Suche &uuml;ber tt_products</b><br/>';
+    public function getViewData (
+        &$content,
+        &$header,
+        &$docHeaderButtons,
+        &$markerArray,
+        $pOb
+    ) {
+        $content = '<b>Suche &uuml;ber tt_products</b><br/>';
 
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('searchbox')) {
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('searchbox')) {
 
 // 			GeneralUtility::requireOnce(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('searchbox') . 'view/class.tx_searchbox_view.php');
-			$searchBoxObj = GeneralUtility::makeInstance('tx_searchbox_view');
+            $searchBoxObj = GeneralUtility::makeInstance('tx_searchbox_view');
 
-			$content .= $searchBoxObj->getContent(
-				$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateFile'],
-				'ITEM_SEARCH',
-				$this->prefixId,
-				$this->vars,
-				'index.php'
-			);
-			$dbListConf = $searchBoxObj->getDblistConf($this->prefixId);
-		}
+            $content .= $searchBoxObj->getContent(
+                $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateFile'],
+                'ITEM_SEARCH',
+                $this->prefixId,
+                $this->vars,
+                'index.php'
+            );
+            $dbListConf = $searchBoxObj->getDblistConf($this->prefixId);
+        }
 
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('db_list')) {
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('db_list')) {
 // 			GeneralUtility::requireOnce(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('db_list') . 'class.tx_dblist_script.php');
-			$dbListObj = GeneralUtility::makeInstance('tx_dblist_script');
-			$dbListObj->init($this->vars, $dbListConf);
+            $dbListObj = GeneralUtility::makeInstance('tx_dblist_script');
+            $dbListObj->init($this->vars, $dbListConf);
 
-			$dbListObj->clearCache();
-			$dbListObj->main($docHeaderButtons, $markerArray, $pOb);
-			$content .= $dbListObj->getContent();
-		}
-		parent::getViewData($content, $header, $docHeaderButtons, $markerArray, $pOb);
-	}
+            $dbListObj->clearCache();
+            $dbListObj->main($docHeaderButtons, $markerArray, $pOb);
+            $content .= $dbListObj->getContent();
+        }
+        parent::getViewData($content, $header, $docHeaderButtons, $markerArray, $pOb);
+    }
 }

--- a/hooks/class.tx_ttproducts_ws_flexslider.php
+++ b/hooks/class.tx_ttproducts_ws_flexslider.php
@@ -43,57 +43,57 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_ws_flexslider {
 
-	public function getUid (
-		$pObj,
-		&$imageField,
-		&$imageArray
-	) {
-		$uid = 0;
+    public function getUid (
+        $pObj,
+        &$imageField,
+        &$imageArray
+    ) {
+        $uid = 0;
 
-		$params =  GeneralUtility::_GP('tt_products');
-		if (isset($params) && is_array($params)) {
-			$uid = $params['cat'];
-		}
+        $params =  GeneralUtility::_GP('tt_products');
+        if (isset($params) && is_array($params)) {
+            $uid = $params['cat'];
+        }
 
-		if ($uid) {
-			$imageField = 'sliderimage';
-			$imageArray =
-				$this->getImages(
-					$pObj,
-					$uid,
-					'tt_products_cat',
-					$imageField
-				);
-			$imageField = 'catimages';
-		}
+        if ($uid) {
+            $imageField = 'sliderimage';
+            $imageArray =
+                $this->getImages(
+                    $pObj,
+                    $uid,
+                    'tt_products_cat',
+                    $imageField
+                );
+            $imageField = 'catimages';
+        }
 
-		return $uid;
-	}
+        return $uid;
+    }
 
-	protected function getImages (
-		WapplerSystems\WsFlexslider\Controller\FlexsliderController $pObj,
-		$uid,
-		$table,
-		$imageField
-	) {
-		$images =
-			$pObj->getImageRepository()->getImages(
-				$table,
-				$imageField,
-				$uid
-			);
-		$imageElement =
-			explode(
-				',',
-				$images[0][$imageField]
-			);
-		$imageArray = [];
+    protected function getImages (
+        WapplerSystems\WsFlexslider\Controller\FlexsliderController $pObj,
+        $uid,
+        $table,
+        $imageField
+    ) {
+        $images =
+            $pObj->getImageRepository()->getImages(
+                $table,
+                $imageField,
+                $uid
+            );
+        $imageElement =
+            explode(
+                ',',
+                $images[0][$imageField]
+            );
+        $imageArray = [];
 
-		foreach ($imageElement as $k => $value) {
-			$imageArray[$k]['image'] = $value;
-		}
+        foreach ($imageElement as $k => $value) {
+            $imageArray[$k]['image'] = $value;
+        }
 
-		return $imageArray;
-	}
+        return $imageArray;
+    }
 }
 

--- a/lib/class.tx_ttproducts_billdelivery.php
+++ b/lib/class.tx_ttproducts_billdelivery.php
@@ -43,258 +43,258 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_billdelivery implements \TYPO3\CMS\Core\SingletonInterface {
-	public $tableArray;
-	public $price;		 // object for price functions
-	public $typeArray = ['bill', 'delivery'];
+    public $tableArray;
+    public $price;		 // object for price functions
+    public $typeArray = ['bill', 'delivery'];
 
 
 
-	public function getTypeArray () {
-		return $this->typeArray;
-	}
+    public function getTypeArray () {
+        return $this->typeArray;
+    }
 
 
-	/**
-	 * get the relative filename of the bill or delivery file by the tracking code
-	 */
-	public function getRelFilename ($tracking, $type, $fileExtension = 'html') {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    /**
+     * get the relative filename of the bill or delivery file by the tracking code
+     */
+    public function getRelFilename ($tracking, $type, $fileExtension = 'html') {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		$rc = $conf['outputFolder'] . '/' . $type . '/' . $tracking . '.' . $fileExtension;
+        $rc = $conf['outputFolder'] . '/' . $type . '/' . $tracking . '.' . $fileExtension;
 
-		return $rc;
-	}
-
-
-	public function getMarkerArray (&$markerArray, $tracking, $type) {
-		$markerprefix = strtoupper($type);
-		$relfilename = $this->getRelFilename($tracking, $type);
-		$markerArray['###' . $markerprefix . '_FILENAME###'] = $relfilename;
-	}
+        return $rc;
+    }
 
 
-	public function getFileAbsFileName ($type, $tracking, $fileExtension) {
-		$relfilename = $this->getRelFilename($tracking, $type, $fileExtension);
-		$filename = GeneralUtility::getFileAbsFileName($relfilename);
-		return $filename;
-	}
+    public function getMarkerArray (&$markerArray, $tracking, $type) {
+        $markerprefix = strtoupper($type);
+        $relfilename = $this->getRelFilename($tracking, $type);
+        $markerArray['###' . $markerprefix . '_FILENAME###'] = $relfilename;
+    }
 
 
-	public function writeFile ($filename, $content) {
-		$theFile = fopen($filename, 'wb');
-		fwrite($theFile, $content);
-		fclose($theFile);
-	}
+    public function getFileAbsFileName ($type, $tracking, $fileExtension) {
+        $relfilename = $this->getRelFilename($tracking, $type, $fileExtension);
+        $filename = GeneralUtility::getFileAbsFileName($relfilename);
+        return $filename;
+    }
 
 
-	public function generateBill (
-		$cObj,
-		$templateCode,
-		$mainMarkerArray,
-		$itemArray,
-		$calculatedArray,
-		$orderArray,
-		$basketExtra,
-		$basketRecs,
-		$type,
-		$generationConf
-	) {
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-		$productRowArray = []; // Todo: make this a parameter
+    public function writeFile ($filename, $content) {
+        $theFile = fopen($filename, 'wb');
+        fwrite($theFile, $content);
+        fclose($theFile);
+    }
 
-		$typeCode = strtoupper($type);
-		$result = false;
-		$generationType = strtolower($generationConf['type'] ?? '');
-		$billGeneratedFromHook = false;
 
-		// Hook
-			// Call all billing delivery hooks
-		if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery']) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery'])) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
+    public function generateBill (
+        $cObj,
+        $templateCode,
+        $mainMarkerArray,
+        $itemArray,
+        $calculatedArray,
+        $orderArray,
+        $basketExtra,
+        $basketRecs,
+        $type,
+        $generationConf
+    ) {
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $productRowArray = []; // Todo: make this a parameter
 
-				if (method_exists($hookObj, 'generateBill')) {
-					$billGeneratedFromHook = $hookObj->generateBill(
-						$this,
-						$cObj,
-						$templateCode,
-						$mainMarkerArray,
-						$itemArray,
-						$calculatedArray,
-						$orderArray,
-						$basketExtra,
-						$basketRecs,
-						$type,
-						$generationConf,
-						$result
-					);
-				}
-				if ($billGeneratedFromHook) {
-					break;
-				}
-			}
-		}
+        $typeCode = strtoupper($type);
+        $result = false;
+        $generationType = strtolower($generationConf['type'] ?? '');
+        $billGeneratedFromHook = false;
 
-		if (!$billGeneratedFromHook && isset($orderArray['bill_no'])) {
-			if ($generationType == 'pdf') {
+        // Hook
+            // Call all billing delivery hooks
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery']) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery'])) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['billdelivery'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
 
-				$absFileName =
-					$this->getFileAbsFileName(
-						$type,
-						str_replace('_', '-', strtolower($orderArray['bill_no'])) . '-' . $orderArray['tracking_code'],
-						'pdf'
-					);
-				$className = 'tx_ttproducts_pdf_view';
-				if (
-					\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fpdf') // use FPDF
-				) {
-					$className = 'tx_ttproducts_fpdf_view';
-				}
+                if (method_exists($hookObj, 'generateBill')) {
+                    $billGeneratedFromHook = $hookObj->generateBill(
+                        $this,
+                        $cObj,
+                        $templateCode,
+                        $mainMarkerArray,
+                        $itemArray,
+                        $calculatedArray,
+                        $orderArray,
+                        $basketExtra,
+                        $basketRecs,
+                        $type,
+                        $generationConf,
+                        $result
+                    );
+                }
+                if ($billGeneratedFromHook) {
+                    break;
+                }
+            }
+        }
 
-				$pdfViewObj = GeneralUtility::makeInstance($className);
-				$result = $pdfViewObj->generate(
-					$cObj,
-					$basketView,
-					$infoViewObj,
-					$templateCode,
-					$mainMarkerArray,
-					$itemArray,
-					$calculatedArray,
-					$orderArray,
-					$productRowArray,
-					$basketExtra,
-					$basketRecs,
-					$typeCode,
-					$generationConf,
-					$absFileName
-				);
-			} else if ($generationType == 'html') {
-				$subpart = $typeCode . '_TEMPLATE';
-				$content = $basketView->getView(
-					$errorCode,
-					$templateCode,
-					$typeCode,
-					$infoViewObj,
-					false,
-					true,
-					$calculatedArray,
-					true,
-					$subpart,
-					$mainMarkerArray,
-					'',
-					$itemArray,
+        if (!$billGeneratedFromHook && isset($orderArray['bill_no'])) {
+            if ($generationType == 'pdf') {
+
+                $absFileName =
+                    $this->getFileAbsFileName(
+                        $type,
+                        str_replace('_', '-', strtolower($orderArray['bill_no'])) . '-' . $orderArray['tracking_code'],
+                        'pdf'
+                    );
+                $className = 'tx_ttproducts_pdf_view';
+                if (
+                    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fpdf') // use FPDF
+                ) {
+                    $className = 'tx_ttproducts_fpdf_view';
+                }
+
+                $pdfViewObj = GeneralUtility::makeInstance($className);
+                $result = $pdfViewObj->generate(
+                    $cObj,
+                    $basketView,
+                    $infoViewObj,
+                    $templateCode,
+                    $mainMarkerArray,
+                    $itemArray,
+                    $calculatedArray,
+                    $orderArray,
+                    $productRowArray,
+                    $basketExtra,
+                    $basketRecs,
+                    $typeCode,
+                    $generationConf,
+                    $absFileName
+                );
+            } else if ($generationType == 'html') {
+                $subpart = $typeCode . '_TEMPLATE';
+                $content = $basketView->getView(
+                    $errorCode,
+                    $templateCode,
+                    $typeCode,
+                    $infoViewObj,
+                    false,
+                    true,
+                    $calculatedArray,
+                    true,
+                    $subpart,
+                    $mainMarkerArray,
+                    '',
+                    $itemArray,
                     $notOverwritePriceIfSet = false,
-					['0' => $orderArray],
-					$productRowArray,
-					$basketExtra,
-					$basketRecs
-				);
+                    ['0' => $orderArray],
+                    $productRowArray,
+                    $basketExtra,
+                    $basketRecs
+                );
 
-				if (
-					!isset($errorCode) ||
-					$errorCode[0] == ''
-				) {
-					$absFileName =
-						$this->getFileAbsFileName(
-							$type,
-							str_replace('_', '-', $orderArray['bill_no']) . '-' . $orderArray['tracking_code'],
-							'html'
-						);
-					$this->writeFile($absFileName, $content);
-					$result = $absFileName;
-				}
-			} else {
-				$result = false;
-			}
-		}
+                if (
+                    !isset($errorCode) ||
+                    $errorCode[0] == ''
+                ) {
+                    $absFileName =
+                        $this->getFileAbsFileName(
+                            $type,
+                            str_replace('_', '-', $orderArray['bill_no']) . '-' . $orderArray['tracking_code'],
+                            'html'
+                        );
+                    $this->writeFile($absFileName, $content);
+                    $result = $absFileName;
+                }
+            } else {
+                $result = false;
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/**
-	 * Bill,Delivery Generation from tracking code
-	 */
-	public function getInformation (
-		$theCode,
-		$orderRow,
-		$templateCode,
-		$trackingCode,
-		$type
-	) {
-		/*
-		Bill or delivery information display, which needs tracking code to be shown
-		This is extension information to tracking at another page
-		See Tracking for further information
-		*/
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    /**
+     * Bill,Delivery Generation from tracking code
+     */
+    public function getInformation (
+        $theCode,
+        $orderRow,
+        $templateCode,
+        $trackingCode,
+        $type
+    ) {
+        /*
+        Bill or delivery information display, which needs tracking code to be shown
+        This is extension information to tracking at another page
+        See Tracking for further information
+        */
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$productRowArray = []; // Todo: make this a parameter
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $productRowArray = []; // Todo: make this a parameter
 
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-		$orderObj = $tablesObj->get('sys_products_orders');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $orderObj = $tablesObj->get('sys_products_orders');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
 // 		$paymentshippingObj = GeneralUtility::makeInstance('tx_ttproducts_paymentshipping');
 
-			// initialize order data.
-		$orderData = $orderObj->getOrderData($orderRow);
-		$itemArray =
-			$orderObj->getItemArray(
-				$orderRow,
-				$calculatedArray,
-				$infoArray
-			);
-		$infoViewObj->init2($infoArray);
+            // initialize order data.
+        $orderData = $orderObj->getOrderData($orderRow);
+        $itemArray =
+            $orderObj->getItemArray(
+                $orderRow,
+                $calculatedArray,
+                $infoArray
+            );
+        $infoViewObj->init2($infoArray);
 
-		$basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
-		$basketExtra =
-			tx_ttproducts_control_basket::getBasketExtras(
-				$tablesObj,
-				$basketRec,
-				$conf
-			);
+        $basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
+        $basketExtra =
+            tx_ttproducts_control_basket::getBasketExtras(
+                $tablesObj,
+                $basketRec,
+                $conf
+            );
 
-		if ($type == 'bill') {
-			$subpartMarker='BILL_TEMPLATE';
-		} else {
-			$subpartMarker='DELIVERY_TEMPLATE';
-		}
+        if ($type == 'bill') {
+            $subpartMarker='BILL_TEMPLATE';
+        } else {
+            $subpartMarker='DELIVERY_TEMPLATE';
+        }
 
-		$orderArray = [];
+        $orderArray = [];
 
-		$orderArray['tracking_code'] = $trackingCode;
-		$orderArray['uid'] = $orderRow['uid'];
-		$orderArray['crdate'] = $orderRow['crdate'];
+        $orderArray['tracking_code'] = $trackingCode;
+        $orderArray['uid'] = $orderRow['uid'];
+        $orderArray['crdate'] = $orderRow['crdate'];
 
-		$content = $basketView->getView(
-			$errorCode,
-			$templateCode,
-			$theCode,
-			$infoViewObj,
-			false,
-			false,
-			$calculatedArray,
-			true,
-			$subpartMarker,
-			$globalMarkerArray,
-			'',
-			$itemArray,
+        $content = $basketView->getView(
+            $errorCode,
+            $templateCode,
+            $theCode,
+            $infoViewObj,
+            false,
+            false,
+            $calculatedArray,
+            true,
+            $subpartMarker,
+            $globalMarkerArray,
+            '',
+            $itemArray,
             $notOverwritePriceIfSet = false,
-			['0' => $orderArray],
-			$productRowArray,
-			$basketExtra,
-			$basketRec
-		);
+            ['0' => $orderArray],
+            $productRowArray,
+            $basketExtra,
+            $basketRec
+        );
 
-		return $content;
-	}
+        return $content;
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_config.php
+++ b/lib/class.tx_ttproducts_config.php
@@ -41,298 +41,298 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_config implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $config;
-	private $bHasBeenInitialised = false;
+    public $conf;
+    public $config;
+    private $bHasBeenInitialised = false;
 
 
-	/**
-	 * Getting the configurations
-	 */
-	public function init ($conf, $config) {
-		$this->conf = $conf;
+    /**
+     * Getting the configurations
+     */
+    public function init ($conf, $config) {
+        $this->conf = $conf;
 
-		$this->config = $config;
-		$this->bHasBeenInitialised = true;
-	} // init
-
-
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+        $this->config = $config;
+        $this->bHasBeenInitialised = true;
+    } // init
 
 
-	public function setConf ($key, $value) {
-		if ($key != '') {
-			$this->conf[$key] = $value;
-		} else {
-			$this->conf = $value;
-		}
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
 
 
-	public function getConf () {
-		$result = $this->conf;
-		if (self::needsInit()) {
-			$result = false;
-		}
-
-		return $result;
-	}
-
-
-	public function setConfig ($value) {
-		$this->config = $value;
-	}
+    public function setConf ($key, $value) {
+        if ($key != '') {
+            $this->conf[$key] = $value;
+        } else {
+            $this->conf = $value;
+        }
+    }
 
 
-	public function getConfig () {
-		return $this->config;
-	}
+    public function getConf () {
+        $result = $this->conf;
+        if (self::needsInit()) {
+            $result = false;
+        }
+
+        return $result;
+    }
 
 
-	public function getUseArticles () {
-		$result = false;
-		$conf = $this->getConf();
-		if (isset($conf) && is_array($conf)) {
-			$result = $conf['useArticles'];
-		}
-		return $result;
-	}
+    public function setConfig ($value) {
+        $this->config = $value;
+    }
 
 
-	public function getTableDesc ($functablename, $type = '') {
-		$tableDesc = [];
-		if (
-			isset($this->conf['table.']) &&
-			isset($this->conf['table.'][$functablename . '.'])
-		) {
-			$tableDesc = $this->conf['table.'][$functablename . '.'];
-		}
-
-		if ($type && isset($tableDesc[$type])) {
-			$result = $tableDesc[$type];
-		} else {
-			$result = $tableDesc;
-		}
-		return $result;
-	}
+    public function getConfig () {
+        return $this->config;
+    }
 
 
-	public function getTableName ($functablename) {
-		if (
-			isset($this->conf['table.']) &&
-			is_array($this->conf['table.']) &&
-			isset($this->conf['table.'][$functablename])
-		) {
-			$result = $this->conf['table.'][$functablename];
-		} else {
-			$result = $functablename;
-		}
-		return $result;
-	}
+    public function getUseArticles () {
+        $result = false;
+        $conf = $this->getConf();
+        if (isset($conf) && is_array($conf)) {
+            $result = $conf['useArticles'];
+        }
+        return $result;
+    }
 
 
-	public function getSpecialConf ($type, $tablename = '', $theCode = '') {
-		$specialConf = [];
+    public function getTableDesc ($functablename, $type = '') {
+        $tableDesc = [];
+        if (
+            isset($this->conf['table.']) &&
+            isset($this->conf['table.'][$functablename . '.'])
+        ) {
+            $tableDesc = $this->conf['table.'][$functablename . '.'];
+        }
 
-		if (isset($this->conf[$type . '.'])) {
+        if ($type && isset($tableDesc[$type])) {
+            $result = $tableDesc[$type];
+        } else {
+            $result = $tableDesc;
+        }
+        return $result;
+    }
 
-			if ($tablename != '' && isset($this->conf[$type . '.'][$tablename . '.'])) {
-				if (
-					is_array($this->conf[$type . '.'][$tablename . '.']['ALL.'])
-				) {
-					$specialConf = $this->conf[$type . '.'][$tablename . '.']['ALL.'];
-				}
-				if (
-					$theCode &&
-					isset($this->conf[$type . '.'][$tablename . '.'][$theCode . '.'])
-				) {
-					$tempConf = $this->conf[$type . '.'][$tablename . '.'][$theCode . '.'];
-					\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($specialConf, $tempConf);
-				}
-				if (
+
+    public function getTableName ($functablename) {
+        if (
+            isset($this->conf['table.']) &&
+            is_array($this->conf['table.']) &&
+            isset($this->conf['table.'][$functablename])
+        ) {
+            $result = $this->conf['table.'][$functablename];
+        } else {
+            $result = $functablename;
+        }
+        return $result;
+    }
+
+
+    public function getSpecialConf ($type, $tablename = '', $theCode = '') {
+        $specialConf = [];
+
+        if (isset($this->conf[$type . '.'])) {
+
+            if ($tablename != '' && isset($this->conf[$type . '.'][$tablename . '.'])) {
+                if (
+                    is_array($this->conf[$type . '.'][$tablename . '.']['ALL.'])
+                ) {
+                    $specialConf = $this->conf[$type . '.'][$tablename . '.']['ALL.'];
+                }
+                if (
+                    $theCode &&
+                    isset($this->conf[$type . '.'][$tablename . '.'][$theCode . '.'])
+                ) {
+                    $tempConf = $this->conf[$type . '.'][$tablename . '.'][$theCode . '.'];
+                    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($specialConf, $tempConf);
+                }
+                if (
                     isset($specialConf['orderBy']) &&
                     $specialConf['orderBy'] == '{$plugin.' . TT_PRODUCTS_EXT . '.orderBy}'
                 ) {
-					$specialConf['orderBy'] = '';
-				}
-			} else {
-				if (isset($this->conf[$type . '.']['ALL.'])) {
-					$specialConf = $this->conf[$type . '.']['ALL.'];
-				}
-				if (
-					$theCode &&
-					isset($this->conf[$type . '.'][$theCode . '.'])
-				) {
-					$tempConf = $this->conf[$type . '.'][$theCode . '.'];
-					\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($specialConf, $tempConf);
-				}
-			}
-		}
-		return $specialConf;
-	}
+                    $specialConf['orderBy'] = '';
+                }
+            } else {
+                if (isset($this->conf[$type . '.']['ALL.'])) {
+                    $specialConf = $this->conf[$type . '.']['ALL.'];
+                }
+                if (
+                    $theCode &&
+                    isset($this->conf[$type . '.'][$theCode . '.'])
+                ) {
+                    $tempConf = $this->conf[$type . '.'][$theCode . '.'];
+                    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($specialConf, $tempConf);
+                }
+            }
+        }
+        return $specialConf;
+    }
 
 
-	public function getTableConf ($functablename, $theCode = '') {
-		$tableConf = $this->getSpecialConf('conf', $functablename, $theCode);
-		return $tableConf;
-	}
+    public function getTableConf ($functablename, $theCode = '') {
+        $tableConf = $this->getSpecialConf('conf', $functablename, $theCode);
+        return $tableConf;
+    }
 
 
-	public function getCSSConf ($functablename, $theCode = '') {
-		$cssConf = $this->getSpecialConf('CSS', $functablename, $theCode);
+    public function getCSSConf ($functablename, $theCode = '') {
+        $cssConf = $this->getSpecialConf('CSS', $functablename, $theCode);
 
-		return $cssConf;
-	}
-
-
-	public function getJsConf ($theCode = '') {
-		$result = $this->getSpecialConf('js', '', $theCode);
-
-		return $result;
-	}
+        return $cssConf;
+    }
 
 
-	public function getFormConf ($theCode = '') {
-		$result = $this->getSpecialConf('form', '', $theCode);
+    public function getJsConf ($theCode = '') {
+        $result = $this->getSpecialConf('js', '', $theCode);
 
-		return $result;
-	}
-
-
-	public function getViewControlConf ($theCode) {
-		$viewConf = $this->getSpecialConf('control', '', $theCode);
-
-		return $viewConf;
-	}
+        return $result;
+    }
 
 
-	public function getTypeConf ($type, $feature, $detail = '') {
+    public function getFormConf ($theCode = '') {
+        $result = $this->getSpecialConf('form', '', $theCode);
 
-		$rc = [];
-
-		if (isset($this->conf[$type . '.'])) {
-			if ($detail != '') {
-				if (
-					isset($this->conf[$type . '.'][$feature . '.']) &&
-					is_array($this->conf[$type . '.'][$feature . '.'])
-				) {
-					if (isset($this->conf[$type . '.'][$feature . '.'][$detail])) {
-						$rc = $this->conf[$type . '.'][$feature . '.'][$detail];
-					} else if (isset($this->conf[$type . '.'][$feature . '.'][$detail . '.'])) {
-						$rc = $this->conf[$type . '.'][$feature . '.'][$detail . '.'];
-					}
-				}
-			} else {
-				if (
-					isset($this->conf[$type . '.'][$feature]) &&
-					$this->conf[$type . '.'][$feature] != ''
-				) {
-					$rc = $this->conf[$type . '.'][$feature];
-				} else if (isset($this->conf[$type . '.'][$feature . '.'])) {
-					$rc = $this->conf[$type . '.'][$feature . '.'];
-				}
-			}
-		}
-		return $rc;
-	}
+        return $result;
+    }
 
 
-	public function getBasketConf ($feature, $detail = '') {
-		$result = $this->getTypeConf('basket', $feature, $detail);
-		return $result;
-	}
+    public function getViewControlConf ($theCode) {
+        $viewConf = $this->getSpecialConf('control', '', $theCode);
+
+        return $viewConf;
+    }
 
 
-	public function getFinalizeConf ($feature, $detail = '') {
-		$result = $this->getTypeConf('finalize', $feature, $detail);
-		return $result;
-	}
+    public function getTypeConf ($type, $feature, $detail = '') {
+
+        $rc = [];
+
+        if (isset($this->conf[$type . '.'])) {
+            if ($detail != '') {
+                if (
+                    isset($this->conf[$type . '.'][$feature . '.']) &&
+                    is_array($this->conf[$type . '.'][$feature . '.'])
+                ) {
+                    if (isset($this->conf[$type . '.'][$feature . '.'][$detail])) {
+                        $rc = $this->conf[$type . '.'][$feature . '.'][$detail];
+                    } else if (isset($this->conf[$type . '.'][$feature . '.'][$detail . '.'])) {
+                        $rc = $this->conf[$type . '.'][$feature . '.'][$detail . '.'];
+                    }
+                }
+            } else {
+                if (
+                    isset($this->conf[$type . '.'][$feature]) &&
+                    $this->conf[$type . '.'][$feature] != ''
+                ) {
+                    $rc = $this->conf[$type . '.'][$feature];
+                } else if (isset($this->conf[$type . '.'][$feature . '.'])) {
+                    $rc = $this->conf[$type . '.'][$feature . '.'];
+                }
+            }
+        }
+        return $rc;
+    }
 
 
-	public function getDownloadConf ($feature, $detail = '') {
-		$result = $this->getTypeConf('download', $feature, $detail);
-		return $result;
-	}
+    public function getBasketConf ($feature, $detail = '') {
+        $result = $this->getTypeConf('basket', $feature, $detail);
+        return $result;
+    }
 
 
-	public function getFallback ($tableConf) {
-		$result = false;
-		if (
-			isset($tableConf) &&
-			is_array($tableConf) &&
-			isset($tableConf['language.']) &&
-			$tableConf['language.']['type'] == 'table' &&
-			isset($tableConf['language.']['mode']) &&
-			$tableConf['language.']['mode'] == 'fallback'
-		) {
-			$result = true;
-		}
-
-		return $result;
-	}
-
-	public function getTranslationFields ($tableConf) {
-		$fieldArray = [];
-		if (isset($tableConf['language.']) && is_array($tableConf['language.']) && isset($tableConf['language.']['type']) && $tableConf['language.']['type'] == 'field') {
-			$langConf = $tableConf['language.']['field.'];
-			if (is_array($langConf)) {
-				foreach ($langConf as $field => $langfield) {
-					$fieldArray[$field] = $langfield;
-				}
-			}
-		}
-		return $fieldArray;
-	}
+    public function getFinalizeConf ($feature, $detail = '') {
+        $result = $this->getTypeConf('finalize', $feature, $detail);
+        return $result;
+    }
 
 
-	public function getImageFields ($tableConf) {
-		$retArray = [];
-
-		$generateArray = ['generateImage', 'generatePath'];
-		foreach ($generateArray as $k => $generate) {
-			if (is_array($tableConf) && isset($tableConf[$generate . '.']) && is_array($tableConf[$generate . '.'])) {
-				$genPartArray = $tableConf[$generate . '.'];
-				if ($genPartArray['type'] == 'tablefields') {
-					$fieldArray = $genPartArray['field.'];
-					if (is_array($fieldArray)) {
-						foreach ($fieldArray as $field => $count) {
-							$retArray[] = $field;
-						}
-					}
-				}
-			}
-		}
-		return $retArray;
-	}
+    public function getDownloadConf ($feature, $detail = '') {
+        $result = $this->getTypeConf('download', $feature, $detail);
+        return $result;
+    }
 
 
-	/**
-	 * Returns true if the item has the $check value checked
-	 *
-	 */
-	public function hasConfig (
-		&$row,
-		$check,
-		$configField = 'config'
-	) {
-		$hasConfig = false;
+    public function getFallback ($tableConf) {
+        $result = false;
+        if (
+            isset($tableConf) &&
+            is_array($tableConf) &&
+            isset($tableConf['language.']) &&
+            $tableConf['language.']['type'] == 'table' &&
+            isset($tableConf['language.']['mode']) &&
+            $tableConf['language.']['mode'] == 'fallback'
+        ) {
+            $result = true;
+        }
 
-		if (isset($row[$configField])) {
-			$config = GeneralUtility::xml2array($row[$configField]);
-			$hasConfig = \JambageCom\Div2007\Utility\FlexformUtility::get($config, $check);
-		}
+        return $result;
+    }
 
-		return $hasConfig;
-	}
+    public function getTranslationFields ($tableConf) {
+        $fieldArray = [];
+        if (isset($tableConf['language.']) && is_array($tableConf['language.']) && isset($tableConf['language.']['type']) && $tableConf['language.']['type'] == 'field') {
+            $langConf = $tableConf['language.']['field.'];
+            if (is_array($langConf)) {
+                foreach ($langConf as $field => $langfield) {
+                    $fieldArray[$field] = $langfield;
+                }
+            }
+        }
+        return $fieldArray;
+    }
 
 
-	public function getColumnFields ($tableConf) {
-		$retArray = [];
+    public function getImageFields ($tableConf) {
+        $retArray = [];
 
-		$generateArray = ['generateColumn'];
-		if (is_array($tableConf)) {
+        $generateArray = ['generateImage', 'generatePath'];
+        foreach ($generateArray as $k => $generate) {
+            if (is_array($tableConf) && isset($tableConf[$generate . '.']) && is_array($tableConf[$generate . '.'])) {
+                $genPartArray = $tableConf[$generate . '.'];
+                if ($genPartArray['type'] == 'tablefields') {
+                    $fieldArray = $genPartArray['field.'];
+                    if (is_array($fieldArray)) {
+                        foreach ($fieldArray as $field => $count) {
+                            $retArray[] = $field;
+                        }
+                    }
+                }
+            }
+        }
+        return $retArray;
+    }
+
+
+    /**
+     * Returns true if the item has the $check value checked
+     *
+     */
+    public function hasConfig (
+        &$row,
+        $check,
+        $configField = 'config'
+    ) {
+        $hasConfig = false;
+
+        if (isset($row[$configField])) {
+            $config = GeneralUtility::xml2array($row[$configField]);
+            $hasConfig = \JambageCom\Div2007\Utility\FlexformUtility::get($config, $check);
+        }
+
+        return $hasConfig;
+    }
+
+
+    public function getColumnFields ($tableConf) {
+        $retArray = [];
+
+        $generateArray = ['generateColumn'];
+        if (is_array($tableConf)) {
             foreach ($generateArray as $k => $generate) {
                 if (isset($tableConf[$generate . '.']) && is_array($tableConf[$generate . '.'])) {
                     $genPartArray = $tableConf[$generate . '.'];
@@ -348,33 +348,33 @@ class tx_ttproducts_config implements \TYPO3\CMS\Core\SingletonInterface {
                 }
             }
         }
-		return $retArray;
-	}
+        return $retArray;
+    }
 
 
-	public function getAJAXConf () {
-		$result = [];
-		if (isset($this->conf['ajax.']) && is_array($this->conf['ajax.']['conf.'])) {
-			$result = $this->conf['ajax.']['conf.'];
-		}
-		return $result;
-	}
+    public function getAJAXConf () {
+        $result = [];
+        if (isset($this->conf['ajax.']) && is_array($this->conf['ajax.']['conf.'])) {
+            $result = $this->conf['ajax.']['conf.'];
+        }
+        return $result;
+    }
 
 
-	public function getTemplateFile ($theCode) {
-		$result = '';
+    public function getTemplateFile ($theCode) {
+        $result = '';
 
-		if (
-			isset($this->conf['templateFile.']) &&
-			!empty($this->conf['templateFile.'][$theCode])
-		) {
-			$result = $this->conf['templateFile.'][$theCode];
-		} else {
-			$result = $this->conf['templateFile'];
-		}
+        if (
+            isset($this->conf['templateFile.']) &&
+            !empty($this->conf['templateFile.'][$theCode])
+        ) {
+            $result = $this->conf['templateFile.'][$theCode];
+        } else {
+            $result = $this->conf['templateFile'];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 }
 

--- a/lib/class.tx_ttproducts_creditpoints_div.php
+++ b/lib/class.tx_ttproducts_creditpoints_div.php
@@ -42,129 +42,129 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_creditpoints_div {
-	static public function getCreditPointsFeuser () {
-		$result = 0;
+    static public function getCreditPointsFeuser () {
+        $result = 0;
 
-		if (
+        if (
             \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
-			isset($GLOBALS['TSFE']->fe_user) &&
-			is_array($GLOBALS['TSFE']->fe_user->user)
-		) {
-			$result = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
-		}
+            isset($GLOBALS['TSFE']->fe_user) &&
+            is_array($GLOBALS['TSFE']->fe_user->user)
+        ) {
+            $result = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function getPriceFactor ($conf) {
-		$pricefactor = 0;
+    static public function getPriceFactor ($conf) {
+        $pricefactor = 0;
 
-		if (isset($conf['creditpoints.'])) {
-			if (isset($conf['creditpoints.']['priceprod'])) {
-				$pricefactor = $conf['creditpoints.']['priceprod'];
-			}
-			if (isset($conf['creditpoints.']['pricefactor'])) {
-				$pricefactor = $conf['creditpoints.']['pricefactor'];
-			}
-			$pricefactor = doubleval($pricefactor);
-		}
+        if (isset($conf['creditpoints.'])) {
+            if (isset($conf['creditpoints.']['priceprod'])) {
+                $pricefactor = $conf['creditpoints.']['priceprod'];
+            }
+            if (isset($conf['creditpoints.']['pricefactor'])) {
+                $pricefactor = $conf['creditpoints.']['pricefactor'];
+            }
+            $pricefactor = doubleval($pricefactor);
+        }
 
-		return $pricefactor;
-	}
+        return $pricefactor;
+    }
 
-	static public function getUsedCreditpoints ($recs) {
+    static public function getUsedCreditpoints ($recs) {
 
-		$creditpoints = 0;
-		$creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
+        $creditpoints = 0;
+        $creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
 
-		$autoCreditpointsTotal = $creditpointsObj->getBasketTotal();
+        $autoCreditpointsTotal = $creditpointsObj->getBasketTotal();
 
-		if ($autoCreditpointsTotal > 0) {
-			$creditpoints = $autoCreditpointsTotal;
-		} else if (
-			isset($recs) &&	is_array($recs) &&
-			isset($recs['tt_products']) && is_array($recs['tt_products']) &&
-			isset($recs['tt_products']['creditpoints']) &&
-			$recs['tt_products']['creditpoints'] > 0
-		) {
-			$creditpoints = $recs['tt_products']['creditpoints'];
-		}
+        if ($autoCreditpointsTotal > 0) {
+            $creditpoints = $autoCreditpointsTotal;
+        } else if (
+            isset($recs) &&	is_array($recs) &&
+            isset($recs['tt_products']) && is_array($recs['tt_products']) &&
+            isset($recs['tt_products']['creditpoints']) &&
+            $recs['tt_products']['creditpoints'] > 0
+        ) {
+            $creditpoints = $recs['tt_products']['creditpoints'];
+        }
 
-		$userCreditpoints = tx_ttproducts_creditpoints_div::getCreditPointsFeuser();
+        $userCreditpoints = tx_ttproducts_creditpoints_div::getCreditPointsFeuser();
 
-		if ($creditpoints > $userCreditpoints) {
-			$creditpoints = $userCreditpoints;
-		}
+        if ($creditpoints > $userCreditpoints) {
+            $creditpoints = $userCreditpoints;
+        }
 
-		$creditpoints = doubleval($creditpoints);
-		return $creditpoints;
-	}
+        $creditpoints = doubleval($creditpoints);
+        return $creditpoints;
+    }
 
-	/**
-	 * Returns the number of creditpoints for the frontend user
-	 */
-	static public function getCreditPoints ($amount, $creditpointsConf) {
-		$type = '';
-		$creditpoints = 0;
-		if (is_array($creditpointsConf)) {
-			foreach ($creditpointsConf as $k1 => $priceCalcTemp) {
-				if (is_array($priceCalcTemp)) {
-					foreach ($priceCalcTemp as $k2 => $v2) {
-						if (!is_array($v2)) {
-							switch ($k2) {
-								case 'type':
-									$type = $v2;
-									break;
-							}
-						}
-					}
-					$dumCount = 0;
-					$creditpoints = doubleval($priceCalcTemp['prod.']['1']);
+    /**
+     * Returns the number of creditpoints for the frontend user
+     */
+    static public function getCreditPoints ($amount, $creditpointsConf) {
+        $type = '';
+        $creditpoints = 0;
+        if (is_array($creditpointsConf)) {
+            foreach ($creditpointsConf as $k1 => $priceCalcTemp) {
+                if (is_array($priceCalcTemp)) {
+                    foreach ($priceCalcTemp as $k2 => $v2) {
+                        if (!is_array($v2)) {
+                            switch ($k2) {
+                                case 'type':
+                                    $type = $v2;
+                                    break;
+                            }
+                        }
+                    }
+                    $dumCount = 0;
+                    $creditpoints = doubleval($priceCalcTemp['prod.']['1']);
 
-					if ($type != 'price') {
-						break;
-					}
-					krsort($priceCalcTemp['prod.']);
-					reset($priceCalcTemp['prod.']);
+                    if ($type != 'price') {
+                        break;
+                    }
+                    krsort($priceCalcTemp['prod.']);
+                    reset($priceCalcTemp['prod.']);
 
-					foreach ($priceCalcTemp['prod.'] as $k2 => $points) {
-						if ($amount >= intval($k2)) { // only the highest value for this count will be used; 1 should never be reached, this would not be logical
-							$creditpoints = $points;
-							break; // finish
-						}
-					}
-				}
-			}
-		}
-		return $creditpoints;
-	} // getCreditPoints
+                    foreach ($priceCalcTemp['prod.'] as $k2 => $points) {
+                        if ($amount >= intval($k2)) { // only the highest value for this count will be used; 1 should never be reached, this would not be logical
+                            $creditpoints = $points;
+                            break; // finish
+                        }
+                    }
+                }
+            }
+        }
+        return $creditpoints;
+    } // getCreditPoints
 
 
-	/**
-	 * adds the number of creditpoints for the frontend user
-	 */
-	static public function addCreditPoints ($username, $creditpoints) {
+    /**
+     * adds the number of creditpoints for the frontend user
+     */
+    static public function addCreditPoints ($username, $creditpoints) {
 
-		if ($username) {
-			$uid_voucher = '';
-			// get the "old" creditpoints for the user
-			$res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid, tt_products_creditpoints', 'fe_users', 'username=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($username,'tt_products_creditpoints'));
-			if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1)) {
-				$ttproductscreditpoints = $row['tt_products_creditpoints'];
-				$uid_voucher = $row['uid'];
-			}
-			if ($uid_voucher) {
-				$fieldsArrayFeUserCredit = [];
-				$fieldsArrayFeUserCredit['tt_products_creditpoints'] = $ttproductscreditpoints + $creditpoints;
+        if ($username) {
+            $uid_voucher = '';
+            // get the "old" creditpoints for the user
+            $res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid, tt_products_creditpoints', 'fe_users', 'username=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($username,'tt_products_creditpoints'));
+            if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1)) {
+                $ttproductscreditpoints = $row['tt_products_creditpoints'];
+                $uid_voucher = $row['uid'];
+            }
+            if ($uid_voucher) {
+                $fieldsArrayFeUserCredit = [];
+                $fieldsArrayFeUserCredit['tt_products_creditpoints'] = $ttproductscreditpoints + $creditpoints;
 
-				$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-					'fe_users',
-					'uid=' . intval($uid_voucher),
-					$fieldsArrayFeUserCredit
-				);
-			}
-		}
-	}
+                $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+                    'fe_users',
+                    'uid=' . intval($uid_voucher),
+                    $fieldsArrayFeUserCredit
+                );
+            }
+        }
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_css.php
+++ b/lib/class.tx_ttproducts_css.php
@@ -39,48 +39,48 @@
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_css implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	protected $isCssStyled;
-	private $bIncluded = false;
+    public $conf;
+    protected $isCssStyled;
+    private $bIncluded = false;
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init () {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->isCssStyled = (isset($cnf->conf['templateStyle']) && $cnf->conf['templateStyle'] == 'css-styled');
-		$this->conf = $cnf->conf['CSS.'] ?? [];
-	} // init
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init () {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->isCssStyled = (isset($cnf->conf['templateStyle']) && $cnf->conf['templateStyle'] == 'css-styled');
+        $this->conf = $cnf->conf['CSS.'] ?? [];
+    } // init
 
-	public function isCSSStyled () {
+    public function isCSSStyled () {
 
-		if (
-			isset($this->conf) &&
-			is_array($this->conf) &&
-			$this->isCssStyled &&
-			!empty($this->conf['file'])
-		) {
-			$result = true;
-		} else {
-			$result = false;
-		}
-		return $result;
-	}
+        if (
+            isset($this->conf) &&
+            is_array($this->conf) &&
+            $this->isCssStyled &&
+            !empty($this->conf['file'])
+        ) {
+            $result = true;
+        } else {
+            $result = false;
+        }
+        return $result;
+    }
 
-	public function setIncluded () {
-		$this->bIncluded = true;
-	}
+    public function setIncluded () {
+        $this->bIncluded = true;
+    }
 
-	public function getIncluded () {
-		return $this->bIncluded;
-	}
+    public function getIncluded () {
+        return $this->bIncluded;
+    }
 
-	public function getConf ($tablename = '', $theCode = 'ALL') {
+    public function getConf ($tablename = '', $theCode = 'ALL') {
 
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$cssConf = $cnf->getSpecialConf('CSS', $tablename, $theCode);
-		return $cssConf;
-	}
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $cssConf = $cnf->getSpecialConf('CSS', $tablename, $theCode);
+        return $cssConf;
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_csv.php
+++ b/lib/class.tx_ttproducts_csv.php
@@ -43,160 +43,160 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_csv implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function create (
-		$functablename,
-		$conf,
-		$itemArray,
-		$calculatedArray,
-		$accountUid,
-		$address,
-		$csvorderuid,
-		$basketExtra,
-		&$csvFilepath,
-		&$errorMessage
-	) {
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$orderObj = $tablesObj->get('sys_products_orders');
-		$accountObj = $tablesObj->get('sys_products_accounts');
-		$itemTable = $tablesObj->get($functablename, false);
+    public function create (
+        $functablename,
+        $conf,
+        $itemArray,
+        $calculatedArray,
+        $accountUid,
+        $address,
+        $csvorderuid,
+        $basketExtra,
+        &$csvFilepath,
+        &$errorMessage
+    ) {
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $orderObj = $tablesObj->get('sys_products_orders');
+        $accountObj = $tablesObj->get('sys_products_accounts');
+        $itemTable = $tablesObj->get($functablename, false);
 
-		$csvFilepath = trim($csvFilepath);
-		if ($csvFilepath[strlen($csvFilepath) - 1] != '/') {
-			$csvFilepath .= '/';
-		}
-		$csvFilepath .= $orderObj->getNumber($csvorderuid) . '.csv';
-		$csvFile = fopen($csvFilepath, 'w');
-		if ($csvFile !== false) {
-			// Generate invoice and delivery address
-			$csvlinehead = '';
-			$csvlineperson = '';
-			$csvlinedelivery = '';
-			$infoFields = explode(',','feusers_uid,name,cnum,first_name,last_name,salutation,address,telephone,fax,email,company,city,zip,state,country,agb,business_partner,organisation_form');
-			foreach($infoFields as $fName) {
-				if ($csvlinehead != '') {
-					$csvlinehead .= ';';
-					$csvlineperson .= ';';
-					$csvlinedelivery .= ';';
-				}
-				$csvlinehead .= '"' . $fName . '"';
-				$csvlineperson .= '"' . str_replace(chr(13) . chr(10), '|', $address->infoArray['billing'][$fName]) . '"';
-				$csvlinedelivery .= '"' . $address->infoArray['delivery'][$fName] . '"';
-			}
+        $csvFilepath = trim($csvFilepath);
+        if ($csvFilepath[strlen($csvFilepath) - 1] != '/') {
+            $csvFilepath .= '/';
+        }
+        $csvFilepath .= $orderObj->getNumber($csvorderuid) . '.csv';
+        $csvFile = fopen($csvFilepath, 'w');
+        if ($csvFile !== false) {
+            // Generate invoice and delivery address
+            $csvlinehead = '';
+            $csvlineperson = '';
+            $csvlinedelivery = '';
+            $infoFields = explode(',','feusers_uid,name,cnum,first_name,last_name,salutation,address,telephone,fax,email,company,city,zip,state,country,agb,business_partner,organisation_form');
+            foreach($infoFields as $fName) {
+                if ($csvlinehead != '') {
+                    $csvlinehead .= ';';
+                    $csvlineperson .= ';';
+                    $csvlinedelivery .= ';';
+                }
+                $csvlinehead .= '"' . $fName . '"';
+                $csvlineperson .= '"' . str_replace(chr(13) . chr(10), '|', $address->infoArray['billing'][$fName]) . '"';
+                $csvlinedelivery .= '"' . $address->infoArray['delivery'][$fName] . '"';
+            }
 
-			// Generate shipping/payment information and delivery note
-			$csvlineshipping = '"' . ($basketExtra['shipping.']['title'] ?? '') . '";"' .
-				$priceViewObj->priceFormat($calculatedArray['priceTax']['shipping']) . '";"' .
-				$priceViewObj->priceFormat($calculatedArray['priceNoTax']['shipping']) . '"';
+            // Generate shipping/payment information and delivery note
+            $csvlineshipping = '"' . ($basketExtra['shipping.']['title'] ?? '') . '";"' .
+                $priceViewObj->priceFormat($calculatedArray['priceTax']['shipping']) . '";"' .
+                $priceViewObj->priceFormat($calculatedArray['priceNoTax']['shipping']) . '"';
 
-			$accountRow = [];
-			if ($accountUid) {
-				$accountRow = $accountObj->getRow($accountUid, 0, true);
-				if (is_array($accountRow) && count($accountRow)) {
-					$csvlineAccount = '"' . implode('";"',$accountRow) . '"';
-					$accountdescr = '"' . implode('";"', array_keys($accountRow)) . '"';
-				}
-			}
+            $accountRow = [];
+            if ($accountUid) {
+                $accountRow = $accountObj->getRow($accountUid, 0, true);
+                if (is_array($accountRow) && count($accountRow)) {
+                    $csvlineAccount = '"' . implode('";"',$accountRow) . '"';
+                    $accountdescr = '"' . implode('";"', array_keys($accountRow)) . '"';
+                }
+            }
 
-			$csvlinepayment = '"' . ($basketExtra['payment.']['title'] ?? '') . '";"' .
-				$priceViewObj->priceFormat($calculatedArray['priceTax']['payment']) . '";"' .
-				$priceViewObj->priceFormat($calculatedArray['priceNoTax']['payment']) . '"';
+            $csvlinepayment = '"' . ($basketExtra['payment.']['title'] ?? '') . '";"' .
+                $priceViewObj->priceFormat($calculatedArray['priceTax']['payment']) . '";"' .
+                $priceViewObj->priceFormat($calculatedArray['priceNoTax']['payment']) . '"';
 
-			$csvlinegift = '"' . $basketObj->recs['tt_products']['giftcode'] . '"';
+            $csvlinegift = '"' . $basketObj->recs['tt_products']['giftcode'] . '"';
 
-			$csvlinedeliverynote = '"' . $address->infoArray['delivery']['note'] . '"';
-			$csvlinedeliverydesireddate = '"' . $address->infoArray['delivery']['desired_date'] . '"';
-			$csvlinedeliverydesiredtime = '"' . $address->infoArray['delivery']['desired_time'] . '"';
+            $csvlinedeliverynote = '"' . $address->infoArray['delivery']['note'] . '"';
+            $csvlinedeliverydesireddate = '"' . $address->infoArray['delivery']['desired_date'] . '"';
+            $csvlinedeliverydesiredtime = '"' . $address->infoArray['delivery']['desired_time'] . '"';
 
-			// Build field list
-			$csvfields = explode(',', $conf['CSVfields']);
-			$csvfieldcount = count($csvfields);
-			for ($a = 0; $a < $csvfieldcount; $a++)	{
-				$csvfields[$a] = trim($csvfields[$a]);
-			}
+            // Build field list
+            $csvfields = explode(',', $conf['CSVfields']);
+            $csvfieldcount = count($csvfields);
+            for ($a = 0; $a < $csvfieldcount; $a++)	{
+                $csvfields[$a] = trim($csvfields[$a]);
+            }
 
-			// Write description header
-			$csvdescr = '"uid";"count"';
+            // Write description header
+            $csvdescr = '"uid";"count"';
 // 			$variantFieldArray = $itemTable->variant->getSelectableFieldArray();
 // 			if (count($variantFieldArray)) {
 // 				$csvdescr .= ';"' . implode('";"',$variantFieldArray) . '"';
 // 			}
 
-			if ($csvfieldcount) {
-				foreach($csvfields as $csvfield) {
-					$csvdescr .= ';"' . $csvfield . '"';
-				}
-			}
+            if ($csvfieldcount) {
+                foreach($csvfields as $csvfield) {
+                    $csvdescr .= ';"' . $csvfield . '"';
+                }
+            }
 
-			if (!empty($conf['CSVinOneLine'])) {
-				$csvdescr .= ';"deliverynote";"desired date";"desired time";"shipping method";"shipping_price";"shipping_no_tax";"payment method";"payment_price";"payment_no_tax"';
-				$csvdescr .= ';"giftcode"';
-				$csvdescr .= ';' . $csvlinehead . ';' . $csvlinehead;
+            if (!empty($conf['CSVinOneLine'])) {
+                $csvdescr .= ';"deliverynote";"desired date";"desired time";"shipping method";"shipping_price";"shipping_no_tax";"payment method";"payment_price";"payment_no_tax"';
+                $csvdescr .= ';"giftcode"';
+                $csvdescr .= ';' . $csvlinehead . ';' . $csvlinehead;
 
-				if ($accountdescr != '') {
-					$csvdescr .= ';' . $accountdescr;
-				}
-			}
-			$csvdescr .= chr(13);
-			fwrite($csvFile, $csvdescr);
+                if ($accountdescr != '') {
+                    $csvdescr .= ';' . $accountdescr;
+                }
+            }
+            $csvdescr .= chr(13);
+            fwrite($csvFile, $csvdescr);
 
-			// Write ordered product list
-			$infoWritten = false;
+            // Write ordered product list
+            $infoWritten = false;
 
-			// loop over all items in the basket indexed by a sorting text
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					$pid = intval($row['pid']);
-					if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
-						// product belongs to another basket
-						continue;
-					}
+            // loop over all items in the basket indexed by a sorting text
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    $pid = intval($row['pid']);
+                    if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
+                        // product belongs to another basket
+                        continue;
+                    }
 // 					$variants = explode(';', $itemTable->variant->getVariantFromRow($row));
-					$csvdata = '"' . intval($row['uid']) . '";"' .
-						intval($actItem['count']) . '"';
-					foreach($csvfields as $csvfield) {
-						$csvdata .= ';"' . $row[$csvfield] . '"';
-					}
+                    $csvdata = '"' . intval($row['uid']) . '";"' .
+                        intval($actItem['count']) . '"';
+                    foreach($csvfields as $csvfield) {
+                        $csvdata .= ';"' . $row[$csvfield] . '"';
+                    }
 
-					if ($conf['CSVinOneLine'] && (!$infoWritten)) {
-						$infoWritten = true;
-						$csvfullline = ';' . $csvlinedeliverynote . ';' . $csvlinedeliverydesireddate . ';' . $csvlinedeliverydesiredtime . ';' . $csvlineshipping .
-							($csvlineAccount != '' ? ';' . $csvlineAccount : '') .
-							';' . $csvlinepayment . ';' . $csvlinegift . ';' . $csvlineperson . ';' . $csvlinedelivery;
-						$csvdata .= $csvfullline;
-					}
-					$csvdata .= chr(13);
-					fwrite($csvFile, $csvdata);
-				}
-			}
+                    if ($conf['CSVinOneLine'] && (!$infoWritten)) {
+                        $infoWritten = true;
+                        $csvfullline = ';' . $csvlinedeliverynote . ';' . $csvlinedeliverydesireddate . ';' . $csvlinedeliverydesiredtime . ';' . $csvlineshipping .
+                            ($csvlineAccount != '' ? ';' . $csvlineAccount : '') .
+                            ';' . $csvlinepayment . ';' . $csvlinegift . ';' . $csvlineperson . ';' . $csvlinedelivery;
+                        $csvdata .= $csvfullline;
+                    }
+                    $csvdata .= chr(13);
+                    fwrite($csvFile, $csvdata);
+                }
+            }
 
-			if (empty($conf['CSVinOneLine'])) {
-				fwrite($csvFile, chr(13));
-				fwrite($csvFile, $csvlinehead . chr(13));
-				fwrite($csvFile, $csvlineperson . chr(13));
-				fwrite($csvFile, $csvlinedelivery . chr(13));
-				fwrite($csvFile, chr(13));
-				fwrite($csvFile, $csvlinedeliverynote . chr(13));
-				fwrite($csvFile, $csvlinedeliverydesireddate . chr(13));
-				fwrite($csvFile, $csvlinedeliverydesiredtime . chr(13));
-				fwrite($csvFile, $csvlineshipping . chr(13));
-				if ($csvlineAccount != '') {
-					fwrite($csvFile, $csvlineAccount . chr(13));
-				}
-				fwrite($csvFile, $csvlinepayment . chr(13));
-				fwrite($csvFile, $csvlinegift . chr(13));
-			}
-			fclose($csvFile);
-		} else {
+            if (empty($conf['CSVinOneLine'])) {
+                fwrite($csvFile, chr(13));
+                fwrite($csvFile, $csvlinehead . chr(13));
+                fwrite($csvFile, $csvlineperson . chr(13));
+                fwrite($csvFile, $csvlinedelivery . chr(13));
+                fwrite($csvFile, chr(13));
+                fwrite($csvFile, $csvlinedeliverynote . chr(13));
+                fwrite($csvFile, $csvlinedeliverydesireddate . chr(13));
+                fwrite($csvFile, $csvlinedeliverydesiredtime . chr(13));
+                fwrite($csvFile, $csvlineshipping . chr(13));
+                if ($csvlineAccount != '') {
+                    fwrite($csvFile, $csvlineAccount . chr(13));
+                }
+                fwrite($csvFile, $csvlinepayment . chr(13));
+                fwrite($csvFile, $csvlinegift . chr(13));
+            }
+            fclose($csvFile);
+        } else {
             $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
 
-			$message = $languageObj->getLabel('no_csv_creation');
-			$messageArr =  explode('|', $message);
-			$errorMessage = $messageArr[0] . $csvFilepath . $messageArr[1];
-		}
-	}
+            $message = $languageObj->getLabel('no_csv_creation');
+            $messageArr =  explode('|', $message);
+            $errorMessage = $messageArr[0] . $csvFilepath . $messageArr[1];
+        }
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_email_div.php
+++ b/lib/class.tx_ttproducts_email_div.php
@@ -42,94 +42,94 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_email_div {
 
-	/**
-	 * Send notification email for tracking
-	 */
-	static public function sendNotifyEmail (
-		$cObj,
-		$conf,
-		$config,
-		$functablename,
-		$orderNumber,
-		$recipient,
-		$v,
-		$statusCodeArray,
-		$tracking,
-		$orderRow,
-		$orderData,
-		$templateCode,
-		$templateMarker,
-		$basketExtra,
-		$basketRecs,
-		$sendername = '',
-		$senderemail = ''
-	) {
+    /**
+     * Send notification email for tracking
+     */
+    static public function sendNotifyEmail (
+        $cObj,
+        $conf,
+        $config,
+        $functablename,
+        $orderNumber,
+        $recipient,
+        $v,
+        $statusCodeArray,
+        $tracking,
+        $orderRow,
+        $orderData,
+        $templateCode,
+        $templateMarker,
+        $basketExtra,
+        $basketRecs,
+        $sendername = '',
+        $senderemail = ''
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		$sendername = ($sendername ? $sendername : $conf['orderEmail_fromName']);
-		$senderemail = ($senderemail ? $senderemail : $conf['orderEmail_from']);
+        $sendername = ($sendername ? $sendername : $conf['orderEmail_fromName']);
+        $senderemail = ($senderemail ? $senderemail : $conf['orderEmail_from']);
 
-			// Notification email
-		$recipients = $recipient;
-		$recipients = GeneralUtility::trimExplode(',', $recipients, 1);
+            // Notification email
+        $recipients = $recipient;
+        $recipients = GeneralUtility::trimExplode(',', $recipients, 1);
 
-		if (count($recipients)) {	// If any recipients, then compile and send the mail.
-			$emailContent =
-				trim(
-					$templateService->getSubpart(
-						$templateCode,
-						'###' . $templateMarker . $config['templateSuffix'] . '###'
-					)
-				);
-			if (!$emailContent) {
-				$emailContent =
-					trim(
-						$templateService->getSubpart(
-							$templateCode,
-							'###' . $templateMarker . '###'
-						)
-					);
-			}
+        if (count($recipients)) {	// If any recipients, then compile and send the mail.
+            $emailContent =
+                trim(
+                    $templateService->getSubpart(
+                        $templateCode,
+                        '###' . $templateMarker . $config['templateSuffix'] . '###'
+                    )
+                );
+            if (!$emailContent) {
+                $emailContent =
+                    trim(
+                        $templateService->getSubpart(
+                            $templateCode,
+                            '###' . $templateMarker . '###'
+                        )
+                    );
+            }
 
-			if ($emailContent) {		// If there is plain text content - which is required!!
-				$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-				$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-				$tagArray = $markerObj->getAllMarkers($emailContent);
+            if ($emailContent) {		// If there is plain text content - which is required!!
+                $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+                $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+                $tagArray = $markerObj->getAllMarkers($emailContent);
 
-				$markerArray = $globalMarkerArray;
-				$markerArray['###ORDER_STATUS_TIME###'] = $cObj->stdWrap($v['time'],$conf['statusDate_stdWrap.']);
-				$markerArray['###ORDER_STATUS###'] = $v['status'];
-				$info = $statusCodeArray[$v['status']];
-				$markerArray['###ORDER_STATUS_INFO###'] = ($info ? $info : $v['info']);
-				$markerArray['###ORDER_STATUS_COMMENT###'] = $v['comment'];
-				$markerArray['###PID_TRACKING###'] = $conf['PIDtracking'];
-				$markerArray['###PERSON_NAME###'] = $orderData['billing']['name'];
-				$markerArray['###DELIVERY_NAME###'] = $orderData['delivery']['name'];
+                $markerArray = $globalMarkerArray;
+                $markerArray['###ORDER_STATUS_TIME###'] = $cObj->stdWrap($v['time'],$conf['statusDate_stdWrap.']);
+                $markerArray['###ORDER_STATUS###'] = $v['status'];
+                $info = $statusCodeArray[$v['status']];
+                $markerArray['###ORDER_STATUS_INFO###'] = ($info ? $info : $v['info']);
+                $markerArray['###ORDER_STATUS_COMMENT###'] = $v['comment'];
+                $markerArray['###PID_TRACKING###'] = $conf['PIDtracking'];
+                $markerArray['###PERSON_NAME###'] = $orderData['billing']['name'];
+                $markerArray['###DELIVERY_NAME###'] = $orderData['delivery']['name'];
 
-				$feusersObj = $tablesObj->get($functablename, true);
-				$feusersObj->getAddressMarkerArray(
-					$functablename,
-					$orderData['billing'],
-					$markerArray,
-					false,
-					'person'
-				);
-				$feusersObj->getAddressMarkerArray(
-					$functablename,
-					$orderData['delivery'],
-					$markerArray,
-					false,
-					'delivery'
-				);
+                $feusersObj = $tablesObj->get($functablename, true);
+                $feusersObj->getAddressMarkerArray(
+                    $functablename,
+                    $orderData['billing'],
+                    $markerArray,
+                    false,
+                    'person'
+                );
+                $feusersObj->getAddressMarkerArray(
+                    $functablename,
+                    $orderData['delivery'],
+                    $markerArray,
+                    false,
+                    'delivery'
+                );
 
-				$markerArray['###ORDER_TRACKING_NO###'] = $tracking;
-				$markerArray['###ORDER_UID###'] = $markerArray['###ORDER_ORDER_NO###'] = $orderNumber;
-				$emailContent = $templateService->substituteMarkerArrayCached($emailContent, $markerArray);
-				$parts = explode(chr(10), $emailContent, 2);
-				$subject = trim($parts[0]);
-				$plain_message = trim($parts[1]);
-				$tmp = '';
+                $markerArray['###ORDER_TRACKING_NO###'] = $tracking;
+                $markerArray['###ORDER_UID###'] = $markerArray['###ORDER_ORDER_NO###'] = $orderNumber;
+                $emailContent = $templateService->substituteMarkerArrayCached($emailContent, $markerArray);
+                $parts = explode(chr(10), $emailContent, 2);
+                $subject = trim($parts[0]);
+                $plain_message = trim($parts[1]);
+                $tmp = '';
                 \JambageCom\Div2007\Utility\MailUtility::send(
                     implode(',', $recipients),
                     $subject,
@@ -145,64 +145,64 @@ class tx_ttproducts_email_div {
                     TT_PRODUCTS_EXT,
                     'sendMail'
                 );
-			}
-		}
-	}
+            }
+        }
+    }
 
 
-	/**
-	 * Send notification email for gift certificates
-	 */
-	static public function sendGiftEmail (
-		$cObj,
-		$conf,
-		$recipient,
-		$comment,
-		$giftRow,
-		$templateCode,
-		$templateMarker,
-		$bHtmlMail = false
-	) {
+    /**
+     * Send notification email for gift certificates
+     */
+    static public function sendGiftEmail (
+        $cObj,
+        $conf,
+        $recipient,
+        $comment,
+        $giftRow,
+        $templateCode,
+        $templateMarker,
+        $bHtmlMail = false
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$sendername = ($giftRow['personname'] ? $giftRow['personname'] : $conf['orderEmail_fromName']);
-		$senderemail = ($giftRow['personemail'] ? $giftRow['personemail'] : $conf['orderEmail_from']);
-		$recipients = $recipient;
-		$recipients = GeneralUtility::trimExplode(',',$recipients,1);
+        $sendername = ($giftRow['personname'] ? $giftRow['personname'] : $conf['orderEmail_fromName']);
+        $senderemail = ($giftRow['personemail'] ? $giftRow['personemail'] : $conf['orderEmail_from']);
+        $recipients = $recipient;
+        $recipients = GeneralUtility::trimExplode(',',$recipients,1);
 
-		if (count($recipients)) {	// If any recipients, then compile and send the mail.
-			$emailContent = trim($templateService->getSubpart($templateCode, '###' . $templateMarker . '###'));
-			if ($emailContent) {		// If there is plain text content - which is required!!
-				$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-				$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-				$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        if (count($recipients)) {	// If any recipients, then compile and send the mail.
+            $emailContent = trim($templateService->getSubpart($templateCode, '###' . $templateMarker . '###'));
+            if ($emailContent) {		// If there is plain text content - which is required!!
+                $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+                $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+                $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
 // 				$parts = explode(chr(10),$emailContent,2);	// First line is subject
 // 				$subject = trim($parts[0]);
 // 				$plain_message = trim($parts[1]);
 
-				$markerArray = $globalMarkerArray;
-				$markerArray['###CERTIFICATES_TOTAL###'] = $priceViewObj->priceFormat($giftRow['amount']);
-				$markerArray['###CERTIFICATES_UNIQUE_CODE###'] = $giftRow['uid'] . '-' . $giftRow['crdate'];
-				$markerArray['###PERSON_NAME###'] = $giftRow['personname'];
-				$markerArray['###DELIVERY_NAME###'] = $giftRow['deliveryname'];
-				$markerArray['###ORDER_STATUS_COMMENT###'] = $giftRow['note'] . ($bHtmlMail ? '\n' : chr(13)) . $comment;
-				$emailContent = $templateService->substituteMarkerArrayCached($emailContent, $markerArray);
+                $markerArray = $globalMarkerArray;
+                $markerArray['###CERTIFICATES_TOTAL###'] = $priceViewObj->priceFormat($giftRow['amount']);
+                $markerArray['###CERTIFICATES_UNIQUE_CODE###'] = $giftRow['uid'] . '-' . $giftRow['crdate'];
+                $markerArray['###PERSON_NAME###'] = $giftRow['personname'];
+                $markerArray['###DELIVERY_NAME###'] = $giftRow['deliveryname'];
+                $markerArray['###ORDER_STATUS_COMMENT###'] = $giftRow['note'] . ($bHtmlMail ? '\n' : chr(13)) . $comment;
+                $emailContent = $templateService->substituteMarkerArrayCached($emailContent, $markerArray);
 
-				$parts = explode(chr(10), $emailContent, 2);	// First line is subject
-				$subject = trim($parts[0]);
-				$emailContent = trim($parts[1]);
-				$recipients = implode($recipients, ',');
+                $parts = explode(chr(10), $emailContent, 2);	// First line is subject
+                $subject = trim($parts[0]);
+                $emailContent = trim($parts[1]);
+                $recipients = implode($recipients, ',');
 
-				if (
-					$bHtmlMail
-				) {	// If htmlmail lib is included, then generate a nice HTML-email
-					$HTMLmailShell = $templateService->getSubpart($this->templateCode, '###EMAIL_HTML_SHELL###');
-					$HTMLmailContent = $templateService->substituteMarker($HTMLmailShell, '###HTML_BODY###', $emailContent);
-					$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-					$HTMLmailContent = $templateService->substituteMarkerArrayCached(
-						$HTMLmailContent,
-						$markerObj->getGlobalMarkerArray()
-					);
+                if (
+                    $bHtmlMail
+                ) {	// If htmlmail lib is included, then generate a nice HTML-email
+                    $HTMLmailShell = $templateService->getSubpart($this->templateCode, '###EMAIL_HTML_SHELL###');
+                    $HTMLmailContent = $templateService->substituteMarker($HTMLmailShell, '###HTML_BODY###', $emailContent);
+                    $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+                    $HTMLmailContent = $templateService->substituteMarkerArrayCached(
+                        $HTMLmailContent,
+                        $markerObj->getGlobalMarkerArray()
+                    );
 
                     \JambageCom\Div2007\Utility\MailUtility::send(
                         $recipients,
@@ -236,10 +236,10 @@ class tx_ttproducts_email_div {
                         TT_PRODUCTS_EXT,
                         'sendMail'
                     );
-				}
-			}
-		}
-	}
+                }
+            }
+        }
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_form_div.php
+++ b/lib/class.tx_ttproducts_form_div.php
@@ -42,221 +42,221 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_form_div {
 
-	static public function createSelect (
-		$languageObj,
-		$valueArray,
-		$name,
-		$selectedKey,
-		$bSelectTags = true,
-		$bTranslateText = true,
-		$allowedArray = [],
-		$type = 'select',
-		$mainAttributeArray = [],
-		$header = '',
-		$layout = '',
-		$imageFileArray = '',
-		$keyMarkerArray = ''
-	) {
-		$result = false;
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-		$flags = ENT_QUOTES;
+    static public function createSelect (
+        $languageObj,
+        $valueArray,
+        $name,
+        $selectedKey,
+        $bSelectTags = true,
+        $bTranslateText = true,
+        $allowedArray = [],
+        $type = 'select',
+        $mainAttributeArray = [],
+        $header = '',
+        $layout = '',
+        $imageFileArray = '',
+        $keyMarkerArray = ''
+    ) {
+        $result = false;
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $flags = ENT_QUOTES;
 
-		if (is_array($valueArray)) {
-			$totaltext = '';
-			if ($header != '') {
-				$newValueArray = [];
-				$newValueArray['-1'] = $header;
-				foreach ($valueArray as $k => $v) {
-					$newValueArray[$k] = $v;
-				}
-				$valueArray = $newValueArray;
-			}
+        if (is_array($valueArray)) {
+            $totaltext = '';
+            if ($header != '') {
+                $newValueArray = [];
+                $newValueArray['-1'] = $header;
+                foreach ($valueArray as $k => $v) {
+                    $newValueArray[$k] = $v;
+                }
+                $valueArray = $newValueArray;
+            }
 
-			foreach ($valueArray as $key => $parts) {
+            foreach ($valueArray as $key => $parts) {
 
-				if (is_array($parts)) {
-					$selectKey = $parts['1'];
-					$selectValue = $parts['0'];
-				} else {
-					$selectKey = $key;
-					$selectValue = $parts;
-				}
+                if (is_array($parts)) {
+                    $selectKey = $parts['1'];
+                    $selectValue = $parts['0'];
+                } else {
+                    $selectKey = $key;
+                    $selectValue = $parts;
+                }
 
-				if ($bTranslateText) {
-					$tmp = $languageObj->splitLabel($selectValue);
-					$text = $languageObj->getLabel($tmp);
-				} else {
-					$text = '';
-				}
-				if ($text == '') {
-					if (strpos($selectValue, 'LLL:EXT') === 0) {
-						continue;
-					}
-					$text = $selectValue;
-				}
+                if ($bTranslateText) {
+                    $tmp = $languageObj->splitLabel($selectValue);
+                    $text = $languageObj->getLabel($tmp);
+                } else {
+                    $text = '';
+                }
+                if ($text == '') {
+                    if (strpos($selectValue, 'LLL:EXT') === 0) {
+                        continue;
+                    }
+                    $text = $selectValue;
+                }
 
-				if (empty($allowedArray) || in_array($selectKey, $allowedArray)) {
-					$nameText = trim($text);
-					$valueText = $selectKey;
-					$selectedText = '';
-					$paramArray = [];
-					$preParamArray = [];
+                if (empty($allowedArray) || in_array($selectKey, $allowedArray)) {
+                    $nameText = trim($text);
+                    $valueText = $selectKey;
+                    $selectedText = '';
+                    $paramArray = [];
+                    $preParamArray = [];
 
-					if ($key == -1) {
-						$selectedText = ($useXHTML ? ' disabled="disabled"' : ' disabled');
-					} else if (strcmp($selectKey, $selectedKey) == 0) {
-						switch ($type) {
-							case 'select':
-								$selectedText = ($useXHTML ? ' selected="selected"' : ' selected');
-								$paramArray['selected'] = 'selected';
-								break;
-							case 'checkbox':
-							case 'radio':
-								$selectedText = ($useXHTML ? ' checked="checked"' : ' checked');
-								$paramArray['checked'] = 'checked';
-								break;
-							default:
-								debug ($type, 'ERROR: unknown type'); // keep this
-								return false;
-								break;
-						}
-					}
+                    if ($key == -1) {
+                        $selectedText = ($useXHTML ? ' disabled="disabled"' : ' disabled');
+                    } else if (strcmp($selectKey, $selectedKey) == 0) {
+                        switch ($type) {
+                            case 'select':
+                                $selectedText = ($useXHTML ? ' selected="selected"' : ' selected');
+                                $paramArray['selected'] = 'selected';
+                                break;
+                            case 'checkbox':
+                            case 'radio':
+                                $selectedText = ($useXHTML ? ' checked="checked"' : ' checked');
+                                $paramArray['checked'] = 'checked';
+                                break;
+                            default:
+                                debug ($type, 'ERROR: unknown type'); // keep this
+                                return false;
+                                break;
+                        }
+                    }
 
-					switch ($type) {
-						case 'select':
-							$inputTextArray = ['<option value="' . htmlspecialchars($valueText, $flags) . '"' . $selectedText . '>', '</option>'];
-							break;
-						case 'checkbox':
-						case 'radio':
-							$preParamArray['type'] = $type;
-							$inputText = self::createTag('input', $name, $valueText, $preParamArray, $paramArray);
+                    switch ($type) {
+                        case 'select':
+                            $inputTextArray = ['<option value="' . htmlspecialchars($valueText, $flags) . '"' . $selectedText . '>', '</option>'];
+                            break;
+                        case 'checkbox':
+                        case 'radio':
+                            $preParamArray['type'] = $type;
+                            $inputText = self::createTag('input', $name, $valueText, $preParamArray, $paramArray);
 
-							if ($layout == '') {
-								$inputText .=  ' ' . $nameText . '<br ' . ($useXHTML ? '/' : '') . '>';
-							}
-							$inputTextArray = [$inputText];
-							break;
-						default:
-							return false;
-							break;
-					}
+                            if ($layout == '') {
+                                $inputText .=  ' ' . $nameText . '<br ' . ($useXHTML ? '/' : '') . '>';
+                            }
+                            $inputTextArray = [$inputText];
+                            break;
+                        default:
+                            return false;
+                            break;
+                    }
 
-					if ($layout == '') {
-						$totaltext .= ($inputTextArray[0] ?? '') . ($type == 'select' ? $nameText : '') . ($inputTextArray[1] ?? '');
-					} else {
-						// $tmpText = str_replace('###INPUT###', $inputText, $layout);
-						$tmpText = $templateService->substituteSubpart($layout, '###INPUT###', $inputTextArray);
+                    if ($layout == '') {
+                        $totaltext .= ($inputTextArray[0] ?? '') . ($type == 'select' ? $nameText : '') . ($inputTextArray[1] ?? '');
+                    } else {
+                        // $tmpText = str_replace('###INPUT###', $inputText, $layout);
+                        $tmpText = $templateService->substituteSubpart($layout, '###INPUT###', $inputTextArray);
 
-						if (is_array($imageFileArray) && isset($imageFileArray[$key])) {
-							$tmpText = str_replace('###IMAGE###', $imageFileArray[$key], $tmpText);
-						}
-						if (is_array($keyMarkerArray) && isset($keyMarkerArray[$key])) {
-							$tmpText = $templateService->substituteMarkerArray(
-								$tmpText,
-								$keyMarkerArray[$key]
-							);
-						}
-						$totaltext .= $tmpText;
-					}
-				}
-			} // foreach ($valueArray as $key => $parts) {
+                        if (is_array($imageFileArray) && isset($imageFileArray[$key])) {
+                            $tmpText = str_replace('###IMAGE###', $imageFileArray[$key], $tmpText);
+                        }
+                        if (is_array($keyMarkerArray) && isset($keyMarkerArray[$key])) {
+                            $tmpText = $templateService->substituteMarkerArray(
+                                $tmpText,
+                                $keyMarkerArray[$key]
+                            );
+                        }
+                        $totaltext .= $tmpText;
+                    }
+                }
+            } // foreach ($valueArray as $key => $parts) {
 
-			if ($bSelectTags && $type == 'select' && $name != '') {
-				$mainAttributes = '';
-				if (isset($mainAttributeArray) && is_array($mainAttributeArray)) {
-					$mainAttributes = self::getAttributeString($mainAttributeArray);
-				}
-				$result = '<select name="' . $name . '" ' . $mainAttributes . '>' . $totaltext . '</select>';
-			} else {
-				$result = $totaltext;
-			}
-		} else {
-			$result = false;
-		}
+            if ($bSelectTags && $type == 'select' && $name != '') {
+                $mainAttributes = '';
+                if (isset($mainAttributeArray) && is_array($mainAttributeArray)) {
+                    $mainAttributes = self::getAttributeString($mainAttributeArray);
+                }
+                $result = '<select name="' . $name . '" ' . $mainAttributes . '>' . $totaltext . '</select>';
+            } else {
+                $result = $totaltext;
+            }
+        } else {
+            $result = false;
+        }
 
-		return $result;
-	}
-
-
-	// fetches the valueArray needed for the functions of this class from a valueArray setup
-	static public function fetchValueArray ($confArray) {
-		$resultArray = [];
-		if (is_array($confArray)) {
-			foreach ($confArray as $k => $vArray) {
-				$resultArray[] =
-					[
-						0 => $vArray['label'],
-						1 => $vArray['value']
-					];
-			}
-		}
-		return $resultArray;
-	}
+        return $result;
+    }
 
 
-	static public function getKeyValueArray ($valueArray) {
-		$resultArray = [];
+    // fetches the valueArray needed for the functions of this class from a valueArray setup
+    static public function fetchValueArray ($confArray) {
+        $resultArray = [];
+        if (is_array($confArray)) {
+            foreach ($confArray as $k => $vArray) {
+                $resultArray[] =
+                    [
+                        0 => $vArray['label'],
+                        1 => $vArray['value']
+                    ];
+            }
+        }
+        return $resultArray;
+    }
 
-		foreach ($valueArray as $k => $row) {
-			$resultArray[$row[1]] = $row[0];
-		}
-		return $resultArray;
-	}
 
-	static protected function getAttributeString ($mainAttributeArray) {
-		$useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-		$resultArray = [];
+    static public function getKeyValueArray ($valueArray) {
+        $resultArray = [];
 
-		if (is_array($mainAttributeArray) && count($mainAttributeArray)) {
+        foreach ($valueArray as $k => $row) {
+            $resultArray[$row[1]] = $row[0];
+        }
+        return $resultArray;
+    }
 
-			foreach ($mainAttributeArray as $attribute => $value) {
-				if (
-					$useXHTML ||
-					$attribute != 'checked' && $attribute != 'selected' && $attribute != 'disabled'
-				) {
-					if ($value != '') {
-						$resultArray[] = $attribute . '="' . $value . '"';
-					}
-				} else {
-					$resultArray[] = $attribute;
-				}
-			}
-		}
-		$result = implode(' ', $resultArray);
-		return $result;
-	}
+    static protected function getAttributeString ($mainAttributeArray) {
+        $useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $resultArray = [];
 
-	static public function createTag (
-		$tag,
-		$name,
-		$value,
-		$preMainAttributes = '',
-		$mainAttributes = ''
-	) {
-		$useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-		$attributeTextArray = [];
-		$attributeArray = [];
-		$attributeArray['pre'] = $preMainAttributes;
-		$attributeArray['post'] = $mainAttributes;
-		$spaceArray = [];
-		$spaceArray['pre'] = ($preMainAttributes != '' ? ' ' : '');
-		$spaceArray['post'] = ($mainAttributes != '' ? ' ' : '');
+        if (is_array($mainAttributeArray) && count($mainAttributeArray)) {
 
-		foreach ($attributeArray as $k => $attributes) {
-			if (isset($attributes) && is_array($attributes)) {
-				$attributeTextArray[$k] = self::getAttributeString($attributes);
-			} else {
-				if ($attributes != '' && substr($attributes, 0, 1) != ' ') {
-					$attributeTextArray[$k] = ' ' . $attributes;
-				}
-			}
-		}
+            foreach ($mainAttributeArray as $attribute => $value) {
+                if (
+                    $useXHTML ||
+                    $attribute != 'checked' && $attribute != 'selected' && $attribute != 'disabled'
+                ) {
+                    if ($value != '') {
+                        $resultArray[] = $attribute . '="' . $value . '"';
+                    }
+                } else {
+                    $resultArray[] = $attribute;
+                }
+            }
+        }
+        $result = implode(' ', $resultArray);
+        return $result;
+    }
 
-		$flags = ENT_QUOTES;
-		$result = '<' . $tag . $spaceArray['pre'] . $attributeTextArray['pre'] . ' name="' . $name . '" value="' . htmlspecialchars($value, $flags) . '"' . $spaceArray['post'] . $attributeTextArray['post'] . ' ' . ($useXHTML ? '/' : '') . '>';
+    static public function createTag (
+        $tag,
+        $name,
+        $value,
+        $preMainAttributes = '',
+        $mainAttributes = ''
+    ) {
+        $useXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $attributeTextArray = [];
+        $attributeArray = [];
+        $attributeArray['pre'] = $preMainAttributes;
+        $attributeArray['post'] = $mainAttributes;
+        $spaceArray = [];
+        $spaceArray['pre'] = ($preMainAttributes != '' ? ' ' : '');
+        $spaceArray['post'] = ($mainAttributes != '' ? ' ' : '');
 
-		return $result;
-	}
+        foreach ($attributeArray as $k => $attributes) {
+            if (isset($attributes) && is_array($attributes)) {
+                $attributeTextArray[$k] = self::getAttributeString($attributes);
+            } else {
+                if ($attributes != '' && substr($attributes, 0, 1) != ' ') {
+                    $attributeTextArray[$k] = ' ' . $attributes;
+                }
+            }
+        }
+
+        $flags = ENT_QUOTES;
+        $result = '<' . $tag . $spaceArray['pre'] . $attributeTextArray['pre'] . ' name="' . $name . '" value="' . htmlspecialchars($value, $flags) . '"' . $spaceArray['post'] . $attributeTextArray['post'] . ' ' . ($useXHTML ? '/' : '') . '>';
+
+        return $result;
+    }
 }
 

--- a/lib/class.tx_ttproducts_gifts_div.php
+++ b/lib/class.tx_ttproducts_gifts_div.php
@@ -41,223 +41,223 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_gifts_div {
-	/**
-	 * returns if the product has been put into the basket as a gift
-	 *
-	 * @param	integer	 uid of the product
-	 * @param	integer	 variant of the product only size is used now --> TODO
-	 * @return  array	all gift numbers for this product
-	 */
-	static public function getGiftNumbers ($uid, $variant, $basketExt) {
-		$giftArray = [];
+    /**
+     * returns if the product has been put into the basket as a gift
+     *
+     * @param	integer	 uid of the product
+     * @param	integer	 variant of the product only size is used now --> TODO
+     * @return  array	all gift numbers for this product
+     */
+    static public function getGiftNumbers ($uid, $variant, $basketExt) {
+        $giftArray = [];
 
-		if ($basketExt['gift']) {
-			foreach ($basketExt['gift'] as $giftnumber => $giftItem) {
-				if ($giftItem['item'][$uid][$variant]) {
-					$giftArray[] = $giftnumber;
-				}
-			}
-		}
+        if ($basketExt['gift']) {
+            foreach ($basketExt['gift'] as $giftnumber => $giftItem) {
+                if ($giftItem['item'][$uid][$variant]) {
+                    $giftArray[] = $giftnumber;
+                }
+            }
+        }
 
-		return $giftArray;
-	}
-
-
-	/**
-	 * Adds gift markers to a markerArray
-	 */
-	static public function addGiftMarkers ($markerArray, $giftnumber, $code = 'LISTGIFTS', $id = '1') {
-
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-
-		$markerArray['###GIFTNO###'] = $giftnumber;
-		$markerArray['###GIFT_PERSON_NAME###'] = $basketExt['gift'][$giftnumber]['personname'];
-		$markerArray['###GIFT_PERSON_EMAIL###'] = $basketExt['gift'][$giftnumber]['personemail'];
-		$markerArray['###GIFT_DELIVERY_NAME###'] = $basketExt['gift'][$giftnumber]['deliveryname'];
-		$markerArray['###GIFT_DELIVERY_EMAIL###'] = $basketExt['gift'][$giftnumber]['deliveryemail'];
-		$markerArray['###GIFT_NOTE###'] = $basketExt['gift'][$giftnumber]['note'];
-
-		$markerArray['###FIELD_ID###'] = TT_PRODUCTS_EXT . '_' . strtolower($code) . '_id_' . $id;
-		// here again, because this is here in ITEM_LIST view
-		//	  $markerArray['###FIELD_QTY###'] =  '';
-
-	 	$markerArray['###FIELD_NAME_PERSON_NAME###']='ttp_gift[personname]';
-		$markerArray['###FIELD_NAME_PERSON_EMAIL###']='ttp_gift[personemail]';
-		$markerArray['###FIELD_NAME_DELIVERY_NAME###']='ttp_gift[deliveryname]';
-		$markerArray['###FIELD_NAME_DELIVERY_EMAIL###']='ttp_gift[deliveryemail]';
-		$markerArray['###FIELD_NAME_GIFT_NOTE###']='ttp_gift[note]';
-
-		return $markerArray;
-	} // addGiftMarkers
+        return $giftArray;
+    }
 
 
-	/**
-	 * Saves the orderRecord and returns the result
-	 *
-	 */
-	static public function saveOrderRecord ($orderUid, $pid, &$giftBasket) {
-		$rc = '';
+    /**
+     * Adds gift markers to a markerArray
+     */
+    static public function addGiftMarkers ($markerArray, $giftnumber, $code = 'LISTGIFTS', $id = '1') {
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$productObj = $tablesObj->get('tt_products');
-		foreach ($giftBasket as $giftnumber => $rec) {
-			$amount = 0;
-			foreach ($rec['item'] as $productid => $product) {
-				$row = $productObj->get($productid);
-				$articleRows = $productObj->getArticleRows($productid);
-				foreach ($product as $variant => $count) {
-					$productObj->variant->modifyRowFromVariant($row, $variant);
-					$articleRow = $productObj->getArticleRow($row, $theCode);
-					if (count ($articleRow)) {
-						$amount += intval($articleRow['price']) * $count;
-					} else {
-						$amount += intval($row['price']) * $count;
-					}
-				}
-			}
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
 
-			// Saving gift order data
-			$insertFields = [
-				'pid' => intval($pid),
-				'tstamp' => time(),
-				'crdate' => time(),
-				'deleted' => 0,
+        $markerArray['###GIFTNO###'] = $giftnumber;
+        $markerArray['###GIFT_PERSON_NAME###'] = $basketExt['gift'][$giftnumber]['personname'];
+        $markerArray['###GIFT_PERSON_EMAIL###'] = $basketExt['gift'][$giftnumber]['personemail'];
+        $markerArray['###GIFT_DELIVERY_NAME###'] = $basketExt['gift'][$giftnumber]['deliveryname'];
+        $markerArray['###GIFT_DELIVERY_EMAIL###'] = $basketExt['gift'][$giftnumber]['deliveryemail'];
+        $markerArray['###GIFT_NOTE###'] = $basketExt['gift'][$giftnumber]['note'];
 
-				'ordernumber'	=> $orderUid,
-				'personname'	=> $rec['personname'],
-				'personemail'	=> $rec['personemail'],
-				'deliveryname'	=> $rec['deliveryname'],
-				'deliveryemail' => $rec['deliveryemail'],
-				'note'			=> $rec['note'],
-				'amount'		=> $amount,
-			];
-			// Saving the gifts order record
+        $markerArray['###FIELD_ID###'] = TT_PRODUCTS_EXT . '_' . strtolower($code) . '_id_' . $id;
+        // here again, because this is here in ITEM_LIST view
+        //	  $markerArray['###FIELD_QTY###'] =  '';
 
-			$GLOBALS['TYPO3_DB']->exec_INSERTquery('tt_products_gifts', $insertFields);
-			$newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
-			$insertFields = [];
-			$insertFields['uid_local'] = $newId;
-			$variantFields = $productObj->variant->getFieldArray();
+        $markerArray['###FIELD_NAME_PERSON_NAME###']='ttp_gift[personname]';
+        $markerArray['###FIELD_NAME_PERSON_EMAIL###']='ttp_gift[personemail]';
+        $markerArray['###FIELD_NAME_DELIVERY_NAME###']='ttp_gift[deliveryname]';
+        $markerArray['###FIELD_NAME_DELIVERY_EMAIL###']='ttp_gift[deliveryemail]';
+        $markerArray['###FIELD_NAME_GIFT_NOTE###']='ttp_gift[note]';
 
-			foreach ($rec['item'] as $productid => $product) {
-				foreach ($product as $variant => $count) {
-					$row = [];
-					$productObj->variant->modifyRowFromVariant ($row, $variant);
-
-					$query='uid_product=\'' . intval($productid) . '\'';
-					foreach ($variantFields as $k => $field) {
-						if ($row[$field]) {
-							$query .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$field],'tt_products_articles');
-						}
-					}
-					$articleRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid', 'tt_products_articles', $query);
-
-					if ($articleRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($articleRes)) {
-						$insertFields['uid_foreign'] = $articleRow['uid'];
-						$insertFields['count'] = $count;
-						// Saving the gifts mm order record
-							$GLOBALS['TYPO3_DB']->exec_INSERTquery('tt_products_gifts_articles_mm',	$insertFields);
-					}
-				}
-			}
-		}
-
-		return $rc;
-	}
+        return $markerArray;
+    } // addGiftMarkers
 
 
-	static public function checkRequired ($basketExt, $infoViewObj, &$wrongGiftNumber) {
-		$result = '';
-		$wrongGiftNumber = 0;
+    /**
+     * Saves the orderRecord and returns the result
+     *
+     */
+    static public function saveOrderRecord ($orderUid, $pid, &$giftBasket) {
+        $rc = '';
 
-		if (
-			isset($basketExt) &&
-			is_array($basketExt) &&
-			isset($basketExt['gift']) &&
-			is_array($basketExt['gift'])
-		) {
-			// RegEx-Check
-			$checkFieldsExpr = $infoViewObj->getFieldChecks('gift');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $productObj = $tablesObj->get('tt_products');
+        foreach ($giftBasket as $giftnumber => $rec) {
+            $amount = 0;
+            foreach ($rec['item'] as $productid => $product) {
+                $row = $productObj->get($productid);
+                $articleRows = $productObj->getArticleRows($productid);
+                foreach ($product as $variant => $count) {
+                    $productObj->variant->modifyRowFromVariant($row, $variant);
+                    $articleRow = $productObj->getArticleRow($row, $theCode);
+                    if (count ($articleRow)) {
+                        $amount += intval($articleRow['price']) * $count;
+                    } else {
+                        $amount += intval($row['price']) * $count;
+                    }
+                }
+            }
 
-			if (($checkFieldsExpr) && (is_array($checkFieldsExpr))) {
-				foreach ($checkFieldsExpr as $fName => $checkExpr) {
+            // Saving gift order data
+            $insertFields = [
+                'pid' => intval($pid),
+                'tstamp' => time(),
+                'crdate' => time(),
+                'deleted' => 0,
 
-					foreach ($basketExt['gift'] as $giftnumber => $giftRow) {
+                'ordernumber'	=> $orderUid,
+                'personname'	=> $rec['personname'],
+                'personemail'	=> $rec['personemail'],
+                'deliveryname'	=> $rec['deliveryname'],
+                'deliveryemail' => $rec['deliveryemail'],
+                'note'			=> $rec['note'],
+                'amount'		=> $amount,
+            ];
+            // Saving the gifts order record
 
-						foreach ($giftRow as $field => $value) {
-							if (
-								strpos($field, $fName) !== false &&
-								preg_match('/' . $checkExpr . '/', $value) == 0
-							) {
-								$wrongGiftNumber = $giftnumber;
-								$result = $fName;
-								break;
-							}
-						}
-					}
-				}
-			}
-		}
+            $GLOBALS['TYPO3_DB']->exec_INSERTquery('tt_products_gifts', $insertFields);
+            $newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
+            $insertFields = [];
+            $insertFields['uid_local'] = $newId;
+            $variantFields = $productObj->variant->getFieldArray();
 
-		return $result;
-	}
+            foreach ($rec['item'] as $productid => $product) {
+                foreach ($product as $variant => $count) {
+                    $row = [];
+                    $productObj->variant->modifyRowFromVariant ($row, $variant);
 
+                    $query='uid_product=\'' . intval($productid) . '\'';
+                    foreach ($variantFields as $k => $field) {
+                        if ($row[$field]) {
+                            $query .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$field],'tt_products_articles');
+                        }
+                    }
+                    $articleRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid', 'tt_products_articles', $query);
 
-	static public function deleteGiftNumber ($giftnumber) {
-		$giftArray = [];
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
+                    if ($articleRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($articleRes)) {
+                        $insertFields['uid_foreign'] = $articleRow['uid'];
+                        $insertFields['count'] = $count;
+                        // Saving the gifts mm order record
+                            $GLOBALS['TYPO3_DB']->exec_INSERTquery('tt_products_gifts_articles_mm',	$insertFields);
+                    }
+                }
+            }
+        }
 
-		if (
-			is_array($basketExt) &&
-			isset($basketExt['gift']) &&
-			is_array($basketExt['gift']) &&
-			isset($basketExt['gift'][$giftnumber])
-		) {
-			$count = count($basketExt['gift']);
-			$itemArray = $basketExt['gift'][$giftnumber]['item'];
-
-			foreach ($itemArray as $uid => $nextData) {
-				foreach ($nextData as $allVariants => $count) {
-					unset($basketExt[$uid][$allVariants]);
-					if (!$basketExt[$uid]) {
-						unset($basketExt[$uid]);
-					}
-				}
-			}
-
-			unset($basketExt['gift'][$giftnumber]);
-			if ($count == 1) {
-				unset($basketExt['gift']);
-			}
-			tx_ttproducts_control_basket::storeBasketExt($basketExt);
-		}
-	}
-
-
-	static public function isGift ($row, $whereGift) {
-		$result = false;
-
-		if (strlen($whereGift)) {
-			$result = tx_ttproducts_sql::isValid($row, $whereGift);
-		}
-		return $result;
-	}
+        return $rc;
+    }
 
 
-	static public function useTaxZero ($row, $giftConf, $whereGift) {
-		$result = false;
-		if (
-			self::isGift($row, $whereGift) &&
-			isset($giftConf) &&
-			is_array($giftConf) &&
-			isset($giftConf['TAXpercentage']) &&
-			doubleval($giftConf['TAXpercentage']) == '0'
-		) {
-			$result = true;
-		}
+    static public function checkRequired ($basketExt, $infoViewObj, &$wrongGiftNumber) {
+        $result = '';
+        $wrongGiftNumber = 0;
 
-		return $result;
-	}
+        if (
+            isset($basketExt) &&
+            is_array($basketExt) &&
+            isset($basketExt['gift']) &&
+            is_array($basketExt['gift'])
+        ) {
+            // RegEx-Check
+            $checkFieldsExpr = $infoViewObj->getFieldChecks('gift');
+
+            if (($checkFieldsExpr) && (is_array($checkFieldsExpr))) {
+                foreach ($checkFieldsExpr as $fName => $checkExpr) {
+
+                    foreach ($basketExt['gift'] as $giftnumber => $giftRow) {
+
+                        foreach ($giftRow as $field => $value) {
+                            if (
+                                strpos($field, $fName) !== false &&
+                                preg_match('/' . $checkExpr . '/', $value) == 0
+                            ) {
+                                $wrongGiftNumber = $giftnumber;
+                                $result = $fName;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+
+    static public function deleteGiftNumber ($giftnumber) {
+        $giftArray = [];
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+
+        if (
+            is_array($basketExt) &&
+            isset($basketExt['gift']) &&
+            is_array($basketExt['gift']) &&
+            isset($basketExt['gift'][$giftnumber])
+        ) {
+            $count = count($basketExt['gift']);
+            $itemArray = $basketExt['gift'][$giftnumber]['item'];
+
+            foreach ($itemArray as $uid => $nextData) {
+                foreach ($nextData as $allVariants => $count) {
+                    unset($basketExt[$uid][$allVariants]);
+                    if (!$basketExt[$uid]) {
+                        unset($basketExt[$uid]);
+                    }
+                }
+            }
+
+            unset($basketExt['gift'][$giftnumber]);
+            if ($count == 1) {
+                unset($basketExt['gift']);
+            }
+            tx_ttproducts_control_basket::storeBasketExt($basketExt);
+        }
+    }
+
+
+    static public function isGift ($row, $whereGift) {
+        $result = false;
+
+        if (strlen($whereGift)) {
+            $result = tx_ttproducts_sql::isValid($row, $whereGift);
+        }
+        return $result;
+    }
+
+
+    static public function useTaxZero ($row, $giftConf, $whereGift) {
+        $result = false;
+        if (
+            self::isGift($row, $whereGift) &&
+            isset($giftConf) &&
+            is_array($giftConf) &&
+            isset($giftConf['TAXpercentage']) &&
+            doubleval($giftConf['TAXpercentage']) == '0'
+        ) {
+            $result = true;
+        }
+
+        return $result;
+    }
 
 }
 

--- a/lib/class.tx_ttproducts_pricecalc.php
+++ b/lib/class.tx_ttproducts_pricecalc.php
@@ -43,86 +43,86 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_pricecalc extends tx_ttproducts_pricecalc_base {
 
-	public function getCalculatedData (
-		&$itemArray,
-		$conf,
-		$type,
-		&$priceReduction,
-		&$discountArray,
-		$priceTotalTax,
-		$bUseArticles,
-		$taxIncluded,
-		$bMergeArticles = true,
+    public function getCalculatedData (
+        &$itemArray,
+        $conf,
+        $type,
+        &$priceReduction,
+        &$discountArray,
+        $priceTotalTax,
+        $bUseArticles,
+        $taxIncluded,
+        $bMergeArticles = true,
         $uid = 0
-	) {
-		$sql = GeneralUtility::makeInstance('tx_ttproducts_sql');
+    ) {
+        $sql = GeneralUtility::makeInstance('tx_ttproducts_sql');
 
-		if (!$itemArray || !count($itemArray)) {
-			return;
-		}
-		ksort($conf);
+        if (!$itemArray || !count($itemArray)) {
+            return;
+        }
+        ksort($conf);
 
-		foreach ($conf as $k1 => $priceCalcTemp) {
+        foreach ($conf as $k1 => $priceCalcTemp) {
 
-			if (!is_array($priceCalcTemp)) {
-				continue;
-			}
-			$countedItems = [];
-			$pricefor1 = doubleval($priceCalcTemp['prod.']['1']);
-			$dumCount = 0;
+            if (!is_array($priceCalcTemp)) {
+                continue;
+            }
+            $countedItems = [];
+            $pricefor1 = doubleval($priceCalcTemp['prod.']['1']);
+            $dumCount = 0;
 
-			// loop over all items in the basket indexed by sort string
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k2 => $actItem) {
+            // loop over all items in the basket indexed by sort string
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k2 => $actItem) {
 
-					$row = $actItem['rec'];
+                    $row = $actItem['rec'];
 
-					if (is_array($priceCalcTemp['sql.']))    {
-						if (!($bIsValid = $sql->isValid($row, $priceCalcTemp['sql.']['where'])))    {
-							continue;
-						}
-					}
+                    if (is_array($priceCalcTemp['sql.']))    {
+                        if (!($bIsValid = $sql->isValid($row, $priceCalcTemp['sql.']['where'])))    {
+                            continue;
+                        }
+                    }
 
-					// has a price reduction already been calculated before ?
-					if ($priceReduction[$row['uid']] == 1) {
-						continue;
-					}
+                    // has a price reduction already been calculated before ?
+                    if ($priceReduction[$row['uid']] == 1) {
+                        continue;
+                    }
 
-					// count all items which will apply to the discount price
-					$count2 = $actItem['count'];
+                    // count all items which will apply to the discount price
+                    $count2 = $actItem['count'];
 
-					if (((float) $count2 > 0) && ($row['price'] == $pricefor1)) {
-						$countedItems[$k1][] = array ('sort' => $sort);
-						$dumCount += $count2;
-					}
-				}
-			}
+                    if (((float) $count2 > 0) && ($row['price'] == $pricefor1)) {
+                        $countedItems[$k1][] = array ('sort' => $sort);
+                        $dumCount += $count2;
+                    }
+                }
+            }
 
-				// nothing found?
-			if ($dumCount == 0) {
-				continue;
-			}
+                // nothing found?
+            if ($dumCount == 0) {
+                continue;
+            }
 
-			$priceTotalTemp = 0;
-			$countTemp = $dumCount;
-			krsort($priceCalcTemp['prod.']);
-			foreach ($priceCalcTemp['prod.'] as $k2 => $price2) {
+            $priceTotalTemp = 0;
+            $countTemp = $dumCount;
+            krsort($priceCalcTemp['prod.']);
+            foreach ($priceCalcTemp['prod.'] as $k2 => $price2) {
 
-				if ((float) $k2 > 0) {
-					while ($countTemp >= (float) $k2) {
-						$countTemp -= (float) $k2;
-						$priceTotalTemp += doubleval($price2);
-					}
-				}
-			}
-			$priceProduct = ((float) $dumCount > 0 ? ($priceTotalTemp / $dumCount) : 0);
+                if ((float) $k2 > 0) {
+                    while ($countTemp >= (float) $k2) {
+                        $countTemp -= (float) $k2;
+                        $priceTotalTemp += doubleval($price2);
+                    }
+                }
+            }
+            $priceProduct = ((float) $dumCount > 0 ? ($priceTotalTemp / $dumCount) : 0);
 
-			foreach ($countedItems[$k1] as $k3 => $v3) {
-				foreach ($itemArray[$v3['sort']] as $k4=>$actItem) {
-					$itemArray[$v3['sort']][$k4][$type] = $priceProduct;
-				}
-			}
-		}
-	} // getCalculatedData
+            foreach ($countedItems[$k1] as $k3 => $v3) {
+                foreach ($itemArray[$v3['sort']] as $k4=>$actItem) {
+                    $itemArray[$v3['sort']][$k4][$type] = $priceProduct;
+                }
+            }
+        }
+    } // getCalculatedData
 }
 

--- a/lib/class.tx_ttproducts_pricecalc_base.php
+++ b/lib/class.tx_ttproducts_pricecalc_base.php
@@ -41,28 +41,28 @@
 
 class tx_ttproducts_pricecalc_base implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function getPrice ($conf, $offset, $num = '1') {
-		$rc = 0;
-		$priceCalcTemp = $conf[$offset];
-		if (is_array($priceCalcTemp)) {
-			$rc = doubleval($priceCalcTemp['prod.'][$num]);
-		}
-		return $rc;
-	}
+    public function getPrice ($conf, $offset, $num = '1') {
+        $rc = 0;
+        $priceCalcTemp = $conf[$offset];
+        if (is_array($priceCalcTemp)) {
+            $rc = doubleval($priceCalcTemp['prod.'][$num]);
+        }
+        return $rc;
+    }
 
-	public function getCalculatedData (
-		&$itemArray,
-		$conf,
-		$type,
-		&$priceReduction,
-		&$discountArray,
-		$priceTotalTax,
-		$bUseArticles,
-		$taxIncluded,
-		$bMergeArticles = true,
-		$uid = 0
-	) {
-	} // getCalculatedData
+    public function getCalculatedData (
+        &$itemArray,
+        $conf,
+        $type,
+        &$priceReduction,
+        &$discountArray,
+        $priceTotalTax,
+        $bUseArticles,
+        $taxIncluded,
+        $bMergeArticles = true,
+        $uid = 0
+    ) {
+    } // getCalculatedData
 
 }
 

--- a/lib/class.tx_ttproducts_sql.php
+++ b/lib/class.tx_ttproducts_sql.php
@@ -42,118 +42,118 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_sql {
-	static public $comparatorConversionArray = [
-		'le' => '<=',
-		'lt' => '<',
-		'ge' => '>=',
-		'gt' => '>'
-	];
+    static public $comparatorConversionArray = [
+        'le' => '<=',
+        'lt' => '<',
+        'ge' => '>=',
+        'gt' => '>'
+    ];
 
 
-	static public function transformComparator ($comparator) {
-		$result = false;
+    static public function transformComparator ($comparator) {
+        $result = false;
 
-		$convertedComparator = self::$comparatorConversionArray[$comparator];
-		if (isset($convertedComparator)) {
-			$result = $convertedComparator;
-		}
+        $convertedComparator = self::$comparatorConversionArray[$comparator];
+        if (isset($convertedComparator)) {
+            $result = $convertedComparator;
+        }
 
-		return $result;
-	}
-
-
-	static public function getWhere4Field($tablename, $field, $comparator, $comparand) {
-		$result = '';
-
-		if (isset($GLOBALS['TCA'][$tablename]) && isset($GLOBALS['TCA'][$tablename]['columns'][$field])) {
-			$tcaConf = $GLOBALS['TCA'][$tablename]['columns'][$field]['config'];
-			if ($tcaConf['eval'] == 'date') {
-				$valueString = self::convertDate($comparand);
-				if ($valueString === false) {
-					return false;
-				}
-			} else {
-				$valueString = $GLOBALS['TYPO3_DB']->fullQuoteStr($comparand, $tablename);
-			}
-			$result = ' AND ' . $field . ' ' . $comparator . ' ' . $valueString;
-		}
-
-		return $result;
-	}
+        return $result;
+    }
 
 
-	static public function convertDate ($date) {
-		$result = false;
-		$delimiter = '.';
+    static public function getWhere4Field($tablename, $field, $comparator, $comparand) {
+        $result = '';
 
-		if (strpos($date, '-') !== false) {
-			$delimiter = '-';
-		}
-		$dateArray = GeneralUtility::trimExplode($delimiter, $date);
+        if (isset($GLOBALS['TCA'][$tablename]) && isset($GLOBALS['TCA'][$tablename]['columns'][$field])) {
+            $tcaConf = $GLOBALS['TCA'][$tablename]['columns'][$field]['config'];
+            if ($tcaConf['eval'] == 'date') {
+                $valueString = self::convertDate($comparand);
+                if ($valueString === false) {
+                    return false;
+                }
+            } else {
+                $valueString = $GLOBALS['TYPO3_DB']->fullQuoteStr($comparand, $tablename);
+            }
+            $result = ' AND ' . $field . ' ' . $comparator . ' ' . $valueString;
+        }
 
-		if (
-			MathUtility::canBeInterpretedAsInteger($dateArray[0]) &&
-			MathUtility::canBeInterpretedAsInteger($dateArray[1]) &&
-			MathUtility::canBeInterpretedAsInteger($dateArray[2])
-		) {
-			$unixTime = mktime(0, 0, 0, $dateArray[1], $dateArray[0], $dateArray[2]);
-			if (isset($unixTime)) {
-				$result = $unixTime;
-			}
-		}
-		return $result;
-	}
+        return $result;
+    }
 
 
-	static public function isValid ($row, $where) {
-		$whereArray = GeneralUtility::trimExplode ('AND', $where);
-		$isValid = true;
+    static public function convertDate ($date) {
+        $result = false;
+        $delimiter = '.';
 
-		foreach($whereArray as $k3 => $condition) {
+        if (strpos($date, '-') !== false) {
+            $delimiter = '-';
+        }
+        $dateArray = GeneralUtility::trimExplode($delimiter, $date);
 
-			if (strpos($condition, '=') !== false) {
-				if ($condition == '1=1' || $condition == '1 = 1') {
-					// nothing: $isValid = true;
-				} else {
-					$args = GeneralUtility::trimExplode ('=', $condition);
+        if (
+            MathUtility::canBeInterpretedAsInteger($dateArray[0]) &&
+            MathUtility::canBeInterpretedAsInteger($dateArray[1]) &&
+            MathUtility::canBeInterpretedAsInteger($dateArray[2])
+        ) {
+            $unixTime = mktime(0, 0, 0, $dateArray[1], $dateArray[0], $dateArray[2]);
+            if (isset($unixTime)) {
+                $result = $unixTime;
+            }
+        }
+        return $result;
+    }
 
-					if ($row[$args[0]] != $args[1]) {
-						$isValid = false;
-					}
-				}
-			} else if (strpos($condition, 'IN') !== false) {
-				$split = 'IN';
-				$isValidRow = false;
-				if (strpos($condition, 'NOT IN') !== false) {
-					$split = 'NOT IN';
-					$isValidRow = true;
-				}
-				$args = GeneralUtility::trimExplode ($split, $condition);
-				$leftBracket = strpos($args[1],'(');
-				$rightBracket = strpos($args[1],')');
-				if ($leftBracket !== false && $rightBracket !== false) {
-					$args[1] = substr($args[1], $leftBracket+1, $rightBracket-$leftBracket-1);
-					$argArray = GeneralUtility::trimExplode(',', $args[1]);
-					if (is_array($argArray)) {
-						foreach($argArray as $arg) {
-							$leftQuote = strpos($arg,'\'');
-							$rightQuote = strrpos($arg,'\'');
-							if ($leftQuote !== false && $rightQuote !== false) {
-								$arg = substr($arg, $leftQuote+1, $rightQuote-$leftQuote-1);
-							}
-							if ($row[$args[0]] == $arg) {
-								if ($split == 'IN') {
-									$isValidRow = true;
-									break;
-								} else {
-									$isValidRow = false;
-									break;
-								}
-							}
-						}
-					}
-					$isValid = $isValidRow;
-				}
+
+    static public function isValid ($row, $where) {
+        $whereArray = GeneralUtility::trimExplode ('AND', $where);
+        $isValid = true;
+
+        foreach($whereArray as $k3 => $condition) {
+
+            if (strpos($condition, '=') !== false) {
+                if ($condition == '1=1' || $condition == '1 = 1') {
+                    // nothing: $isValid = true;
+                } else {
+                    $args = GeneralUtility::trimExplode ('=', $condition);
+
+                    if ($row[$args[0]] != $args[1]) {
+                        $isValid = false;
+                    }
+                }
+            } else if (strpos($condition, 'IN') !== false) {
+                $split = 'IN';
+                $isValidRow = false;
+                if (strpos($condition, 'NOT IN') !== false) {
+                    $split = 'NOT IN';
+                    $isValidRow = true;
+                }
+                $args = GeneralUtility::trimExplode ($split, $condition);
+                $leftBracket = strpos($args[1],'(');
+                $rightBracket = strpos($args[1],')');
+                if ($leftBracket !== false && $rightBracket !== false) {
+                    $args[1] = substr($args[1], $leftBracket+1, $rightBracket-$leftBracket-1);
+                    $argArray = GeneralUtility::trimExplode(',', $args[1]);
+                    if (is_array($argArray)) {
+                        foreach($argArray as $arg) {
+                            $leftQuote = strpos($arg,'\'');
+                            $rightQuote = strrpos($arg,'\'');
+                            if ($leftQuote !== false && $rightQuote !== false) {
+                                $arg = substr($arg, $leftQuote+1, $rightQuote-$leftQuote-1);
+                            }
+                            if ($row[$args[0]] == $arg) {
+                                if ($split == 'IN') {
+                                    $isValidRow = true;
+                                    break;
+                                } else {
+                                    $isValidRow = false;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    $isValid = $isValidRow;
+                }
             } else if (
                 strpos($condition, '<') !== false ||
                 strpos($condition, '>') !== false ||
@@ -199,15 +199,15 @@ class tx_ttproducts_sql {
                 } else {
                     $isValid = false;
                 }
-			} else if ($condition != '') {
-				$isValid = false;
-			}
-			if ($isValid == false) {
-				break;
-			}
-		}
-		return ($isValid);
-	}
+            } else if ($condition != '') {
+                $isValid = false;
+            }
+            if ($isValid == false) {
+                break;
+            }
+        }
+        return ($isValid);
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_tables.php
+++ b/lib/class.tx_ttproducts_tables.php
@@ -39,227 +39,227 @@
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_tables implements \TYPO3\CMS\Core\SingletonInterface {
-	protected $tableClassArray = [
-		'address' => 'tx_ttproducts_address',
-		'fe_users' => 'tx_ttproducts_orderaddress',
-		'pages' => 'tx_ttproducts_page',
-		'static_banks_de' => 'tx_ttproducts_bank_de',
-		'static_countries' => 'tx_ttproducts_country',
-		'static_taxes' => 'tx_ttproducts_static_tax',
-		'sys_file_reference' => 'tx_ttproducts_fal',
-		'sys_products_orders' => 'tx_ttproducts_order',
-		'sys_products_accounts' => 'tx_ttproducts_account',
-		'sys_products_cards' => 'tx_ttproducts_card',
-		'tt_content' => 'tx_ttproducts_content',
-		'tt_products' => 'tx_ttproducts_product',
-		'tt_products_articles' => 'tx_ttproducts_article',
-		'tt_products_cat' => 'tx_ttproducts_category',
-		'tt_products_downloads' => 'tx_ttproducts_download',
-		'tt_products_emails' => 'tx_ttproducts_email',
-		'tt_products_texts' => 'tx_ttproducts_text',
-		'tx_dam' => 'tx_ttproducts_dam',
-		'tx_dam_cat' => 'tx_ttproducts_damcategory',
-		'voucher' => 'tx_ttproducts_voucher',
-	];
-	protected $needExtensionArray = [
-		'static_banks_de' => 'static_info_tables_banks_de',
-		'static_countries' => 'static_info_tables',
-		'sys_file_reference' => 'filelist',
-		'tx_dam' => 'dam',
-		'tx_dam_cat' => 'dam'
-	];
-	protected $usedObjectArray = [];
+    protected $tableClassArray = [
+        'address' => 'tx_ttproducts_address',
+        'fe_users' => 'tx_ttproducts_orderaddress',
+        'pages' => 'tx_ttproducts_page',
+        'static_banks_de' => 'tx_ttproducts_bank_de',
+        'static_countries' => 'tx_ttproducts_country',
+        'static_taxes' => 'tx_ttproducts_static_tax',
+        'sys_file_reference' => 'tx_ttproducts_fal',
+        'sys_products_orders' => 'tx_ttproducts_order',
+        'sys_products_accounts' => 'tx_ttproducts_account',
+        'sys_products_cards' => 'tx_ttproducts_card',
+        'tt_content' => 'tx_ttproducts_content',
+        'tt_products' => 'tx_ttproducts_product',
+        'tt_products_articles' => 'tx_ttproducts_article',
+        'tt_products_cat' => 'tx_ttproducts_category',
+        'tt_products_downloads' => 'tx_ttproducts_download',
+        'tt_products_emails' => 'tx_ttproducts_email',
+        'tt_products_texts' => 'tx_ttproducts_text',
+        'tx_dam' => 'tx_ttproducts_dam',
+        'tx_dam_cat' => 'tx_ttproducts_damcategory',
+        'voucher' => 'tx_ttproducts_voucher',
+    ];
+    protected $needExtensionArray = [
+        'static_banks_de' => 'static_info_tables_banks_de',
+        'static_countries' => 'static_info_tables',
+        'sys_file_reference' => 'filelist',
+        'tx_dam' => 'dam',
+        'tx_dam_cat' => 'dam'
+    ];
+    protected $usedObjectArray = [];
 
 
-	public function getTableClassArray () {
-		return $this->tableClassArray;
-	}
+    public function getTableClassArray () {
+        return $this->tableClassArray;
+    }
 
-	public function setTableClassArray ($tableClassArray) {
-		$this->tableClassArray = $tableClassArray;
-	}
+    public function setTableClassArray ($tableClassArray) {
+        $this->tableClassArray = $tableClassArray;
+    }
 
-	public function getTableClass ($functablename, $bView = false) {
+    public function getTableClass ($functablename, $bView = false) {
 
-		$rc = '';
-		if ($functablename) {
+        $rc = '';
+        if ($functablename) {
             $neededExtension = '';
             if (isset($this->needExtensionArray[$functablename])) {
                 $neededExtension = $this->needExtensionArray[$functablename];
-			}
-			if (empty($neededExtension) || \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($neededExtension)) {
-				$rc = $this->tableClassArray[$functablename] . ($bView ? '_view' : '');
-			} else {
-				$rc = 'skip';
-			}
-		}
-		return $rc;
-	}
+            }
+            if (empty($neededExtension) || \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($neededExtension)) {
+                $rc = $this->tableClassArray[$functablename] . ($bView ? '_view' : '');
+            } else {
+                $rc = 'skip';
+            }
+        }
+        return $rc;
+    }
 
-	/* set the $bView to true if you want to get the view class */
-	public function get ($functablename, $bView = false, $bInit = true) {
-		$classNameArray = [];
-		$tableObjArray = [];
-		$resultInit = true;
+    /* set the $bView to true if you want to get the view class */
+    public function get ($functablename, $bView = false, $bInit = true) {
+        $classNameArray = [];
+        $tableObjArray = [];
+        $resultInit = true;
 
-		$classNameArray['model'] = $this->getTableClass($functablename, false);
+        $classNameArray['model'] = $this->getTableClass($functablename, false);
 
-		if ($bView) {
-			$classNameArray['view'] = $this->getTableClass($functablename, true);
-		}
+        if ($bView) {
+            $classNameArray['view'] = $this->getTableClass($functablename, true);
+        }
 
-		if (!$classNameArray['model'] || $bView && !$classNameArray['view']) {
-			debug ('Error in '.TT_PRODUCTS_EXT.'. No class found after calling function tx_ttproducts_tables::get with parameters "' . $functablename . '", ' . $bView . ' . ','internal error'); // keep this
-			return false;
-		}
+        if (!$classNameArray['model'] || $bView && !$classNameArray['view']) {
+            debug ('Error in '.TT_PRODUCTS_EXT.'. No class found after calling function tx_ttproducts_tables::get with parameters "' . $functablename . '", ' . $bView . ' . ','internal error'); // keep this
+            return false;
+        }
 
-		foreach ($classNameArray as $k => $className) {
-			if ($className != 'skip') {
-				if (strpos($className, ':') === false) {
-					$path = PATH_BE_TTPRODUCTS;
-				} else {
-					list($extKey, $className) = GeneralUtility::trimExplode(':', $className, true);
+        foreach ($classNameArray as $k => $className) {
+            if ($className != 'skip') {
+                if (strpos($className, ':') === false) {
+                    $path = PATH_BE_TTPRODUCTS;
+                } else {
+                    list($extKey, $className) = GeneralUtility::trimExplode(':', $className, true);
 
-					if (!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
-						debug ('Error in '.TT_PRODUCTS_EXT.'. No extension "' . $extKey . '" has been activated to use class class.' . $className . '.','internal error');
-						continue;
-					}
-					$path = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($extKey);
-				}
-				$classRef = 'class.' . $className;
-				$classFile = $path . $k . '/' . $classRef . '.php';
+                    if (!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
+                        debug ('Error in '.TT_PRODUCTS_EXT.'. No extension "' . $extKey . '" has been activated to use class class.' . $className . '.','internal error');
+                        continue;
+                    }
+                    $path = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($extKey);
+                }
+                $classRef = 'class.' . $className;
+                $classFile = $path . $k . '/' . $classRef . '.php';
 
-				if (file_exists($classFile)) {
-					$classRef = $classFile . ':' . $className;
-					$tableObj[$k] = GeneralUtility::makeInstance($className);	// fetch and store it as persistent object
-					$this->usedObjectArray[$className] = true;
-				} else {
-					debug ($classFile, 'File not found: ' . $classFile . ' in file class.tx_ttproducts_tables.php'); // keep this
-				}
-			}
-		}
+                if (file_exists($classFile)) {
+                    $classRef = $classFile . ':' . $className;
+                    $tableObj[$k] = GeneralUtility::makeInstance($className);	// fetch and store it as persistent object
+                    $this->usedObjectArray[$className] = true;
+                } else {
+                    debug ($classFile, 'File not found: ' . $classFile . ' in file class.tx_ttproducts_tables.php'); // keep this
+                }
+            }
+        }
 
-		if (isset($tableObj['model']) && is_object($tableObj['model'])) {
-			if ($bInit && $tableObj['model']->needsInit()) {
-				$resultInit = $tableObj['model']->init(
-					$functablename
-				);
-			}
-		} else {
-			if ($classNameArray['model'] == 'skip') {
+        if (isset($tableObj['model']) && is_object($tableObj['model'])) {
+            if ($bInit && $tableObj['model']->needsInit()) {
+                $resultInit = $tableObj['model']->init(
+                    $functablename
+                );
+            }
+        } else {
+            if ($classNameArray['model'] == 'skip') {
                 if (isset($this->needExtensionArray[$functablename])) {
                     debug ('The extension \'' . $this->needExtensionArray[$functablename] . '\' needed for table \'' . $functablename . '\' has not been installed.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
                 } else {
                     debug ('Table \'' . $functablename . '\' is not configured.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
                 }
-			} else {
-				debug ('Object for \'' . $functablename . '\' has not been found.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
-			}
-		}
+            } else {
+                debug ('Object for \'' . $functablename . '\' has not been found.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
+            }
+        }
 
-		if (
-			$resultInit &&
-			isset($tableObj['view']) &&
-			is_object($tableObj['view']) &&
-			isset($tableObj['model']) &&
-			is_object($tableObj['model'])
-		) {
-			if ($bInit && $tableObj['view']->needsInit()) {
+        if (
+            $resultInit &&
+            isset($tableObj['view']) &&
+            is_object($tableObj['view']) &&
+            isset($tableObj['model']) &&
+            is_object($tableObj['model'])
+        ) {
+            if ($bInit && $tableObj['view']->needsInit()) {
 
-				$resultInit = $tableObj['view']->init(
-					$tableObj['model']
-				);
-			}
-		}
+                $resultInit = $tableObj['view']->init(
+                    $tableObj['model']
+                );
+            }
+        }
 
-		$result = false;
-		if ($resultInit) {
-			$result = ($bView ? $tableObj['view'] : $tableObj['model'] ?? false);
-		}
-		return $result;
-	}
+        $result = false;
+        if ($resultInit) {
+            $result = ($bView ? $tableObj['view'] : $tableObj['model'] ?? false);
+        }
+        return $result;
+    }
 
-	public function getMM ($functablename) {
+    public function getMM ($functablename) {
 
-		$tableObj = GeneralUtility::makeInstance('tx_ttproducts_mm_table');
+        $tableObj = GeneralUtility::makeInstance('tx_ttproducts_mm_table');
 
-		if (isset($tableObj) && is_object($tableObj)) {
-			if ($tableObj->needsInit() || $tableObj->getFuncTablename() != $functablename) {
-				$tableObj->init(
-					$functablename
-				);
-			}
-		} else {
-			debug ('Object for \'' . $functablename . '\' has not been found.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
-		}
-		return $tableObj;
-	}
+        if (isset($tableObj) && is_object($tableObj)) {
+            if ($tableObj->needsInit() || $tableObj->getFuncTablename() != $functablename) {
+                $tableObj->init(
+                    $functablename
+                );
+            }
+        } else {
+            debug ('Object for \'' . $functablename . '\' has not been found.', 'internal error in ' . TT_PRODUCTS_EXT); // keep this
+        }
+        return $tableObj;
+    }
 
-	/**
-	 * Returns informations about the table and foreign table
-	 * This is used by various tables.
-	 *
-	 * @param	string		name of the table
-	 * @param	string		field of the table
-	 *
-	 * @return	array		infos about the table and foreign table:
-					table         ... name of the table
-					foreign_table ... name of the foreign table
-					mmtable       ... name of the mm table
-					foreign_field ... name of the field in the mm table which joins with
-					                  the foreign table
-	 * @access	public
-	 *
-	 */
-	public function getForeignTableInfo ($functablename, $fieldname) {
-		$rc = [];
-		if ($fieldname != '') {
-			$tableObj = $this->get($functablename, false);
-			$tablename = $tableObj->getTableName($functablename);
-			$rc = \JambageCom\Div2007\Utility\TableUtility::getForeignTableInfo($tablename, $fieldname);
-		}
-		return $rc;
-	}
+    /**
+     * Returns informations about the table and foreign table
+     * This is used by various tables.
+     *
+     * @param	string		name of the table
+     * @param	string		field of the table
+     *
+     * @return	array		infos about the table and foreign table:
+                    table         ... name of the table
+                    foreign_table ... name of the foreign table
+                    mmtable       ... name of the mm table
+                    foreign_field ... name of the field in the mm table which joins with
+                                      the foreign table
+     * @access	public
+     *
+     */
+    public function getForeignTableInfo ($functablename, $fieldname) {
+        $rc = [];
+        if ($fieldname != '') {
+            $tableObj = $this->get($functablename, false);
+            $tablename = $tableObj->getTableName($functablename);
+            $rc = \JambageCom\Div2007\Utility\TableUtility::getForeignTableInfo($tablename, $fieldname);
+        }
+        return $rc;
+    }
 
-	public function prepareSQL (
-		$foreignTableInfoArray,
-		$tableAliasArray,
-		$aliasPostfix,
-		&$sqlArray
-	) {
-		if (
+    public function prepareSQL (
+        $foreignTableInfoArray,
+        $tableAliasArray,
+        $aliasPostfix,
+        &$sqlArray
+    ) {
+        if (
             empty($foreignTableInfoArray['mmtable']) && 
             !empty($foreignTableInfoArray['foreign_table'])
         ) {
             $fieldname = $foreignTableInfoArray['table_field'];
             $tablename = $foreignTableInfoArray['table'];
-			if (isset($tableAliasArray[$tablename])) {
-				$tablealiasname = $tableAliasArray[$tablename];
-			} else {
-				$tablealiasname = $tablename;
-			}
+            if (isset($tableAliasArray[$tablename])) {
+                $tablealiasname = $tableAliasArray[$tablename];
+            } else {
+                $tablealiasname = $tablename;
+            }
 
-			$foreigntablename = $foreignTableInfoArray['foreign_table'];
-			if (isset($tableAliasArray[$foreigntablename])) {
-				$foreigntablealiasname = $tableAliasArray[$foreigntablename];
-			} else {
-				$foreigntablealiasname = $foreigntablename;
-			}
+            $foreigntablename = $foreignTableInfoArray['foreign_table'];
+            if (isset($tableAliasArray[$foreigntablename])) {
+                $foreigntablealiasname = $tableAliasArray[$foreigntablename];
+            } else {
+                $foreigntablealiasname = $foreigntablename;
+            }
 
-			$sqlArray['local'] = $tablename;
-			$sqlArray['from'] = $tablename.' '.$tablealiasname.$aliasPostfix.' INNER JOIN '.$foreigntablename.' '.$foreigntablealiasname.$aliasPostfix.' ON '.$tablealiasname.$aliasPostfix.'.'.$fieldname.'='.$foreigntablealiasname.$aliasPostfix.'.uid';
-			$sqlArray['where'] = $tablealiasname.'.uid='.$tablealiasname.$aliasPostfix.'.uid';
-		}
-	}
+            $sqlArray['local'] = $tablename;
+            $sqlArray['from'] = $tablename.' '.$tablealiasname.$aliasPostfix.' INNER JOIN '.$foreigntablename.' '.$foreigntablealiasname.$aliasPostfix.' ON '.$tablealiasname.$aliasPostfix.'.'.$fieldname.'='.$foreigntablealiasname.$aliasPostfix.'.uid';
+            $sqlArray['where'] = $tablealiasname.'.uid='.$tablealiasname.$aliasPostfix.'.uid';
+        }
+    }
 
-	public function destruct() {
-		foreach ($this->usedObjectArray as $className => $bFreeMemory) {
-			if ($bFreeMemory) {
-				$object = GeneralUtility::makeInstance($className);
-				$object->destruct();
-			}
-		}
-	}
+    public function destruct() {
+        foreach ($this->usedObjectArray as $className => $bFreeMemory) {
+            if ($bFreeMemory) {
+                $object = GeneralUtility::makeInstance($className);
+                $object->destruct();
+            }
+        }
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_template.php
+++ b/lib/class.tx_ttproducts_template.php
@@ -41,70 +41,70 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_template implements \TYPO3\CMS\Core\SingletonInterface {
-	private $templateFile;
-	protected $templateSuffix = '';
+    private $templateFile;
+    protected $templateSuffix = '';
 
-	public function getTemplateFile () {
-		return $this->templateFile;
-	}
-
-
-	public function setTemplateSuffix ($value) {
-		$this->templateSuffix = $value;
-	}
+    public function getTemplateFile () {
+        return $this->templateFile;
+    }
 
 
-	public function getTemplateSuffix () {
-		return $this->templateSuffix;
-	}
+    public function setTemplateSuffix ($value) {
+        $this->templateSuffix = $value;
+    }
 
 
-	public function get (
-		$theCode,
-		&$templateFile,
-		&$errorCode
-	) {
+    public function getTemplateSuffix () {
+        return $this->templateSuffix;
+    }
 
-		$templateCode = '';
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$templateFile = $cnf->getTemplateFile($theCode);
-		$pathFilename = '';
+
+    public function get (
+        $theCode,
+        &$templateFile,
+        &$errorCode
+    ) {
+
+        $templateCode = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $templateFile = $cnf->getTemplateFile($theCode);
+        $pathFilename = '';
         if ($templateFile) {
             $pathFilename = GeneralUtility::getFileAbsFileName($templateFile);
         }
 
-		if (file_exists($pathFilename)) {
-			// template file is fetched. The whole template file from which the various subpart are extracted.
-			$templateCode = file_get_contents($pathFilename);
-		}
+        if (file_exists($pathFilename)) {
+            // template file is fetched. The whole template file from which the various subpart are extracted.
+            $templateCode = file_get_contents($pathFilename);
+        }
 
-		if (
-			(!$templateFile || empty($templateCode))
-		) {
+        if (
+            (!$templateFile || empty($templateCode))
+        ) {
             $tmplText = '';
-			if (!empty($conf['templateFile.'][$theCode])) {
-				$tmplText = $theCode . '.';
-			}
-			$tmplText .= 'templateFile';
+            if (!empty($conf['templateFile.'][$theCode])) {
+                $tmplText = $theCode . '.';
+            }
+            $tmplText .= 'templateFile';
 
-			if (empty($errorCode)) {
-				$errorCode[0] = 'no_template';
-				$errorCode[1] =  ' plugin.' . TT_PRODUCTS_EXT . '.' . $tmplText . ' = ' .
-					($templateFile ? $templateFile : '');
-			}
-		}
+            if (empty($errorCode)) {
+                $errorCode[0] = 'no_template';
+                $errorCode[1] =  ' plugin.' . TT_PRODUCTS_EXT . '.' . $tmplText . ' = ' .
+                    ($templateFile ? $templateFile : '');
+            }
+        }
 
-		if (
-			$theCode != 'ERROR' &&
-			$templateFile != '' &&
-			!empty($templateCode)
-		) {
-			$this->templateFile = $templateFile;
-		}
+        if (
+            $theCode != 'ERROR' &&
+            $templateFile != '' &&
+            !empty($templateCode)
+        ) {
+            $this->templateFile = $templateFile;
+        }
 
-		return $templateCode;
-	}
+        return $templateCode;
+    }
 }
 
 

--- a/lib/class.tx_ttproducts_tracking.php
+++ b/lib/class.tx_ttproducts_tracking.php
@@ -44,737 +44,737 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_tracking implements \TYPO3\CMS\Core\SingletonInterface {
-	public $cObj;
-	public $conf;		  // original configuration
-	private $statusCodeArray;
+    public $cObj;
+    public $conf;		  // original configuration
+    private $statusCodeArray;
 
 
-	/**
-	 * $basket is the TYPO3 default shopping basket array from ses-data
-	 *
-	 * @param		string		  $fieldname is the field in the table you want to create a JavaScript for
-	 * @return	  void
-	 */
-	public function init ($cObj) {
+    /**
+     * $basket is the TYPO3 default shopping basket array from ses-data
+     *
+     * @param		string		  $fieldname is the field in the table you want to create a JavaScript for
+     * @return	  void
+     */
+    public function init ($cObj) {
 
-		$this->cObj = $cObj;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->conf;
+        $this->cObj = $cObj;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->conf;
 
-		if (
-			isset($this->conf['statusCodes.']) &&
-			is_array($this->conf['statusCodes.'])
-		) {
-			foreach ($this->conf['statusCodes.'] as $k => $v) {
-				if (
-					MathUtility::canBeInterpretedAsInteger($k)
-				) {
-					$statusCodeArray[$k] = $v;
-				}
-			}
-		} elseif ($this->conf['statusCodesSource']) {
+        if (
+            isset($this->conf['statusCodes.']) &&
+            is_array($this->conf['statusCodes.'])
+        ) {
+            foreach ($this->conf['statusCodes.'] as $k => $v) {
+                if (
+                    MathUtility::canBeInterpretedAsInteger($k)
+                ) {
+                    $statusCodeArray[$k] = $v;
+                }
+            }
+        } elseif ($this->conf['statusCodesSource']) {
 
-			switch ($this->conf['statusCodesSource']) {
-				case 'marker_locallang':
-					$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-					$langArray = $markerObj->getLangArray();
+            switch ($this->conf['statusCodesSource']) {
+                case 'marker_locallang':
+                    $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+                    $langArray = $markerObj->getLangArray();
 
-					if (is_array($langArray)) {
-						$statusMessage = 'tracking_status_message_';
-						$len = strlen($statusMessage);
-						foreach ($langArray as $k => $v) {
-							if (($pos = strpos($k, $statusMessage)) === 0) {
-								$rest = substr($k, $len);
-								if (
-									MathUtility::canBeInterpretedAsInteger($rest)
-								) {
-									$statusCodeArray[$rest] = $v;
-								}
-							}
-						}
-					}
-				break;
-			}
-		}
+                    if (is_array($langArray)) {
+                        $statusMessage = 'tracking_status_message_';
+                        $len = strlen($statusMessage);
+                        foreach ($langArray as $k => $v) {
+                            if (($pos = strpos($k, $statusMessage)) === 0) {
+                                $rest = substr($k, $len);
+                                if (
+                                    MathUtility::canBeInterpretedAsInteger($rest)
+                                ) {
+                                    $statusCodeArray[$rest] = $v;
+                                }
+                            }
+                        }
+                    }
+                break;
+            }
+        }
 
-		$this->setStatusCodeArray($statusCodeArray);
-	}
-
-
-	public function setStatusCodeArray (&$statusCodeArray) {
-		$this->statusCodeArray = $statusCodeArray;
-	}
+        $this->setStatusCodeArray($statusCodeArray);
+    }
 
 
-	public function getStatusCodeArray () {
-		return $this->statusCodeArray;
-	}
+    public function setStatusCodeArray (&$statusCodeArray) {
+        $this->statusCodeArray = $statusCodeArray;
+    }
 
 
-	protected function getDate ($newData) {
-		$date = '';
-		if ($newData) {
-			$dateArray = GeneralUtility::trimExplode('-', $newData);
-			$date = mktime(0, 0, 0, $dateArray[1], $dateArray[0], $dateArray[2]);
-			if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-				$date += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-			}
-		} else {
-			$date = time();
-		}
-		return $date;
-	}
+    public function getStatusCodeArray () {
+        return $this->statusCodeArray;
+    }
 
 
-	/* search the order status for paid and closed */
-	public function searchOrderStatus (
-		$status_log,
-		&$orderPaid,
-		&$orderClosed
-	) {
-		$orderPaid = false;
-		$orderClosed = false;
-		if (isset($status_log) && is_array($status_log)) {
-			foreach($status_log as $key => $val) {
-				if ($val['status'] == 13) {// Numbers 13 means order has been payed
-					$orderPaid = true;
-				}
-				if ($val['status'] >= 100) {// Numbers 13 means order has been payed
-					$orderClosed = true;
-					break;
-				}
-			}
-		}
-	}
+    protected function getDate ($newData) {
+        $date = '';
+        if ($newData) {
+            $dateArray = GeneralUtility::trimExplode('-', $newData);
+            $date = mktime(0, 0, 0, $dateArray[1], $dateArray[0], $dateArray[2]);
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                $date += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+            }
+        } else {
+            $date = time();
+        }
+        return $date;
+    }
 
-	/*
-		Tracking information display and maintenance.
 
-		status-values are
-			0:  Blank order
-		1-1 Incoming orders
-			1:  Order confirmed at website
-		2-49: Useable by the shop admin
-			2 = Order is received and accepted by store
-			10 = Shop is awaiting goods from third-party
-			11 = Shop is awaiting customer payment
-			12 = Shop is awaiting material from customer
-			13 = Order has been payed
-			20 = Goods shipped to customer
-			21 = Gift certificates shipped to customer
-			30 = Other message from store
-			...
-		50-99:  Useable by the customer
-		50-59: General user messages, may be updated by the ordinary users.
-			50 = Customer request for cancelling
-			51 = Message from customer to shop
-		60-69:  Special user messages by the customer
-			60 = Send gift certificate message to receiver
+    /* search the order status for paid and closed */
+    public function searchOrderStatus (
+        $status_log,
+        &$orderPaid,
+        &$orderClosed
+    ) {
+        $orderPaid = false;
+        $orderClosed = false;
+        if (isset($status_log) && is_array($status_log)) {
+            foreach($status_log as $key => $val) {
+                if ($val['status'] == 13) {// Numbers 13 means order has been payed
+                    $orderPaid = true;
+                }
+                if ($val['status'] >= 100) {// Numbers 13 means order has been payed
+                    $orderClosed = true;
+                    break;
+                }
+            }
+        }
+    }
 
-		100-299:  Order finalized.
-			100 = Order shipped and closed
-			101 = Order closed
-			200 = Order cancelled
+    /*
+        Tracking information display and maintenance.
 
-		All status values can be altered only if you're logged in as a BE-user and if you know the correct code (setup as .update_code in TypoScript config)
-	*/
-	public function getTrackingInformation (
-		$orderRow,
-		$templateCode,
-		$trackingCode,
-		$updateCode,
-		&$orderRecord,
-		$bValidUpdateCode
-	) {
+        status-values are
+            0:  Blank order
+        1-1 Incoming orders
+            1:  Order confirmed at website
+        2-49: Useable by the shop admin
+            2 = Order is received and accepted by store
+            10 = Shop is awaiting goods from third-party
+            11 = Shop is awaiting customer payment
+            12 = Shop is awaiting material from customer
+            13 = Order has been payed
+            20 = Goods shipped to customer
+            21 = Gift certificates shipped to customer
+            30 = Other message from store
+            ...
+        50-99:  Useable by the customer
+        50-59: General user messages, may be updated by the ordinary users.
+            50 = Customer request for cancelling
+            51 = Message from customer to shop
+        60-69:  Special user messages by the customer
+            60 = Send gift certificate message to receiver
+
+        100-299:  Order finalized.
+            100 = Order shipped and closed
+            101 = Order closed
+            200 = Order cancelled
+
+        All status values can be altered only if you're logged in as a BE-user and if you know the correct code (setup as .update_code in TypoScript config)
+    */
+    public function getTrackingInformation (
+        $orderRow,
+        $templateCode,
+        $trackingCode,
+        $updateCode,
+        &$orderRecord,
+        $bValidUpdateCode
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$orderObj = $tablesObj->get('sys_products_orders');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
-		$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        $bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $orderObj = $tablesObj->get('sys_products_orders');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $basketView = GeneralUtility::makeInstance('tx_ttproducts_basket_view');
+        $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
 // 		$paymentshippingObj = GeneralUtility::makeInstance('tx_ttproducts_paymentshipping');
-		$theTable = 'sys_products_orders';
-		$piVars = tx_ttproducts_model_control::getPiVars();
+        $theTable = 'sys_products_orders';
+        $piVars = tx_ttproducts_model_control::getPiVars();
 
-		$orderData = $orderObj->getOrderData($orderRow);
-		$statusCodeArray = [];
+        $orderData = $orderObj->getOrderData($orderRow);
+        $statusCodeArray = [];
 
-		$allowUpdateFields = ['email', 'email_notify', 'status', 'status_log'];
-		$newData = $piVars['data'];
-		$bStatusValid = false;
-		$basketRec = [];
-		$basketExtra = [];
+        $allowUpdateFields = ['email', 'email_notify', 'status', 'status_log'];
+        $newData = $piVars['data'];
+        $bStatusValid = false;
+        $basketRec = [];
+        $basketExtra = [];
 
-		if (
-			isset($orderRow) &&
-			is_array($orderRow) &&
-			$orderRow['uid']
-		) {
-			$basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
-			$basketExtra =
-				tx_ttproducts_control_basket::getBasketExtras(
-					$tablesObj,
-					$basketRec,
-					$this->conf
-				);
+        if (
+            isset($orderRow) &&
+            is_array($orderRow) &&
+            $orderRow['uid']
+        ) {
+            $basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
+            $basketExtra =
+                tx_ttproducts_control_basket::getBasketExtras(
+                    $tablesObj,
+                    $basketRec,
+                    $this->conf
+                );
 
-			$statusCodeArray = $this->getStatusCodeArray();
-			$pageTitle = $orderRow['uid'] . ' (' . $orderRow['bill_no'] . '): ' . $orderRow['name'] . '-' . $orderRow['zip'] . '-' . $orderRow['city'] . '-' . $orderRow['country'];
-			$GLOBALS['TSFE']->page['title'] = $pageTitle;
-			$GLOBALS['TSFE']->indexedDocTitle = $pageTitle;
+            $statusCodeArray = $this->getStatusCodeArray();
+            $pageTitle = $orderRow['uid'] . ' (' . $orderRow['bill_no'] . '): ' . $orderRow['name'] . '-' . $orderRow['zip'] . '-' . $orderRow['city'] . '-' . $orderRow['country'];
+            $GLOBALS['TSFE']->page['title'] = $pageTitle;
+            $GLOBALS['TSFE']->indexedDocTitle = $pageTitle;
 
-				// Initialize update of status...
-			$fieldsArray = [];
-			if (isset($orderRecord['email_notify'])) {
-				$fieldsArray['email_notify'] = $orderRecord['email_notify'];
-				$orderRow['email_notify'] = $orderRecord['email_notify'];
-			}
-			if (isset($orderRecord['email'])) {
-				$fieldsArray['email'] = $orderRecord['email'];
-				$orderRow['email'] = $orderRecord['email'];
-			}
+                // Initialize update of status...
+            $fieldsArray = [];
+            if (isset($orderRecord['email_notify'])) {
+                $fieldsArray['email_notify'] = $orderRecord['email_notify'];
+                $orderRow['email_notify'] = $orderRecord['email_notify'];
+            }
+            if (isset($orderRecord['email'])) {
+                $fieldsArray['email'] = $orderRecord['email'];
+                $orderRow['email'] = $orderRecord['email'];
+            }
 
-			if (
-				is_array($orderRecord['status']) &&
-				isset($statusCodeArray) &&
-				is_array($statusCodeArray)
-			) {
-				$bStatusValid = true;
-				$status_log = unserialize($orderRow['status_log']);
-				$update = 0;
-				$count = 0;
+            if (
+                is_array($orderRecord['status']) &&
+                isset($statusCodeArray) &&
+                is_array($statusCodeArray)
+            ) {
+                $bStatusValid = true;
+                $status_log = unserialize($orderRow['status_log']);
+                $update = 0;
+                $count = 0;
 
-				foreach($orderRecord['status'] as $val) {
+                foreach($orderRecord['status'] as $val) {
 
-					if (!isset($statusCodeArray[$val])) {
+                    if (!isset($statusCodeArray[$val])) {
 
-						$bStatusValid = false;
-						break;
-					}
-					$internalComment = '';
+                        $bStatusValid = false;
+                        break;
+                    }
+                    $internalComment = '';
 
-					if ($bValidUpdateCode) {
+                    if ($bValidUpdateCode) {
 
-						if ($val >= 31 && $val <= 32) {// Numbers 31,32 are for storing of bill no. of external software
-							if ($newData) {
-								$fieldsArray['bill_no'] = $newData;
-							}
-						}
+                        if ($val >= 31 && $val <= 32) {// Numbers 31,32 are for storing of bill no. of external software
+                            if ($newData) {
+                                $fieldsArray['bill_no'] = $newData;
+                            }
+                        }
 
-						if ($val == 13) {// Number 13 is that order has been paid. The date muss be entered in format dd-mm-yyyy
-							$date = $this->getDate($newData);
+                        if ($val == 13) {// Number 13 is that order has been paid. The date muss be entered in format dd-mm-yyyy
+                            $date = $this->getDate($newData);
 
-							if (
-								isset($orderRow) &&
-								is_array($orderRow) &&
-								$orderRow['uid']
-							) {
-								$basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
-								$basketExtra =
-									tx_ttproducts_control_basket::getBasketExtras(
-										$tablesObj,
-										$basketRec,
-										$this->conf
-									);
+                            if (
+                                isset($orderRow) &&
+                                is_array($orderRow) &&
+                                $orderRow['uid']
+                            ) {
+                                $basketRec = \JambageCom\TtProducts\Api\BasketApi::getBasketRec($orderRow);
+                                $basketExtra =
+                                    tx_ttproducts_control_basket::getBasketExtras(
+                                        $tablesObj,
+                                        $basketRec,
+                                        $this->conf
+                                    );
 
-								$whereGift = $this->conf['whereGift'];
-								$voucherUidArray = [];
+                                $whereGift = $this->conf['whereGift'];
+                                $voucherUidArray = [];
 
-								if (
-									$whereGift != '' &&
-									\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('voucher')
-								) {
-									$hidden = tx_ttproducts_voucher::unhideGifts(
-										$voucherUidArray,
-										$orderRow,
-										$whereGift
-									);
+                                if (
+                                    $whereGift != '' &&
+                                    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('voucher')
+                                ) {
+                                    $hidden = tx_ttproducts_voucher::unhideGifts(
+                                        $voucherUidArray,
+                                        $orderRow,
+                                        $whereGift
+                                    );
 
-									if (
-										$hidden &&
-										isset($voucherUidArray) &&
-										is_array($voucherUidArray) &&
-										!empty($voucherUidArray)
-									) {
-										$voucherObj = $tablesObj->get('voucher');
-										$voucherRows = $voucherObj->get(implode(',', $voucherUidArray));
-										$voucherCodeArray = [];
+                                    if (
+                                        $hidden &&
+                                        isset($voucherUidArray) &&
+                                        is_array($voucherUidArray) &&
+                                        !empty($voucherUidArray)
+                                    ) {
+                                        $voucherObj = $tablesObj->get('voucher');
+                                        $voucherRows = $voucherObj->get(implode(',', $voucherUidArray));
+                                        $voucherCodeArray = [];
 
-										if (
-											isset($voucherRows) &&
-											is_array($voucherRows) &&
-											!empty($voucherRows)
-										) {
-											if (count($voucherUidArray) > 1) {
-												foreach ($voucherRows as $voucherRow) {
-													$voucherCodeArray[] = $voucherRow['code'];
-												}
-											} else {
-												$voucherCodeArray[] = $voucherRows['code'];
-											}
-										}
-										$text = $languageObj->getLabel(
-											'voucher_gained',
-											$usedLang = 'default'
-										);
-										$internalComment =
-											$text . ': ' . chr(13) . implode(chr(13), $voucherCodeArray);
-									}
-								}
-							}
+                                        if (
+                                            isset($voucherRows) &&
+                                            is_array($voucherRows) &&
+                                            !empty($voucherRows)
+                                        ) {
+                                            if (count($voucherUidArray) > 1) {
+                                                foreach ($voucherRows as $voucherRow) {
+                                                    $voucherCodeArray[] = $voucherRow['code'];
+                                                }
+                                            } else {
+                                                $voucherCodeArray[] = $voucherRows['code'];
+                                            }
+                                        }
+                                        $text = $languageObj->getLabel(
+                                            'voucher_gained',
+                                            $usedLang = 'default'
+                                        );
+                                        $internalComment =
+                                            $text . ': ' . chr(13) . implode(chr(13), $voucherCodeArray);
+                                    }
+                                }
+                            }
 
-							$payMode = \JambageCom\TtProducts\Api\PaymentApi::getPayMode($languageObj, $basketExtra);
+                            $payMode = \JambageCom\TtProducts\Api\PaymentApi::getPayMode($languageObj, $basketExtra);
 
-							$fieldsArray['date_of_payment'] = $date;
-							if (!$payMode) {
+                            $fieldsArray['date_of_payment'] = $date;
+                            if (!$payMode) {
                                 $payMode = '1';
                             }
                             $fieldsArray['pay_mode'] = $payMode;
 
-						}
+                        }
 
-						if ($val == 20) {// Number 20 is that items have been shipped. The date muss be entered in format dd-mm-yyyy
-							$date = $this->getDate($newData);
-							$fieldsArray['date_of_delivery'] = $date;
-						}
-					}
+                        if ($val == 20) {// Number 20 is that items have been shipped. The date muss be entered in format dd-mm-yyyy
+                            $date = $this->getDate($newData);
+                            $fieldsArray['date_of_delivery'] = $date;
+                        }
+                    }
 
-					$status_log_element = [
-						'time' => time(),
-						'info' => $statusCodeArray[$val],
-						'status' => $val,
-						'comment' => ($count == 0 ? $orderRecord['status_comment'] . ($internalComment != '' ? $internalComment : '') . ($newData != '' ? '|' . $newData : '') : ''), // comment is inserted only to the first status
-					];
+                    $status_log_element = [
+                        'time' => time(),
+                        'info' => $statusCodeArray[$val],
+                        'status' => $val,
+                        'comment' => ($count == 0 ? $orderRecord['status_comment'] . ($internalComment != '' ? $internalComment : '') . ($newData != '' ? '|' . $newData : '') : ''), // comment is inserted only to the first status
+                    ];
 
-					if ($bValidUpdateCode || ($val >= 50 && $val < 59)) {// Numbers 50-59 are usermessages.
-						$recipient = $this->conf['orderEmail_to'];
-						if (!empty($orderRow['email']) && !empty($orderRow['email_notify'])) {
-							$recipient .= ',' . $orderRow['email'];
-						}
-						$templateMarker = 'TRACKING_EMAILNOTIFY_TEMPLATE';
-						tx_ttproducts_email_div::sendNotifyEmail(
-							$this->cObj,
-							$this->conf,
-							$this->config,
-							'fe_users',
-							$orderObj->getNumber($orderRow['uid']),
-							$recipient,
-							$status_log_element,
-							$statusCodeArray,
-							GeneralUtility::_GP('tracking'),
-							$orderRow,
-							$orderData,
-							$templateCode,
-							$templateMarker,
-							$basketExtra,
-							$basketRecs
-						);
-						$status_log[] = $status_log_element;
-						$update = 1;
-					}
+                    if ($bValidUpdateCode || ($val >= 50 && $val < 59)) {// Numbers 50-59 are usermessages.
+                        $recipient = $this->conf['orderEmail_to'];
+                        if (!empty($orderRow['email']) && !empty($orderRow['email_notify'])) {
+                            $recipient .= ',' . $orderRow['email'];
+                        }
+                        $templateMarker = 'TRACKING_EMAILNOTIFY_TEMPLATE';
+                        tx_ttproducts_email_div::sendNotifyEmail(
+                            $this->cObj,
+                            $this->conf,
+                            $this->config,
+                            'fe_users',
+                            $orderObj->getNumber($orderRow['uid']),
+                            $recipient,
+                            $status_log_element,
+                            $statusCodeArray,
+                            GeneralUtility::_GP('tracking'),
+                            $orderRow,
+                            $orderData,
+                            $templateCode,
+                            $templateMarker,
+                            $basketExtra,
+                            $basketRecs
+                        );
+                        $status_log[] = $status_log_element;
+                        $update = 1;
+                    }
 
-					if ($val >= 60 && $val < 69) { //  60 -69 are special messages
-						$templateMarker = 'TRACKING_EMAIL_GIFTNOTIFY_TEMPLATE';
-						$query = 'ordernumber=\'' . intval($orderRow['uid']) . '\'';
-						$giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
-						while ($giftRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes)) {
-							$recipient = $giftRow['deliveryemail'] . ',' . $giftRow['personemail'];
-							tx_ttproducts_email_div::sendGiftEmail(
-								$this->cObj,
-								$this->conf,
-								$recipient,
-								$orderRecord['status_comment'],
-								$giftRow,
-								$templateCode,
-								$templateMarker,
-								$this->conf['orderEmail_htmlmail']
-							);
-						}
-						$GLOBALS['TYPO3_DB']->sql_free_result($giftRes);
+                    if ($val >= 60 && $val < 69) { //  60 -69 are special messages
+                        $templateMarker = 'TRACKING_EMAIL_GIFTNOTIFY_TEMPLATE';
+                        $query = 'ordernumber=\'' . intval($orderRow['uid']) . '\'';
+                        $giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
+                        while ($giftRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes)) {
+                            $recipient = $giftRow['deliveryemail'] . ',' . $giftRow['personemail'];
+                            tx_ttproducts_email_div::sendGiftEmail(
+                                $this->cObj,
+                                $this->conf,
+                                $recipient,
+                                $orderRecord['status_comment'],
+                                $giftRow,
+                                $templateCode,
+                                $templateMarker,
+                                $this->conf['orderEmail_htmlmail']
+                            );
+                        }
+                        $GLOBALS['TYPO3_DB']->sql_free_result($giftRes);
 
-						if (!$update) {
-							$status_log[] = $status_log_element;
-							$update = 1;
-						}
-					}
-					$count++;
-				}
-				if ($update) {
-					$fieldsArray['status_log'] = serialize($status_log);
-					$fieldsArray['status'] = intval($status_log_element['status']);
-				}
-			}
+                        if (!$update) {
+                            $status_log[] = $status_log_element;
+                            $update = 1;
+                        }
+                    }
+                    $count++;
+                }
+                if ($update) {
+                    $fieldsArray['status_log'] = serialize($status_log);
+                    $fieldsArray['status'] = intval($status_log_element['status']);
+                }
+            }
 
-			if (is_array($fieldsArray) && count($fieldsArray)) {		// If any items in the field array, save them
-				if (!$bValidUpdateCode) {	// only these fields may be updated in an already stored order
-					$fieldsArray = array_intersect_key($fieldsArray, array_flip($allowUpdateFields));
-				}
-				if (count($fieldsArray)) {
-					$fieldsArray['tstamp'] = time();
-					$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-						'sys_products_orders',
-						'uid=' . intval($orderRow['uid']),
-						$fieldsArray
-					);
-					$orderRow = $orderObj->getRecord($orderRow['uid']);
-				}
-			}
-			$status_log = unserialize($orderRow['status_log']);
-		}
+            if (is_array($fieldsArray) && count($fieldsArray)) {		// If any items in the field array, save them
+                if (!$bValidUpdateCode) {	// only these fields may be updated in an already stored order
+                    $fieldsArray = array_intersect_key($fieldsArray, array_flip($allowUpdateFields));
+                }
+                if (count($fieldsArray)) {
+                    $fieldsArray['tstamp'] = time();
+                    $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+                        'sys_products_orders',
+                        'uid=' . intval($orderRow['uid']),
+                        $fieldsArray
+                    );
+                    $orderRow = $orderObj->getRecord($orderRow['uid']);
+                }
+            }
+            $status_log = unserialize($orderRow['status_log']);
+        }
 
-			// Getting the template stuff and initialize order data.
-		$template = $templateService->getSubpart($templateCode, '###TRACKING_DISPLAY_INFO###');
-		$this->searchOrderStatus($status_log, $orderPaid, $orderClosed);
+            // Getting the template stuff and initialize order data.
+        $template = $templateService->getSubpart($templateCode, '###TRACKING_DISPLAY_INFO###');
+        $this->searchOrderStatus($status_log, $orderPaid, $orderClosed);
 
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
 
-		// making status code 60 disappear if the order has not been payed yet
-		if (!$orderPaid || $orderClosed) {
-				// Fill marker arrays
-			$markerArray = $globalMarkerArray;
-			$subpartArray = [];
-			$subpartArray['###STATUS_CODE_60###'] = '';
+        // making status code 60 disappear if the order has not been payed yet
+        if (!$orderPaid || $orderClosed) {
+                // Fill marker arrays
+            $markerArray = $globalMarkerArray;
+            $subpartArray = [];
+            $subpartArray['###STATUS_CODE_60###'] = '';
 
-			$template = $templateService->substituteMarkerArrayCached($template, $markerArray, $subpartArray);
-		}
+            $template = $templateService->substituteMarkerArrayCached($template, $markerArray, $subpartArray);
+        }
 
-			// Status:
-		$statusItemOut = $templateService->getSubpart($template, '###STATUS_ITEM###');
-		$statusItemOut_c='';
+            // Status:
+        $statusItemOut = $templateService->getSubpart($template, '###STATUS_ITEM###');
+        $statusItemOut_c='';
 
-		if (is_array($status_log)) {
-			foreach($status_log as $k => $v) {
-				$markerArray = [];
-				$markerArray['###ORDER_STATUS_TIME###'] = $this->cObj->stdWrap($v['time'], $this->conf['statusDate_stdWrap.']);
-				$markerArray['###ORDER_STATUS###'] = $v['status'];
+        if (is_array($status_log)) {
+            foreach($status_log as $k => $v) {
+                $markerArray = [];
+                $markerArray['###ORDER_STATUS_TIME###'] = $this->cObj->stdWrap($v['time'], $this->conf['statusDate_stdWrap.']);
+                $markerArray['###ORDER_STATUS###'] = $v['status'];
 
-				$info = $statusCodeArray[$v['status']];
-				$markerArray['###ORDER_STATUS_INFO###'] = ($info ? $info : $v['info']);
-				$markerArray['###ORDER_STATUS_COMMENT###'] = nl2br($v['comment']);
-				$statusItemOut_c .= $templateService->substituteMarkerArrayCached($statusItemOut, $markerArray);
-			}
-		}
+                $info = $statusCodeArray[$v['status']];
+                $markerArray['###ORDER_STATUS_INFO###'] = ($info ? $info : $v['info']);
+                $markerArray['###ORDER_STATUS_COMMENT###'] = nl2br($v['comment']);
+                $statusItemOut_c .= $templateService->substituteMarkerArrayCached($statusItemOut, $markerArray);
+            }
+        }
 
-		$markerArray = $globalMarkerArray;
-		$subpartArray = [];
-		$wrappedSubpartArray=[];
-		$markerArray['###OTHER_ORDERS_OPTIONS###'] = '';
-		$markerArray['###STATUS_OPTIONS###'] = '';
-		$subpartArray['###STATUS_ITEM###'] = $statusItemOut_c;
+        $markerArray = $globalMarkerArray;
+        $subpartArray = [];
+        $wrappedSubpartArray=[];
+        $markerArray['###OTHER_ORDERS_OPTIONS###'] = '';
+        $markerArray['###STATUS_OPTIONS###'] = '';
+        $subpartArray['###STATUS_ITEM###'] = $statusItemOut_c;
 
-		$bBEAdmin = ($this->conf['shopAdmin'] == 'BE');
-		tx_ttproducts_admin_control_view::getSubpartArrays(
-			tx_ttproducts_control_access::isAllowed($bBEAdmin),
-			$bValidUpdateCode,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
+        $bBEAdmin = ($this->conf['shopAdmin'] == 'BE');
+        tx_ttproducts_admin_control_view::getSubpartArrays(
+            tx_ttproducts_control_access::isAllowed($bBEAdmin),
+            $bValidUpdateCode,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
 
-		$tableName = 'sys_products_orders';
-		$markerFieldArray = [];
-		$orderView = $tablesObj->get($tableName, true);
-		$orderObj = $orderView->getModelObj();
-		$orderMarkerArray = $globalMarkerArray;
-		$viewTagArray = [];
-		$parentArray = [];
-		$t = [];
-		$t['orderFrameWork'] = $templateService->getSubpart($template, '###ORDER_ITEM###');
-		$fieldsArray = $markerObj->getMarkerFields(
-			$t['orderFrameWork'],
-			$orderObj->getTableObj()->tableFieldArray,
-			$orderObj->getTableObj()->requiredFieldArray,
-			$markerFieldArray,
-			$orderView->getMarker(),
-			$viewTagArray,
-			$parentArray
-		);
+        $tableName = 'sys_products_orders';
+        $markerFieldArray = [];
+        $orderView = $tablesObj->get($tableName, true);
+        $orderObj = $orderView->getModelObj();
+        $orderMarkerArray = $globalMarkerArray;
+        $viewTagArray = [];
+        $parentArray = [];
+        $t = [];
+        $t['orderFrameWork'] = $templateService->getSubpart($template, '###ORDER_ITEM###');
+        $fieldsArray = $markerObj->getMarkerFields(
+            $t['orderFrameWork'],
+            $orderObj->getTableObj()->tableFieldArray,
+            $orderObj->getTableObj()->requiredFieldArray,
+            $markerFieldArray,
+            $orderView->getMarker(),
+            $viewTagArray,
+            $parentArray
+        );
 
-		if ($orderRow) {
+        if ($orderRow) {
             $tmp = [];
-			$orderView->getRowMarkerArray(
-				$tableName,
-				$orderRow,
-				'',
-				$orderMarkerArray,
-				$tmp,
-				$tmp,
-				$viewTagArray,
-				'TRACKING',
+            $orderView->getRowMarkerArray(
+                $tableName,
+                $orderRow,
+                '',
+                $orderMarkerArray,
+                $tmp,
+                $tmp,
+                $viewTagArray,
+                'TRACKING',
                 $basketExtra,
                 $basketRecs
-			);
+            );
 
-			$subpartArray['###ORDER_ITEM###'] =
+            $subpartArray['###ORDER_ITEM###'] =
                 $templateService->substituteMarkerArrayCached(
                     $t['orderFrameWork'],
                     $orderMarkerArray
                 );
-		} else {
-			$subpartArray['###ORDER_ITEM###'] = '';
-		}
+        } else {
+            $subpartArray['###ORDER_ITEM###'] = '';
+        }
 
-		//
-		if ($bValidUpdateCode) {
-				// Status admin:
-			if (isset($statusCodeArray) && is_array($statusCodeArray)) {
-				foreach($statusCodeArray as $k => $v) {
-					if ($k != 1) {
-						$markerArray['###STATUS_OPTIONS###'] .= '<option value="' . $k . '">' . htmlspecialchars($k . ': ' . $v) . '</option>';
-					}
-				}
-			}
-			$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-			if (isset($this->conf['tracking.']) && isset($this->conf['tracking.']['fields']))	{
-				$fields = $this->conf['tracking.']['fields'];
-			} else {
-				$fields = 'uid';
-			}
-			$fields .= ',' . 'crdate,tracking_code,status,status_log,bill_no,name,amount,feusers_uid';
-			$fields = GeneralUtility::uniqueList($fields);
-			$history = [];
-			$fieldMarkerArray = [];
-			$oldMode = preg_match('/###OTHER_ORDERS_OPTIONS###\s*<\/select>/i', $templateCode);
-			$where = 'status!=0 AND status<100';
-			$orderBy = 'crdate';
+        //
+        if ($bValidUpdateCode) {
+                // Status admin:
+            if (isset($statusCodeArray) && is_array($statusCodeArray)) {
+                foreach($statusCodeArray as $k => $v) {
+                    if ($k != 1) {
+                        $markerArray['###STATUS_OPTIONS###'] .= '<option value="' . $k . '">' . htmlspecialchars($k . ': ' . $v) . '</option>';
+                    }
+                }
+            }
+            $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+            if (isset($this->conf['tracking.']) && isset($this->conf['tracking.']['fields']))	{
+                $fields = $this->conf['tracking.']['fields'];
+            } else {
+                $fields = 'uid';
+            }
+            $fields .= ',' . 'crdate,tracking_code,status,status_log,bill_no,name,amount,feusers_uid';
+            $fields = GeneralUtility::uniqueList($fields);
+            $history = [];
+            $fieldMarkerArray = [];
+            $oldMode = preg_match('/###OTHER_ORDERS_OPTIONS###\s*<\/select>/i', $templateCode);
+            $where = 'status!=0 AND status<100';
+            $orderBy = 'crdate';
 
-			if (
-				isset($this->conf['tracking.']) &&
-				isset($this->conf['tracking.']['sql.'])
-			) {
-				if (isset($this->conf['tracking.']['sql.']['where'])) {
-					$where = $this->conf['tracking.']['sql.']['where'];
-				}
-				if (isset($this->conf['tracking.']['sql.']['orderBy'])) {
-					$orderBy = $this->conf['tracking.']['sql.']['orderBy'];
-				}
-			}
-			$bUseHistoryMarkers = (strpos($orderBy, 'crdate') !== false);
-			$bInverseHistory = (strpos($orderBy, 'crdate desc') !== false);
+            if (
+                isset($this->conf['tracking.']) &&
+                isset($this->conf['tracking.']['sql.'])
+            ) {
+                if (isset($this->conf['tracking.']['sql.']['where'])) {
+                    $where = $this->conf['tracking.']['sql.']['where'];
+                }
+                if (isset($this->conf['tracking.']['sql.']['orderBy'])) {
+                    $orderBy = $this->conf['tracking.']['sql.']['orderBy'];
+                }
+            }
+            $bUseHistoryMarkers = (strpos($orderBy, 'crdate') !== false);
+            $bInverseHistory = (strpos($orderBy, 'crdate desc') !== false);
 
-			if ($bInverseHistory) {
-				$orderBy = 'crdate'; // Todo: all order by fields must be reversed to keep the history program logic
-			}
+            if ($bInverseHistory) {
+                $orderBy = 'crdate'; // Todo: all order by fields must be reversed to keep the history program logic
+            }
 
-			$enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_products_orders');
+            $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_products_orders');
 
-				// Get unprocessed orders.
-			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				$fields,
-				'sys_products_orders',
-				$where . $enableFields,
-				'',
-				$orderBy
-			);
+                // Get unprocessed orders.
+            $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                $fields,
+                'sys_products_orders',
+                $where . $enableFields,
+                '',
+                $orderBy
+            );
 
-			$valueArray = [];
-			$keyMarkerArray = [];
+            $valueArray = [];
+            $keyMarkerArray = [];
 
-			while(($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
+            while(($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
 
-				$tmpStatuslog = unserialize($row['status_log']);
-				$classPrefix = str_replace('_','-',$pibaseObj->prefixId);
-				$this->searchOrderStatus($tmpStatuslog, $tmpPaid, $tmpClosed);
-				$class = ($tmpPaid ? $classPrefix.'-paid' : '');
-				$class = ($class ? $class . ' ' : '' ) . ($tmpClosed ? $classPrefix . '-closed' : '');
-				$class = ($class ? ' class="' . $class . '"' : '');
+                $tmpStatuslog = unserialize($row['status_log']);
+                $classPrefix = str_replace('_','-',$pibaseObj->prefixId);
+                $this->searchOrderStatus($tmpStatuslog, $tmpPaid, $tmpClosed);
+                $class = ($tmpPaid ? $classPrefix.'-paid' : '');
+                $class = ($class ? $class . ' ' : '' ) . ($tmpClosed ? $classPrefix . '-closed' : '');
+                $class = ($class ? ' class="' . $class . '"' : '');
 
-				$fieldMarkerArray['###OPTION_CLASS###'] = $class;
+                $fieldMarkerArray['###OPTION_CLASS###'] = $class;
 
-				if ($oldMode) {
-					$markerArray['###OTHER_ORDERS_OPTIONS###'] .=
-						'<option ' . $class . ' value="' . $row['tracking_code'] . '"' . ($row['uid'] == $orderRow['uid'] ? 'selected="selected"' : '') . '>'.
-							htmlspecialchars($row['uid'].' ('.$row['bill_no'].'): '.
-								$row['name'] . ' (' . $priceViewObj->priceFormat($row['amount']) . ' ' . $this->conf['currencySymbol'] . ') /' . $row['status']
-							) .
-						'</option>';
-				} else {
-					if (isset($row['feusers_uid']) && $bUseHistoryMarkers) {
-						if(!$row['feusers_uid'] || !isset($history[$row['feusers_uid']])) {
-							$history[$row['feusers_uid']] = [
-								'out' => '',
-								'count' => 0,
-							];
-						}
-						$history[$row['feusers_uid']]['count'] += 1;
-						$last_order = $history[$row['feusers_uid']];
+                if ($oldMode) {
+                    $markerArray['###OTHER_ORDERS_OPTIONS###'] .=
+                        '<option ' . $class . ' value="' . $row['tracking_code'] . '"' . ($row['uid'] == $orderRow['uid'] ? 'selected="selected"' : '') . '>'.
+                            htmlspecialchars($row['uid'].' ('.$row['bill_no'].'): '.
+                                $row['name'] . ' (' . $priceViewObj->priceFormat($row['amount']) . ' ' . $this->conf['currencySymbol'] . ') /' . $row['status']
+                            ) .
+                        '</option>';
+                } else {
+                    if (isset($row['feusers_uid']) && $bUseHistoryMarkers) {
+                        if(!$row['feusers_uid'] || !isset($history[$row['feusers_uid']])) {
+                            $history[$row['feusers_uid']] = [
+                                'out' => '',
+                                'count' => 0,
+                            ];
+                        }
+                        $history[$row['feusers_uid']]['count'] += 1;
+                        $last_order = $history[$row['feusers_uid']];
 
-						if($last_order['count'] == 1) {
-							$fieldMarkerArray['###LAST_ORDER_TYPE###'] = $languageObj->getLabel('first_order');
-							$fieldMarkerArray['###LAST_ORDER_COUNT###'] = '-';
-						} else {
-							$fieldMarkerArray['###LAST_ORDER_TYPE###'] = $last_order['out'];
-							$fieldMarkerArray['###LAST_ORDER_COUNT###'] = $last_order['count'];
-						}
-						if($row['feusers_uid'] == 0) {
-							$fieldMarkerArray['###LAST_ORDER_TYPE###'] = $languageObj->getLabel('unregistered');
-							$fieldMarkerArray['###LAST_ORDER_COUNT###'] = '-';
-						}
-						if($row['company'] == '') {
-							$row['company'] = $languageObj->getLabel('undeclared');
-						}
-						$history[$row['feusers_uid']]['out'] = date('d.m.Y - H:i', $row['crdate']);
-					}
+                        if($last_order['count'] == 1) {
+                            $fieldMarkerArray['###LAST_ORDER_TYPE###'] = $languageObj->getLabel('first_order');
+                            $fieldMarkerArray['###LAST_ORDER_COUNT###'] = '-';
+                        } else {
+                            $fieldMarkerArray['###LAST_ORDER_TYPE###'] = $last_order['out'];
+                            $fieldMarkerArray['###LAST_ORDER_COUNT###'] = $last_order['count'];
+                        }
+                        if($row['feusers_uid'] == 0) {
+                            $fieldMarkerArray['###LAST_ORDER_TYPE###'] = $languageObj->getLabel('unregistered');
+                            $fieldMarkerArray['###LAST_ORDER_COUNT###'] = '-';
+                        }
+                        if($row['company'] == '') {
+                            $row['company'] = $languageObj->getLabel('undeclared');
+                        }
+                        $history[$row['feusers_uid']]['out'] = date('d.m.Y - H:i', $row['crdate']);
+                    }
 
-					$fieldMarkerArray['###OPTION_SELECTED###'] = ($row['uid'] == $orderRow['uid'] ? 'selected="selected"' : '');
-					foreach ($row as $field => $value) {
-						switch ($field) {
-							case 'amount':
-								$value = $priceViewObj->priceFormat($value);
-							break;
-							case 'crdate':
-								$value = date('d.m.Y - H:i', $value);
-							break;
-							default:
-								$value = htmlspecialchars($value);
-							break;
-						}
-						$fieldMarkerArray['###ORDER_' . strtoupper($field) . '###'] = $value;
-					}
+                    $fieldMarkerArray['###OPTION_SELECTED###'] = ($row['uid'] == $orderRow['uid'] ? 'selected="selected"' : '');
+                    foreach ($row as $field => $value) {
+                        switch ($field) {
+                            case 'amount':
+                                $value = $priceViewObj->priceFormat($value);
+                            break;
+                            case 'crdate':
+                                $value = date('d.m.Y - H:i', $value);
+                            break;
+                            default:
+                                $value = htmlspecialchars($value);
+                            break;
+                        }
+                        $fieldMarkerArray['###ORDER_' . strtoupper($field) . '###'] = $value;
+                    }
                     $fieldMarkerArray['###ORDER_ORDER_NO###'] = $fieldMarkerArray['###ORDER_UID###'];
-					$fieldMarkerArray['###CUR_SYM###'] = $this->conf['currencySymbol'];
-					$valueArray[$row['tracking_code']] = $row['uid'];
-					$keyMarkerArray[$row['tracking_code']] = $fieldMarkerArray;
-				}
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
+                    $fieldMarkerArray['###CUR_SYM###'] = $this->conf['currencySymbol'];
+                    $valueArray[$row['tracking_code']] = $row['uid'];
+                    $keyMarkerArray[$row['tracking_code']] = $fieldMarkerArray;
+                }
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
 
-			if (!$oldMode) {
+            if (!$oldMode) {
 
-				if ($bInverseHistory) {
-					$valueArray = array_reverse($valueArray);
-				}
-				if (isset($this->conf['tracking.'])) {
-					$type = $this->conf['tracking.']['recordType'];
-					$recordLine = $this->conf['tracking.']['recordLine'];
-				}
-				if ($type == '') {
-					$type = 'select';
-				}
-				if ($recordLine == '') {
-					$recordLine = '<!-- ###INPUT### begin -->###ORDER_ORDER_NO### (###ORDER_BILL_NO###): ###ORDER_NAME### (###ORDER_AMOUNT### ###CUR_SYM###) / ###ORDER_STATUS###) ###ORDER_CRDATE### ###LAST_ORDER_TYPE### ###LAST_ORDER_COUNT###<!-- ###INPUT### end -->';
-				}
+                if ($bInverseHistory) {
+                    $valueArray = array_reverse($valueArray);
+                }
+                if (isset($this->conf['tracking.'])) {
+                    $type = $this->conf['tracking.']['recordType'];
+                    $recordLine = $this->conf['tracking.']['recordLine'];
+                }
+                if ($type == '') {
+                    $type = 'select';
+                }
+                if ($recordLine == '') {
+                    $recordLine = '<!-- ###INPUT### begin -->###ORDER_ORDER_NO### (###ORDER_BILL_NO###): ###ORDER_NAME### (###ORDER_AMOUNT### ###CUR_SYM###) / ###ORDER_STATUS###) ###ORDER_CRDATE### ###LAST_ORDER_TYPE### ###LAST_ORDER_COUNT###<!-- ###INPUT### end -->';
+                }
 
-				$out = tx_ttproducts_form_div::createSelect(
-					$languageObj,
-					$valueArray,
-					'tracking',
-					$orderRow['tracking_code'],
-					false,
-					false,
-					[],
-					$type,
-					[],
-					'',
-					$recordLine,
-					'',
-					$keyMarkerArray
-				);
+                $out = tx_ttproducts_form_div::createSelect(
+                    $languageObj,
+                    $valueArray,
+                    'tracking',
+                    $orderRow['tracking_code'],
+                    false,
+                    false,
+                    [],
+                    $type,
+                    [],
+                    '',
+                    $recordLine,
+                    '',
+                    $keyMarkerArray
+                );
 
-				if (isset($this->conf['tracking.']) && isset($this->conf['tracking.']['recordBox.'])) {
-					$out = $this->cObj->stdWrap($out, $this->conf['tracking.']['recordBox.']);
-				}
-				$markerArray['###OTHER_ORDERS_OPTIONS###'] .= $out;
-			}
-		}
+                if (isset($this->conf['tracking.']) && isset($this->conf['tracking.']['recordBox.'])) {
+                    $out = $this->cObj->stdWrap($out, $this->conf['tracking.']['recordBox.']);
+                }
+                $markerArray['###OTHER_ORDERS_OPTIONS###'] .= $out;
+            }
+        }
 
-		$bHasTrackingTemplate = preg_match('/###TRACKING_TEMPLATE###/i', $templateCode);
+        $bHasTrackingTemplate = preg_match('/###TRACKING_TEMPLATE###/i', $templateCode);
 
-			// Final things
-		if (!$bHasTrackingTemplate) {
-			$markerArray['###ORDER_HTML_OUTPUT###'] = $orderData['html_output'];	// The save order-information in HTML-format
-		} else if (isset($orderRow) && is_array($orderRow) && $orderRow['uid']) {
-			$itemArray = $orderObj->getItemArray($orderRow, $calculatedArray, $infoArray);
-			$infoViewObj->init2($infoArray);
-			$productRowArray = []; // Todo: make this a parameter
+            // Final things
+        if (!$bHasTrackingTemplate) {
+            $markerArray['###ORDER_HTML_OUTPUT###'] = $orderData['html_output'];	// The save order-information in HTML-format
+        } else if (isset($orderRow) && is_array($orderRow) && $orderRow['uid']) {
+            $itemArray = $orderObj->getItemArray($orderRow, $calculatedArray, $infoArray);
+            $infoViewObj->init2($infoArray);
+            $productRowArray = []; // Todo: make this a parameter
 
-			if ($orderRow['ac_uid']) {
-				// get bank account info
-				$accountViewObj = $tablesObj->get('sys_products_accounts', true, false);
-				$accountObj = $tablesObj->get('sys_products_accounts', false, false);
-				$accountRow = $accountObj->getRow($orderRow['ac_uid']);
-				$accountViewObj->getMarkerArray($accountRow, $globalMarkerArray, true);
-			}
+            if ($orderRow['ac_uid']) {
+                // get bank account info
+                $accountViewObj = $tablesObj->get('sys_products_accounts', true, false);
+                $accountObj = $tablesObj->get('sys_products_accounts', false, false);
+                $accountRow = $accountObj->getRow($orderRow['ac_uid']);
+                $accountViewObj->getMarkerArray($accountRow, $globalMarkerArray, true);
+            }
 
-			if ($orderRow['cc_uid']) {
-				$cardViewObj = $tablesObj->get('sys_products_cards', true, false);
-				$cardObj = $tablesObj->get('sys_products_cards', false, false);
-				$cardRow = $cardObj->getRow($orderRow['cc_uid']);
-				$cardViewObj->setCObj($this->cObj);
-				$cardViewObj->setConf($this->conf);
-				$cardViewObj->getMarkerArray($cardRow, $globalMarkerArray, []);
-			}
-			$customerEmail = $orderRow['email']; // $infoViewObj->getCustomerEmail();
-			$globalMarkerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = $customerEmail;
-			$markerArray['###ORDER_HTML_OUTPUT###'] =
-				$basketView->getView(
-					$errorCode,
-					$templateCode,
-					'TRACKING',
-					$infoViewObj,
-					false,
-					false,
-					$calculatedArray,
-					true,
-					'TRACKING_TEMPLATE',
-					$globalMarkerArray,
-					'',
-					$itemArray,
+            if ($orderRow['cc_uid']) {
+                $cardViewObj = $tablesObj->get('sys_products_cards', true, false);
+                $cardObj = $tablesObj->get('sys_products_cards', false, false);
+                $cardRow = $cardObj->getRow($orderRow['cc_uid']);
+                $cardViewObj->setCObj($this->cObj);
+                $cardViewObj->setConf($this->conf);
+                $cardViewObj->getMarkerArray($cardRow, $globalMarkerArray, []);
+            }
+            $customerEmail = $orderRow['email']; // $infoViewObj->getCustomerEmail();
+            $globalMarkerArray['###CUSTOMER_RECIPIENTS_EMAIL###'] = $customerEmail;
+            $markerArray['###ORDER_HTML_OUTPUT###'] =
+                $basketView->getView(
+                    $errorCode,
+                    $templateCode,
+                    'TRACKING',
+                    $infoViewObj,
+                    false,
+                    false,
+                    $calculatedArray,
+                    true,
+                    'TRACKING_TEMPLATE',
+                    $globalMarkerArray,
+                    '',
+                    $itemArray,
                     $notOverwritePriceIfSet = false,
-					['0' => $orderRow],
-					$productRowArray,
-					$basketExtra,
-					$basketRec
-				);
-		} else {
-			$markerArray['###ORDER_HTML_OUTPUT###'] = '';
-		}
+                    ['0' => $orderRow],
+                    $productRowArray,
+                    $basketExtra,
+                    $basketRec
+                );
+        } else {
+            $markerArray['###ORDER_HTML_OUTPUT###'] = '';
+        }
 
-		if (isset($orderData) && is_array($orderData)) {
-			$markerArray['###ORDERCONFIRMATION_HTML_OUTPUT###'] = $orderData['html_output'];	// The save order-information in HTML-format
-		} else {
-			$markerArray['###ORDERCONFIRMATION_HTML_OUTPUT###'] = '';
-		}
+        if (isset($orderData) && is_array($orderData)) {
+            $markerArray['###ORDERCONFIRMATION_HTML_OUTPUT###'] = $orderData['html_output'];	// The save order-information in HTML-format
+        } else {
+            $markerArray['###ORDERCONFIRMATION_HTML_OUTPUT###'] = '';
+        }
 
-		$checkedHTML = ($bUseXHTML ? 'checked="checked"' : 'checked');
-		$markerArray['###FIELD_EMAIL_NOTIFY###'] = $orderRow['email_notify'] ? ' ' . $checkedHTML : '';
+        $checkedHTML = ($bUseXHTML ? 'checked="checked"' : 'checked');
+        $markerArray['###FIELD_EMAIL_NOTIFY###'] = $orderRow['email_notify'] ? ' ' . $checkedHTML : '';
 
-		$markerArray['###FIELD_EMAIL###'] = $orderRow['email'];
-		$markerArray['###ORDER_UID###'] = $markerArray['###ORDER_ORDER_NO###'] = $orderObj->getNumber($orderRow['uid']);
-		$markerArray['###ORDER_DATE###'] = $this->cObj->stdWrap($orderRow['crdate'], $this->conf['orderDate_stdWrap.'] ?? '');
-		$markerArray['###TRACKING_NUMBER###'] =  $trackingCode;
-		$markerArray['###UPDATE_CODE###'] = $updateCode;
-		$markerArray['###TRACKING_DATA_NAME###'] = $pibaseObj->prefixId . '[data]';
-		$markerArray['###TRACKING_DATA_VALUE###'] = ($bStatusValid ? '' : $newData);
-		$markerArray['###TRACKING_STATUS_COMMENT_NAME###'] = 'orderRecord[status_comment]';
-		$markerArray['###TRACKING_STATUS_COMMENT_VALUE###'] = ($bStatusValid ? '' : $orderRecord['status_comment']);
+        $markerArray['###FIELD_EMAIL###'] = $orderRow['email'];
+        $markerArray['###ORDER_UID###'] = $markerArray['###ORDER_ORDER_NO###'] = $orderObj->getNumber($orderRow['uid']);
+        $markerArray['###ORDER_DATE###'] = $this->cObj->stdWrap($orderRow['crdate'], $this->conf['orderDate_stdWrap.'] ?? '');
+        $markerArray['###TRACKING_NUMBER###'] =  $trackingCode;
+        $markerArray['###UPDATE_CODE###'] = $updateCode;
+        $markerArray['###TRACKING_DATA_NAME###'] = $pibaseObj->prefixId . '[data]';
+        $markerArray['###TRACKING_DATA_VALUE###'] = ($bStatusValid ? '' : $newData);
+        $markerArray['###TRACKING_STATUS_COMMENT_NAME###'] = 'orderRecord[status_comment]';
+        $markerArray['###TRACKING_STATUS_COMMENT_VALUE###'] = ($bStatusValid ? '' : $orderRecord['status_comment']);
 
-		if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking']) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking'])) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'getTrackingInformation')) {
-					$hookObj->getTrackingInformation(
-						$this,
-						$orderRow,
-						$templateCode,
-						$trackingCode,
-						$updateCode,
-						$orderRecord,
-						$bValidUpdateCode,
-						$template,
-						$markerArray,
-						$subpartArray
-					);
-				}
-			}
-		}
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking']) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking'])) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tracking'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'getTrackingInformation')) {
+                    $hookObj->getTrackingInformation(
+                        $this,
+                        $orderRow,
+                        $templateCode,
+                        $trackingCode,
+                        $updateCode,
+                        $orderRecord,
+                        $bValidUpdateCode,
+                        $template,
+                        $markerArray,
+                        $subpartArray
+                    );
+                }
+            }
+        }
 
-		$content = $templateService->substituteMarkerArrayCached($template, $markerArray, $subpartArray, $wrappedSubpartArray);
+        $content = $templateService->substituteMarkerArrayCached($template, $markerArray, $subpartArray, $wrappedSubpartArray);
 
-		return $content;
-	} // getTrackingInformation
+        return $content;
+    } // getTrackingInformation
 }
 
 

--- a/marker/class.tx_ttproducts_javascript_marker.php
+++ b/marker/class.tx_ttproducts_javascript_marker.php
@@ -42,46 +42,46 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_javascript_marker implements \TYPO3\CMS\Core\SingletonInterface {
-	protected $marker = 'JAVASCRIPT';
+    protected $marker = 'JAVASCRIPT';
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a JavaScript
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getMarkerArray (&$markerArray, $itemMarkerArray, $cObj) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a JavaScript
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getMarkerArray (&$markerArray, $itemMarkerArray, $cObj) {
 
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
 
-		if (isset($conf['javaScript.'])) {
-			$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+        if (isset($conf['javaScript.'])) {
+            $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
 
-			$jsItemMarkerArray = [];
-			foreach ($itemMarkerArray as $marker => $value) {
-				$jsItemMarkerArray[$marker] = $javaScriptObj->jsspecialchars($value);
-			}
+            $jsItemMarkerArray = [];
+            foreach ($itemMarkerArray as $marker => $value) {
+                $jsItemMarkerArray[$marker] = $javaScriptObj->jsspecialchars($value);
+            }
 
-			foreach ($conf['javaScript.'] as $key => $confJS) {
-				$marker = rtrim($key, '.');
-				$jsText =
-					$templateService->substituteMarkerArray($confJS['value'], $jsItemMarkerArray);
-				$paramsArray = [$marker => $jsText];
-				$javaScriptObj->set('direct', $paramsArray, $cObj->currentRecord);
-				$marker = '###' . $this->marker . '_' . strtoupper($marker) . '###';
-				$markerArray[$marker] = '';
-			}
-		}
-	}
+            foreach ($conf['javaScript.'] as $key => $confJS) {
+                $marker = rtrim($key, '.');
+                $jsText =
+                    $templateService->substituteMarkerArray($confJS['value'], $jsItemMarkerArray);
+                $paramsArray = [$marker => $jsText];
+                $javaScriptObj->set('direct', $paramsArray, $cObj->currentRecord);
+                $marker = '###' . $this->marker . '_' . strtoupper($marker) . '###';
+                $markerArray[$marker] = '';
+            }
+        }
+    }
 }
 
 

--- a/marker/class.tx_ttproducts_marker.php
+++ b/marker/class.tx_ttproducts_marker.php
@@ -47,323 +47,323 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 use JambageCom\TtProducts\Model\Field\FieldInterface;
 
 class tx_ttproducts_marker implements \TYPO3\CMS\Core\SingletonInterface {
-	public $markerArray;
-	public $globalMarkerArray;
-	public $urlArray;
-	private $langArray;
-	private $errorCode = [];
-	private $specialArray = ['eq', 'ne', 'lt', 'le', 'gt', 'ge', 'id', 'fn'];
+    public $markerArray;
+    public $globalMarkerArray;
+    public $urlArray;
+    private $langArray;
+    private $errorCode = [];
+    private $specialArray = ['eq', 'ne', 'lt', 'le', 'gt', 'ge', 'id', 'fn'];
 
-	/**
-	 * Initialized the marker object
-	 * $basket is the TYPO3 default shopping basket array from ses-data
-	 *
-	 * @param	string		$fieldname is the field in the table you want to create a JavaScript for
-	 * @param	array		array urls which should be overridden with marker key as index
-	 * @return	  void
-	 */
-	public function init ($conf, $piVars) {
-		$this->markerArray = ['CATEGORY', 'PRODUCT', 'ARTICLE'];
-		$markerFile = $conf['markerFile'] ?? '';
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+    /**
+     * Initialized the marker object
+     * $basket is the TYPO3 default shopping basket array from ses-data
+     *
+     * @param	string		$fieldname is the field in the table you want to create a JavaScript for
+     * @param	array		array urls which should be overridden with marker key as index
+     * @return	  void
+     */
+    public function init ($conf, $piVars) {
+        $this->markerArray = ['CATEGORY', 'PRODUCT', 'ARTICLE'];
+        $markerFile = $conf['markerFile'] ?? '';
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
         $language = $languageObj->getLanguage();
         $languageSubpath = '/Resources/Private/Language/';
-		$defaultMarkerFile = 'EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'locallang_marker.xlf';
-		$languageObj->loadLocalLang($defaultMarkerFile);
+        $defaultMarkerFile = 'EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'locallang_marker.xlf';
+        $languageObj->loadLocalLang($defaultMarkerFile);
 
-		if ($language == '' || $language == 'default' || $language == 'en') {
+        if ($language == '' || $language == 'default' || $language == 'en') {
             if (!$markerFile) {
                 $markerFile = $defaultMarkerFile;
             }
-			if ($markerFile) {
-				$languageObj->loadLocalLang($markerFile);
-			}
-		} else {
-			if (!$markerFile || $markerFile == '{$plugin.tt_products.file.markerFile}') {
+            if ($markerFile) {
+                $languageObj->loadLocalLang($markerFile);
+            }
+        } else {
+            if (!$markerFile || $markerFile == '{$plugin.tt_products.file.markerFile}') {
                 $markerFile = $defaultMarkerFile;
-			} else if (substr($markerFile, 0, 4) == 'EXT:') {	// extension
-				list($extKey, $local) = explode('/', substr($markerFile, 4), 2);
-				$filename = '';
-				if (
-					strcmp($extKey, '') &&
-					!ExtensionManagementUtility::isLoaded($extKey) &&
-					strcmp($local, '')
-				) {
-					$errorCode = [];
-					$errorCode[0] = 'extension_missing';
-					$errorCode[1] = $extKey;
-					$errorCode[2] = $markerFile;
-					$this->setErrorCode($errorCode);
-				}
-			}
+            } else if (substr($markerFile, 0, 4) == 'EXT:') {	// extension
+                list($extKey, $local) = explode('/', substr($markerFile, 4), 2);
+                $filename = '';
+                if (
+                    strcmp($extKey, '') &&
+                    !ExtensionManagementUtility::isLoaded($extKey) &&
+                    strcmp($local, '')
+                ) {
+                    $errorCode = [];
+                    $errorCode[0] = 'extension_missing';
+                    $errorCode[1] = $extKey;
+                    $errorCode[2] = $markerFile;
+                    $this->setErrorCode($errorCode);
+                }
+            }
 
-			if (!$markerFile) {
+            if (!$markerFile) {
                 throw new \RuntimeException('Error in tt_products: No marker file for language "' . $language . '" set.', 50011);
             }
-			$languageObj->loadLocalLang($markerFile);
-		}
-		$locallang = $languageObj->getLocallang();
-		$LLkey = $languageObj->getLocalLangKey();
-		$this->setGlobalMarkerArray($conf, $piVars, $locallang, $LLkey);
-		$errorCode = $this->getErrorCode();
+            $languageObj->loadLocalLang($markerFile);
+        }
+        $locallang = $languageObj->getLocallang();
+        $LLkey = $languageObj->getLocalLangKey();
+        $this->setGlobalMarkerArray($conf, $piVars, $locallang, $LLkey);
+        $errorCode = $this->getErrorCode();
 
-		return (!is_array($errorCode) || (count($errorCode) == 0) ? true : false);
-	}
+        return (!is_array($errorCode) || (count($errorCode) == 0) ? true : false);
+    }
 
-	public function getErrorCode () {
-		return $this->errorCode;
-	}
+    public function getErrorCode () {
+        return $this->errorCode;
+    }
 
-	public function setErrorCode ($errorCode) {
-		$this->errorCode = $errorCode;
-	}
+    public function setErrorCode ($errorCode) {
+        $this->errorCode = $errorCode;
+    }
 
-	public function setLangArray (&$langArray) {
-		$this->langArray = $langArray;
-	}
+    public function setLangArray (&$langArray) {
+        $this->langArray = $langArray;
+    }
 
-	public function getLangArray () {
-		return $this->langArray;
-	}
+    public function getLangArray () {
+        return $this->langArray;
+    }
 
-	public function getGlobalMarkerArray () {
-		return $this->globalMarkerArray;
-	}
+    public function getGlobalMarkerArray () {
+        return $this->globalMarkerArray;
+    }
 
-	public function replaceGlobalMarkers (&$content, $markerArray = []) {
+    public function replaceGlobalMarkers (&$content, $markerArray = []) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$globalMarkerArray = $this->getGlobalMarkerArray();
-		$markerArray = array_merge($globalMarkerArray, $markerArray);
-		$result = $templateService->substituteMarkerArrayCached($content, $markerArray);
-		return $result;
-	}
+        $globalMarkerArray = $this->getGlobalMarkerArray();
+        $markerArray = array_merge($globalMarkerArray, $markerArray);
+        $result = $templateService->substituteMarkerArrayCached($content, $markerArray);
+        return $result;
+    }
 
-	/**
-	 * getting the global markers
-	 */
-	public function setGlobalMarkerArray ($conf, $piVars, $locallang, $LLkey) {
+    /**
+     * getting the global markers
+     */
+    public function setGlobalMarkerArray ($conf, $piVars, $locallang, $LLkey) {
         $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-		$markerArray = [];
-		$language = $GLOBALS['TSFE']->config['config']['language'] ?? '';
-		if ($language == '') {
-			$language = 'default';
-		}
+        $markerArray = [];
+        $language = $GLOBALS['TSFE']->config['config']['language'] ?? '';
+        if ($language == '') {
+            $language = 'default';
+        }
 
-			// globally substituted markers, fonts and colors.
-		$splitMark = md5(microtime());
-		list($markerArray['###GW1B###' ], $markerArray['###GW1E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap1.'] ?? ''));
-		list($markerArray['###GW2B###'], $markerArray['###GW2E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap2.'] ?? ''));
-		list($markerArray['###GW3B###'], $markerArray['###GW3E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap3.'] ?? ''));
-		$markerArray['###GC1###'] = $cObj->stdWrap($conf['color1'] ?? '', $conf['color1.'] ?? '');
-		$markerArray['###GC2###'] = $cObj->stdWrap($conf['color2'] ?? '', $conf['color2.'] ?? '');
-		$markerArray['###GC3###'] = $cObj->stdWrap($conf['color3'] ?? '', $conf['color3.'] ?? '');
-		$markerArray['###DOMAIN###'] = $conf['domain'] ?? '';
+            // globally substituted markers, fonts and colors.
+        $splitMark = md5(microtime());
+        list($markerArray['###GW1B###' ], $markerArray['###GW1E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap1.'] ?? ''));
+        list($markerArray['###GW2B###'], $markerArray['###GW2E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap2.'] ?? ''));
+        list($markerArray['###GW3B###'], $markerArray['###GW3E###']) = explode($splitMark, $cObj->stdWrap($splitMark, $conf['wrap3.'] ?? ''));
+        $markerArray['###GC1###'] = $cObj->stdWrap($conf['color1'] ?? '', $conf['color1.'] ?? '');
+        $markerArray['###GC2###'] = $cObj->stdWrap($conf['color2'] ?? '', $conf['color2.'] ?? '');
+        $markerArray['###GC3###'] = $cObj->stdWrap($conf['color3'] ?? '', $conf['color3.'] ?? '');
+        $markerArray['###DOMAIN###'] = $conf['domain'] ?? '';
         $path = ExtensionManagementUtility::extPath('tt_products');
 
-		if (ExtensionManagementUtility::isLoaded('addons_tt_products')) {
+        if (ExtensionManagementUtility::isLoaded('addons_tt_products')) {
             $path = ExtensionManagementUtility::extPath('addons_tt_products');
         }
         $patchFe = PathUtility::getAbsoluteWebPath($path);
         $markerArray['###PATH_FE_REL###'] = $patchFe;
         $markerArray['###PATH_FE_ICONS###'] = $patchFe . 'Resources/Public/Images/';
-		$pidMarkerArray = [
-			'agb', 'basket', 'billing', 'delivery', 'finalize', 'info', 'itemDisplay',
-			'listDisplay', 'payment', 'revocation',
-			'search', 'storeRoot', 'thanks', 'tracking',
-			'memo'
-		];
-		foreach ($pidMarkerArray as $k => $function) {
-			$markerArray['###PID_' . strtoupper($function) . '###'] = intval($conf['PID' . $function] ?? 0);
-		}
-		$markerArray['###SHOPADMIN_EMAIL###'] = $conf['orderEmail_from'] ?? 'undefined';
-		$lang =  GeneralUtility::_GET('L');
+        $pidMarkerArray = [
+            'agb', 'basket', 'billing', 'delivery', 'finalize', 'info', 'itemDisplay',
+            'listDisplay', 'payment', 'revocation',
+            'search', 'storeRoot', 'thanks', 'tracking',
+            'memo'
+        ];
+        foreach ($pidMarkerArray as $k => $function) {
+            $markerArray['###PID_' . strtoupper($function) . '###'] = intval($conf['PID' . $function] ?? 0);
+        }
+        $markerArray['###SHOPADMIN_EMAIL###'] = $conf['orderEmail_from'] ?? 'undefined';
+        $lang =  GeneralUtility::_GET('L');
 
-		if ($lang != '') {
-			$markerArray['###LANGPARAM###'] = '&amp;L=' . $lang;
-		} else {
-			$markerArray['###LANGPARAM###'] = '';
-		}
-		$markerArray['###LANG###'] = $lang;
-		$markerArray['###LANGUAGE###'] = $GLOBALS['TSFE']->config['config']['language'] ?? '';
-		$markerArray['###LOCALE_ALL###'] = $GLOBALS['TSFE']->config['config']['locale_all'] ?? '';
+        if ($lang != '') {
+            $markerArray['###LANGPARAM###'] = '&amp;L=' . $lang;
+        } else {
+            $markerArray['###LANGPARAM###'] = '';
+        }
+        $markerArray['###LANG###'] = $lang;
+        $markerArray['###LANGUAGE###'] = $GLOBALS['TSFE']->config['config']['language'] ?? '';
+        $markerArray['###LOCALE_ALL###'] = $GLOBALS['TSFE']->config['config']['locale_all'] ?? '';
 
-		$backPID = $piVars['backPID'] ?? '';
-		$backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
-		$backPID = ($backPID  ? $backPID : (!empty($conf['PIDlistDisplay']) ? $conf['PIDlistDisplay'] : $GLOBALS['TSFE']->id ?? 0));
-		$markerArray['###BACK_PID###'] = $backPID;
+        $backPID = $piVars['backPID'] ?? '';
+        $backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
+        $backPID = ($backPID  ? $backPID : (!empty($conf['PIDlistDisplay']) ? $conf['PIDlistDisplay'] : $GLOBALS['TSFE']->id ?? 0));
+        $markerArray['###BACK_PID###'] = $backPID;
 
-			// Call all addGlobalMarkers hooks at the end of this method
-		if (
+            // Call all addGlobalMarkers hooks at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addGlobalMarkers']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addGlobalMarkers'])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addGlobalMarkers'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addGlobalMarkers')) {
-					$hookObj->addGlobalMarkers($markerArray);
-				}
-			}
-		}
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addGlobalMarkers'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addGlobalMarkers')) {
+                    $hookObj->addGlobalMarkers($markerArray);
+                }
+            }
+        }
 
-		if (isset($locallang[$LLkey])) {
-			if (isset($locallang['default']) && is_array($locallang['default'])) {
-				$langArray = array_merge($locallang['default'], $locallang[$LLkey]);
-			} else {
-				$langArray = $locallang[$LLkey];
-			}
-		} else {
-			$langArray = $locallang['default'];
-		}
+        if (isset($locallang[$LLkey])) {
+            if (isset($locallang['default']) && is_array($locallang['default'])) {
+                $langArray = array_merge($locallang['default'], $locallang[$LLkey]);
+            } else {
+                $langArray = $locallang[$LLkey];
+            }
+        } else {
+            $langArray = $locallang['default'];
+        }
 
-		if(isset($langArray) && is_array($langArray)) {
-			foreach ($langArray as $key => $value) {
-				if (
-					is_array($value) &&
-					isset($value[0])
-				) {
-					if (!empty($value[0]['target'])) {
-						$value = $value[0]['target'];
-					} else {
-						$value = $value[0]['source'];
-					}
-				} else {
+        if(isset($langArray) && is_array($langArray)) {
+            foreach ($langArray as $key => $value) {
+                if (
+                    is_array($value) &&
+                    isset($value[0])
+                ) {
+                    if (!empty($value[0]['target'])) {
+                        $value = $value[0]['target'];
+                    } else {
+                        $value = $value[0]['source'];
+                    }
+                } else {
                     $value = '';
-				}
+                }
 
-				$langArray[$key] = $value;
-				$markerArray['###' . strtoupper($key) . '###'] = $value;
-			}
-		} else {
-			$langArray = [];
-		}
+                $langArray[$key] = $value;
+                $markerArray['###' . strtoupper($key) . '###'] = $value;
+            }
+        } else {
+            $langArray = [];
+        }
 
-		if (isset($conf['marks.'])) {
+        if (isset($conf['marks.'])) {
 
-				// Substitute Marker Array from TypoScript Setup
-			foreach ($conf['marks.'] as $key => $value) {
+                // Substitute Marker Array from TypoScript Setup
+            foreach ($conf['marks.'] as $key => $value) {
 
-				if (is_array($value)) {
-					switch($key) {
-						case 'image.':
-							foreach ($value as $k2 => $v2) {
+                if (is_array($value)) {
+                    switch($key) {
+                        case 'image.':
+                            foreach ($value as $k2 => $v2) {
                                 $fileresource = FrontendUtility::fileResource($v2);
-								$markerArray['###IMAGE' . strtoupper($k2) . '###'] = $fileresource;
-							}
-						break;
-						case '_LOCAL_LANG.':
-							if (isset($value[$language . '.'])) {
-								foreach ($value[$language . '.'] as $key2 => $value2) {
-									$markerArray['###' . strtoupper($key2) . '###'] = $value2;
-								}
-							}
-						break;
-					}
-				} else {
-					if(
+                                $markerArray['###IMAGE' . strtoupper($k2) . '###'] = $fileresource;
+                            }
+                        break;
+                        case '_LOCAL_LANG.':
+                            if (isset($value[$language . '.'])) {
+                                foreach ($value[$language . '.'] as $key2 => $value2) {
+                                    $markerArray['###' . strtoupper($key2) . '###'] = $value2;
+                                }
+                            }
+                        break;
+                    }
+                } else {
+                    if(
                         isset($conf['marks.'][$key . '.']) &&
                         is_array($conf['marks.'][$key . '.'])
                     ) {
-						$out = $cObj->cObjGetSingle(
+                        $out = $cObj->cObjGetSingle(
                             $conf['marks.'][$key],
                             $conf['marks.'][$key . '.'],
                             $key
                         );
-					} else {
-						$langArray[$key] = $value;
-						$out = $value;
-					}
-					$markerArray['###' . strtoupper($key) . '###'] = $out;
-				}
-			}
-		}
+                    } else {
+                        $langArray[$key] = $value;
+                        $out = $value;
+                    }
+                    $markerArray['###' . strtoupper($key) . '###'] = $out;
+                }
+            }
+        }
 
-		$this->globalMarkerArray = $markerArray;
-		$this->setLangArray($langArray);
-	} // setGlobalMarkerArray
+        $this->globalMarkerArray = $markerArray;
+        $this->setLangArray($langArray);
+    } // setGlobalMarkerArray
 
-	public function reduceMarkerArray ($templateCode, $markerArray) {
-		$result = [];
+    public function reduceMarkerArray ($templateCode, $markerArray) {
+        $result = [];
 
-		$tagArray = $this->getAllMarkers($templateCode);
+        $tagArray = $this->getAllMarkers($templateCode);
 
-		foreach ($tagArray as $tag => $v) {
-			$marker = '###' . $tag. '###';
-			if (isset($markerArray[$marker])) {
-				$result[$marker] = $markerArray[$marker];
-			}
-		}
-		return $result;
-	}
+        foreach ($tagArray as $tag => $v) {
+            $marker = '###' . $tag. '###';
+            if (isset($markerArray[$marker])) {
+                $result[$marker] = $markerArray[$marker];
+            }
+        }
+        return $result;
+    }
 
-	public function getAllMarkers ($templateCode) {
+    public function getAllMarkers ($templateCode) {
 
-		$treffer = [];
-		$tagArray = false;
+        $treffer = [];
+        $tagArray = false;
 
-		preg_match_all('/###([\w:-]+)###/', $templateCode, $treffer);
-		if (
-			isset($treffer) &&
-			is_array($treffer) &&
-			isset($treffer['1'])
-		) {
-			$tagArray = array_unique($treffer['1']);
-		}
+        preg_match_all('/###([\w:-]+)###/', $templateCode, $treffer);
+        if (
+            isset($treffer) &&
+            is_array($treffer) &&
+            isset($treffer['1'])
+        ) {
+            $tagArray = array_unique($treffer['1']);
+        }
 
-		if (is_array($tagArray)) {
-			$tagArray = array_flip($tagArray);
-		}
+        if (is_array($tagArray)) {
+            $tagArray = array_flip($tagArray);
+        }
 
-		return $tagArray;
-	}
+        return $tagArray;
+    }
 
-	/**
-	 * finds all the markers for a product
-	 * This helps to reduce the data transfer from the database
-	 *
-	 * @access private
-	 */
-	public function getMarkerFields (
-		$templateCode,
-		&$tableFieldArray,
-		&$requiredFieldArray,
-		&$addCheckArray,
-		$prefixParam,
-		&$tagArray,
-		&$parentArray
-	) {
-		$retArray = (count($requiredFieldArray) ? $requiredFieldArray : []);
-		// obligatory fields uid and pid
+    /**
+     * finds all the markers for a product
+     * This helps to reduce the data transfer from the database
+     *
+     * @access private
+     */
+    public function getMarkerFields (
+        $templateCode,
+        &$tableFieldArray,
+        &$requiredFieldArray,
+        &$addCheckArray,
+        $prefixParam,
+        &$tagArray,
+        &$parentArray
+    ) {
+        $retArray = (count($requiredFieldArray) ? $requiredFieldArray : []);
+        // obligatory fields uid and pid
 
-		$prefix = $prefixParam . '_';
-		$prefixLen = strlen($prefix);
+        $prefix = $prefixParam . '_';
+        $prefixLen = strlen($prefix);
 
-		$bFieldaddedArray = [];
+        $bFieldaddedArray = [];
 
-		$tagArray = $this->getAllMarkers($templateCode);
+        $tagArray = $this->getAllMarkers($templateCode);
 
-		if (is_array($tagArray)) {
-			$retTagArray = $tagArray;
-			foreach ($tagArray as $tag => $v1) {
-				$prefixFound = strpos($tag, $prefix);
+        if (is_array($tagArray)) {
+            $retTagArray = $tagArray;
+            foreach ($tagArray as $tag => $v1) {
+                $prefixFound = strpos($tag, $prefix);
 
-				if ($prefixFound !== false) {
-					$fieldTmp = substr($tag, $prefixFound + $prefixLen);
-					$fieldTmp = strtolower($fieldTmp);
-					$fieldTmp = preg_replace('/[0-9]$/', '', $fieldTmp); // remove trailing numbers
+                if ($prefixFound !== false) {
+                    $fieldTmp = substr($tag, $prefixFound + $prefixLen);
+                    $fieldTmp = strtolower($fieldTmp);
+                    $fieldTmp = preg_replace('/[0-9]$/', '', $fieldTmp); // remove trailing numbers
 
-					$field = $fieldTmp;
+                    $field = $fieldTmp;
 
-					if (isset($tableFieldArray[FieldInterface::EXTERNAL_FIELD_PREFIX . $field])) {
-						$field = FieldInterface::EXTERNAL_FIELD_PREFIX . $field;
-					}
+                    if (isset($tableFieldArray[FieldInterface::EXTERNAL_FIELD_PREFIX . $field])) {
+                        $field = FieldInterface::EXTERNAL_FIELD_PREFIX . $field;
+                    }
 
-					if (!isset($tableFieldArray[$field])) {
+                    if (!isset($tableFieldArray[$field])) {
 
-						$fieldPartArray = GeneralUtility::trimExplode('_', $fieldTmp);
-						$fieldTmp = $fieldPartArray[0];
-						$subFieldPartArray = GeneralUtility::trimExplode(':', $fieldTmp);
-						$colon = (count($subFieldPartArray) > 1);
-						$field = $subFieldPartArray[0];
+                        $fieldPartArray = GeneralUtility::trimExplode('_', $fieldTmp);
+                        $fieldTmp = $fieldPartArray[0];
+                        $subFieldPartArray = GeneralUtility::trimExplode(':', $fieldTmp);
+                        $colon = (count($subFieldPartArray) > 1);
+                        $field = $subFieldPartArray[0];
 
                         if (
                             !isset($tableFieldArray[$field]) ||
@@ -387,83 +387,83 @@ class tx_ttproducts_marker implements \TYPO3\CMS\Core\SingletonInterface {
                             !$colon &&
                             !isset($tableFieldArray[$field])
                         ) {
-							$newFieldPartArray = [];
-							foreach ($fieldPartArray as $k => $v) {
-								if (in_array($v, $this->specialArray)) {
-									break;
-								} else {
-									$newFieldPartArray[] = $v;
-								}
-							}
-							$field = implode('_', $newFieldPartArray);
-						}
+                            $newFieldPartArray = [];
+                            foreach ($fieldPartArray as $k => $v) {
+                                if (in_array($v, $this->specialArray)) {
+                                    break;
+                                } else {
+                                    $newFieldPartArray[] = $v;
+                                }
+                            }
+                            $field = implode('_', $newFieldPartArray);
+                        }
 
-						if (
+                        if (
                             !$colon &&
                             (
                                 !isset($tableFieldArray[$field]) ||
                                 !is_array($tableFieldArray[$field])
-							)
-						) {	// find similar field names with letters in other cases
-							$upperField = strtoupper($field);
-							foreach ($tableFieldArray as $k => $v) {
-								if (strtoupper($k) == $upperField) {
-									$field = $k;
-									break;
-								}
-							}
-						}
-					}
-					$field = strtolower($field);
-					if (
-						isset($tableFieldArray[$field]) &&
-						is_array($tableFieldArray[$field])
-					) {
-						$retArray[] = $field;
-						$bFieldaddedArray[$field] = true;
-					}
-					$parentFound = strpos($tag, 'PARENT');
+                            )
+                        ) {	// find similar field names with letters in other cases
+                            $upperField = strtoupper($field);
+                            foreach ($tableFieldArray as $k => $v) {
+                                if (strtoupper($k) == $upperField) {
+                                    $field = $k;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    $field = strtolower($field);
+                    if (
+                        isset($tableFieldArray[$field]) &&
+                        is_array($tableFieldArray[$field])
+                    ) {
+                        $retArray[] = $field;
+                        $bFieldaddedArray[$field] = true;
+                    }
+                    $parentFound = strpos($tag, 'PARENT');
 
-					if ($parentFound !== false) {
-						$parentEnd = strpos($tag, '_');
-						$parentLen = strlen('PARENT');
-						$temp = substr($tag, $parentLen, ($parentEnd - $parentFound) - $parentLen);
-						$parentArray[] = $temp;
-					}
-				} else {
-					// unset the tags of different tables
+                    if ($parentFound !== false) {
+                        $parentEnd = strpos($tag, '_');
+                        $parentLen = strlen('PARENT');
+                        $temp = substr($tag, $parentLen, ($parentEnd - $parentFound) - $parentLen);
+                        $parentArray[] = $temp;
+                    }
+                } else {
+                    // unset the tags of different tables
 
-					foreach ($this->markerArray as $k => $marker) {
-						if ($marker != $prefixParam) {
-							$bMarkerFound = strpos($tag, $marker);
-							if ($bMarkerFound == 0 && $bMarkerFound !== false) {
-								unset($retTagArray[$tag]);
-							}
-						}
-					}
-				}
-			}
-			$tagArray = $retTagArray;
-		} else {
+                    foreach ($this->markerArray as $k => $marker) {
+                        if ($marker != $prefixParam) {
+                            $bMarkerFound = strpos($tag, $marker);
+                            if ($bMarkerFound == 0 && $bMarkerFound !== false) {
+                                unset($retTagArray[$tag]);
+                            }
+                        }
+                    }
+                }
+            }
+            $tagArray = $retTagArray;
+        } else {
             $tagArray = [];
-		}
+        }
 
-		$parentArray = array_unique($parentArray);
-		sort($parentArray);
+        $parentArray = array_unique($parentArray);
+        sort($parentArray);
 
-		if (is_array($addCheckArray)) {
-			foreach ($addCheckArray as $marker => $field) {
-				if (empty($bFieldaddedArray[$field]) && isset($tableFieldArray[$field])) { 	// TODO: check also if the marker is in the $tagArray
-					$retArray[] = $field;
-				}
-			}
-		}
+        if (is_array($addCheckArray)) {
+            foreach ($addCheckArray as $marker => $field) {
+                if (empty($bFieldaddedArray[$field]) && isset($tableFieldArray[$field])) { 	// TODO: check also if the marker is in the $tagArray
+                    $retArray[] = $field;
+                }
+            }
+        }
 
-		if (is_array($retArray)) {
-			$retArray = array_unique($retArray);
-		}
+        if (is_array($retArray)) {
+            $retArray = array_unique($retArray);
+        }
 
-		return $retArray;
-	}
+        return $retArray;
+    }
 }
 

--- a/marker/class.tx_ttproducts_subpartmarker.php
+++ b/marker/class.tx_ttproducts_subpartmarker.php
@@ -44,66 +44,66 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_subpartmarker implements \TYPO3\CMS\Core\SingletonInterface {
 
-	/**
-	 * Returning template subpart marker
-	 */
-	public function spMarker ($subpartMarker) {
+    /**
+     * Returning template subpart marker
+     */
+    public function spMarker ($subpartMarker) {
 
-		$altSPM = '';
-		if (isset($conf['altMainMarkers.'])) {
+        $altSPM = '';
+        if (isset($conf['altMainMarkers.'])) {
             $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
             $conf = $cnfObj->getConf();
             $cObj = FrontendUtility::getContentObjectRenderer();
             $sPBody = substr($subpartMarker, 3, -3);
-			$altSPM = trim($cObj->stdWrap($conf['altMainMarkers.'][$sPBody], $conf['altMainMarkers.'][$sPBody.'.']));
-		}
-		$rc = $altSPM ? $altSPM : $subpartMarker;
-		return $rc;
-	} // spMarker
+            $altSPM = trim($cObj->stdWrap($conf['altMainMarkers.'][$sPBody], $conf['altMainMarkers.'][$sPBody.'.']));
+        }
+        $rc = $altSPM ? $altSPM : $subpartMarker;
+        return $rc;
+    } // spMarker
 
 
-	/**
-	 * Returning template subpart array
-	 */
-	public function getTemplateSubParts ($templateCode, $subItemMarkerArray) {
-		$rc = [];
-		foreach ($subItemMarkerArray as $key => $subItemMarker) {
-			$rc[$subItemMarker] = substr($this->spMarker('###'.$subItemMarker . '_TEMPLATE###'), 3, -3);
-		}
-		return $rc;
-	} // getTemplate
+    /**
+     * Returning template subpart array
+     */
+    public function getTemplateSubParts ($templateCode, $subItemMarkerArray) {
+        $rc = [];
+        foreach ($subItemMarkerArray as $key => $subItemMarker) {
+            $rc[$subItemMarker] = substr($this->spMarker('###'.$subItemMarker . '_TEMPLATE###'), 3, -3);
+        }
+        return $rc;
+    } // getTemplate
 
 
-	/**
-	 * Returns a subpart from the input content stream.
-	 * A subpart is a part of the input stream which is encapsulated in a
-	 * string matching the input string, $marker. If this string is found
-	 * inside of HTML comment tags the start/end points of the content block
-	 * returned will be that right outside that comment block.
-	 * Example: The contennt string is
-	 * "Hello <!--###sub1### begin--> World. How are <!--###sub1### end--> you?"
-	 * If $marker is "###sub1###" then the content returned is
-	 * " World. How are ". The input content string could just as well have
-	 * been "Hello ###sub1### World. How are ###sub1### you?" and the result
-	 * would be the same
-	 * Wrapper for t3lib_parsehtml::getSubpart which behaves identical
-	 *
-	 * @param	string		The content stream, typically HTML template content.
-	 * @param	string		The marker string, typically on the form "###[the marker string]###"
-	 * @return	string		The subpart found, if found.
-	 * @see substituteSubpart(), t3lib_parsehtml::getSubpart()
-	 */
-	public function getSubpart ($content, $marker, &$error_code) {
+    /**
+     * Returns a subpart from the input content stream.
+     * A subpart is a part of the input stream which is encapsulated in a
+     * string matching the input string, $marker. If this string is found
+     * inside of HTML comment tags the start/end points of the content block
+     * returned will be that right outside that comment block.
+     * Example: The contennt string is
+     * "Hello <!--###sub1### begin--> World. How are <!--###sub1### end--> you?"
+     * If $marker is "###sub1###" then the content returned is
+     * " World. How are ". The input content string could just as well have
+     * been "Hello ###sub1### World. How are ###sub1### you?" and the result
+     * would be the same
+     * Wrapper for t3lib_parsehtml::getSubpart which behaves identical
+     *
+     * @param	string		The content stream, typically HTML template content.
+     * @param	string		The marker string, typically on the form "###[the marker string]###"
+     * @return	string		The subpart found, if found.
+     * @see substituteSubpart(), t3lib_parsehtml::getSubpart()
+     */
+    public function getSubpart ($content, $marker, &$error_code) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
         $result = $templateService->getSubpart($content, $marker);
 
-		if (!$result) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$error_code[0] = 'no_subtemplate';
-			$error_code[1] = $marker;
-			$error_code[2] = $templateObj->getTemplateFile();
-		}
-		return $result;
-	}
+        if (!$result) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $error_code[0] = 'no_subtemplate';
+            $error_code[1] = $marker;
+            $error_code[2] = $templateObj->getTemplateFile();
+        }
+        return $result;
+    }
 }
 

--- a/model/class.tx_ttproducts_account.php
+++ b/model/class.tx_ttproducts_account.php
@@ -41,287 +41,287 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_account extends tx_ttproducts_table_base {
-	public $pibase; // reference to object of pibase
-	public $conf;
-	public $acArray;	// credit card data
-	public $bIsAllowed = false; // enable of bank ACCOUNTS
-	public $requiredFieldArray = ['owner_name', 'iban', 'ac_number', 'bic'];
-	public $tablename = 'sys_products_accounts';
-	public $asterisk = '********';
-	public $useAsterisk = false;
-	public $sepa = true;
+    public $pibase; // reference to object of pibase
+    public $conf;
+    public $acArray;	// credit card data
+    public $bIsAllowed = false; // enable of bank ACCOUNTS
+    public $requiredFieldArray = ['owner_name', 'iban', 'ac_number', 'bic'];
+    public $tablename = 'sys_products_accounts';
+    public $asterisk = '********';
+    public $useAsterisk = false;
+    public $sepa = true;
 
 
-	public function init ($functablename) {
+    public function init ($functablename) {
 
-		$result = true;
+        $result = true;
 
-		if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['sepa']) {
-			$this->sepa = true;
-			$this->requiredFieldArray = ['owner_name', 'iban'];
-			if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['bic']) {
-				$this->requiredFieldArray[] = 'bic';
-			}
-		} else {
-			$this->sepa = false;
-			$this->requiredFieldArray = ['owner_name', 'ac_number', 'bic'];
-		}
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$formerBasket = $basketObj->recs;
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
-		$bIsAllowed = $basketExtra['payment.']['accounts'] ?? false;
+        if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['sepa']) {
+            $this->sepa = true;
+            $this->requiredFieldArray = ['owner_name', 'iban'];
+            if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['bic']) {
+                $this->requiredFieldArray[] = 'bic';
+            }
+        } else {
+            $this->sepa = false;
+            $this->requiredFieldArray = ['owner_name', 'ac_number', 'bic'];
+        }
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $formerBasket = $basketObj->recs;
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $bIsAllowed = $basketExtra['payment.']['accounts'] ?? false;
 
-		if (isset($basketExtra['payment.']['useAsterisk'])) {
-			$this->useAsterisk = $basketExtra['payment.']['useAsterisk'];
-		}
+        if (isset($basketExtra['payment.']['useAsterisk'])) {
+            $this->useAsterisk = $basketExtra['payment.']['useAsterisk'];
+        }
 
-		$result = parent::init('sys_products_accounts');
-		$this->acArray = [];
-		$this->acArray = $formerBasket['account'] ?? '';
-		if (isset($bIsAllowed)) {
-			$this->bIsAllowed = $bIsAllowed;
-		}
+        $result = parent::init('sys_products_accounts');
+        $this->acArray = [];
+        $this->acArray = $formerBasket['account'] ?? '';
+        if (isset($bIsAllowed)) {
+            $this->bIsAllowed = $bIsAllowed;
+        }
 
-		$bNumberRecentlyModified = true;
+        $bNumberRecentlyModified = true;
 
-		if (
-			!empty($this->sepa) && empty($this->acArray['iban']) ||
-			empty($this->sepa) && empty($this->acArray['ac_number'])
-		) {
-			$bNumberRecentlyModified = false;
-		}
+        if (
+            !empty($this->sepa) && empty($this->acArray['iban']) ||
+            empty($this->sepa) && empty($this->acArray['ac_number'])
+        ) {
+            $bNumberRecentlyModified = false;
+        }
 
-		if ($bNumberRecentlyModified) {
-			$acArray = tx_ttproducts_control_session::readSession('ac');
-			if (!$acArray) {
-				$acArray = [];
-			}
-			$acArray['ac_uid'] = $this->create($acArray['ac_uid'], $this->acArray);
-			$GLOBALS['TSFE']->fe_user->setKey('ses', 'ac', $acArray);
-			if ($this->useAsterisk) {
-				if (
-					$this->sepa
-				) {
-					$this->acArray['iban'] = $this->asterisk;
-				} else {
-					$this->acArray['ac_number'] = $this->asterisk;
-				}
-			}
-		}
+        if ($bNumberRecentlyModified) {
+            $acArray = tx_ttproducts_control_session::readSession('ac');
+            if (!$acArray) {
+                $acArray = [];
+            }
+            $acArray['ac_uid'] = $this->create($acArray['ac_uid'], $this->acArray);
+            $GLOBALS['TSFE']->fe_user->setKey('ses', 'ac', $acArray);
+            if ($this->useAsterisk) {
+                if (
+                    $this->sepa
+                ) {
+                    $this->acArray['iban'] = $this->asterisk;
+                } else {
+                    $this->acArray['ac_number'] = $this->asterisk;
+                }
+            }
+        }
 
-		return $result;
-	}
-
-
-	public function getIsAllowed () {
-		return $this->bIsAllowed;
-	}
+        return $result;
+    }
 
 
-	// **************************
-	// ORDER related functions
-	// **************************
-	/**
-	 * Create a new credit card record
-	 *
-	 * This creates a new account record on the page with pid PID_sys_products_orders. This page must exist!
-	 */
-	public function create ($uid, $acArray) {
-		$newId = 0;
-		$pid = intval($this->conf['PID_sys_products_orders']);
-		if (!$pid) {
-			$pid = intval($GLOBALS['TSFE']->id);
-		}
-
-		$accountField = 'iban';
-		if (
-			!$this->sepa
-		) {
-			$accountField = 'ac_number';
-		}
-
-		if (
-			!empty($acArray['owner_name']) &&
-			$acArray[$accountField] &&
-			$GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)
-		) {
-			$time = time();
-			$newFields = array (
-				'pid' => intval($pid),
-				'tstamp' => $time,
-				'crdate' => $time,
-				'owner_name' => $acArray['owner_name'],
-				'bic' => $acArray['bic'],
-			);
-
-			if (strcmp($acArray[$accountField], $this->asterisk) != 0) {
-				$newFields[$accountField] = $acArray[$accountField];
-			}
-
-			if ($uid) {
-				$GLOBALS['TYPO3_DB']->exec_UPDATEquery($this->tablename, 'uid=' . $uid, $newFields);
-				$newId = $uid;
-			} else {
-				$GLOBALS['TYPO3_DB']->exec_INSERTquery($this->tablename, $newFields);
-				$newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
-			}
-		}
-		return $newId;
-	} // create
+    public function getIsAllowed () {
+        return $this->bIsAllowed;
+    }
 
 
-	public function getUid () {
-		$result = 0;
-		$accountArray = tx_ttproducts_control_session::readSession('ac');
-		if (isset($accountArray['ac_uid'])) {
-			$result = $accountArray['ac_uid'];
-		}
-		return $result;
-	}
+    // **************************
+    // ORDER related functions
+    // **************************
+    /**
+     * Create a new credit card record
+     *
+     * This creates a new account record on the page with pid PID_sys_products_orders. This page must exist!
+     */
+    public function create ($uid, $acArray) {
+        $newId = 0;
+        $pid = intval($this->conf['PID_sys_products_orders']);
+        if (!$pid) {
+            $pid = intval($GLOBALS['TSFE']->id);
+        }
+
+        $accountField = 'iban';
+        if (
+            !$this->sepa
+        ) {
+            $accountField = 'ac_number';
+        }
+
+        if (
+            !empty($acArray['owner_name']) &&
+            $acArray[$accountField] &&
+            $GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)
+        ) {
+            $time = time();
+            $newFields = array (
+                'pid' => intval($pid),
+                'tstamp' => $time,
+                'crdate' => $time,
+                'owner_name' => $acArray['owner_name'],
+                'bic' => $acArray['bic'],
+            );
+
+            if (strcmp($acArray[$accountField], $this->asterisk) != 0) {
+                $newFields[$accountField] = $acArray[$accountField];
+            }
+
+            if ($uid) {
+                $GLOBALS['TYPO3_DB']->exec_UPDATEquery($this->tablename, 'uid=' . $uid, $newFields);
+                $newId = $uid;
+            } else {
+                $GLOBALS['TYPO3_DB']->exec_INSERTquery($this->tablename, $newFields);
+                $newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
+            }
+        }
+        return $newId;
+    } // create
 
 
-	public function getRow ($uid, $bFieldArrayAll = false) {
-		$result = [];
-		if ($bFieldArrayAll) {
-			foreach ($this->requiredFieldArray as $k => $field) {
-				$result[$field] = '';
-			}
-		}
-
-		if ($uid) {
-			$where = 'uid = ' . intval($uid);
-			// Fetching the products
-			$fields = '*';
-			if ($bFieldArrayAll) {
-				$fields = implode(',', $this->requiredFieldArray);
-			}
-			$tablename = $this->getTablename();
-			if ($tablename == '') {
-				$tablename = 'sys_products_accounts';
-			}
-			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery($fields, $tablename, $where);
-			$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-			if ($row) {
-				$result = $row;
-			}
-		}
-		return $result;
-	}
+    public function getUid () {
+        $result = 0;
+        $accountArray = tx_ttproducts_control_session::readSession('ac');
+        if (isset($accountArray['ac_uid'])) {
+            $result = $accountArray['ac_uid'];
+        }
+        return $result;
+    }
 
 
-	/**
-	 * Returns the label of the record, Usage in the following format:
-	 *
-	 * @param	array		$row: current record
-	 * @return	string		Label of the record
-	 */
-	public function getLabel ($row) {
-		$result = $row['owner_name'] . ':';
+    public function getRow ($uid, $bFieldArrayAll = false) {
+        $result = [];
+        if ($bFieldArrayAll) {
+            foreach ($this->requiredFieldArray as $k => $field) {
+                $result[$field] = '';
+            }
+        }
 
-		if ($this->sepa) {
-			$result .= $row['iban'];
-		} else {
-			$result .= $row['ac_number'] . ':' . $row['bic'];
-		}
+        if ($uid) {
+            $where = 'uid = ' . intval($uid);
+            // Fetching the products
+            $fields = '*';
+            if ($bFieldArrayAll) {
+                $fields = implode(',', $this->requiredFieldArray);
+            }
+            $tablename = $this->getTablename();
+            if ($tablename == '') {
+                $tablename = 'sys_products_accounts';
+            }
+            $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery($fields, $tablename, $where);
+            $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+            if ($row) {
+                $result = $row;
+            }
+        }
+        return $result;
+    }
 
-		return $result;
-	}
+
+    /**
+     * Returns the label of the record, Usage in the following format:
+     *
+     * @param	array		$row: current record
+     * @return	string		Label of the record
+     */
+    public function getLabel ($row) {
+        $result = $row['owner_name'] . ':';
+
+        if ($this->sepa) {
+            $result .= $row['iban'];
+        } else {
+            $result .= $row['ac_number'] . ':' . $row['bic'];
+        }
+
+        return $result;
+    }
 
 
 
-	 /**
-	 * Returns the label of the record, Usage in the following format:
-	 * taken from https://codedump.io/share/uL5GlRG5SjCL/1/validate-iban-php
-	 * It fits the
-	 * http://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
-	 *
-	 * @param	array		$row: current record
-	 * @return	string		Label of the record
-	 */
+     /**
+     * Returns the label of the record, Usage in the following format:
+     * taken from https://codedump.io/share/uL5GlRG5SjCL/1/validate-iban-php
+     * It fits the
+     * http://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
+     *
+     * @param	array		$row: current record
+     * @return	string		Label of the record
+     */
 
-	static public function checkIBAN ($iban) {
-		$result = false;
+    static public function checkIBAN ($iban) {
+        $result = false;
 
         if (!extension_loaded('bcmath')) {
             throw new RuntimeException('Required PHP module bcmath is not loaded!', 50007);
         }
 
-		$iban = strtolower(str_replace(' ', '', $iban));
-		$Countries = [
-			'al' => 28, 'ad' => 24, 'at' => 20, 'az' => 28, 'bh' => 22, 'be' => 16, 'ba' => 20, 'br' => 29, 'bg' => 22, 'cr' => 21, 'hr' => 21, 'cy' => 28, 'cz' => 24, 'dk' => 18, 'do' => 28,
-			'ee' => 20, 'fo '=> 18, 'fi' => 18, 'fr' => 27, 'ge' => 22, 'de' => 22, 'gi' => 23, 'gr' => 27, 'gl' => 18, 'gt' => 28, 'hu' => 28, 'is' => 26, 'ie' => 22, 'il' => 23, 'it' => 27,
-			'jo' => 30, 'kz' => 20, 'kw' => 30, 'lv' => 21, 'lb' => 28, 'li' => 21, 'lt' => 20, 'lu' => 20, 'mk' => 19, 'mt' =>31, 'mr' => 27, 'mu' => 30, 'mc' => 27, 'md' => 24, 'me' => 22, 'nl' => 18, 'no' => 15, 'pk' => 24, 'ps' => 29,
-			'pl' => 28, 'pt' => 25, 'qa' => 29, 'ro' => 24, 'sm' => 27, 'sa' => 24, 'rs' => 22, 'sk' => 24, 'si' => 19, 'es' => 24, 'se' => 24, 'ch' => 21, 'tn' => 24, 'tr' => 26, 'ae' => 23, 'gb' => 22, 'vg' => 24];
-		$Chars =
-			[
-				'a' => 10, 'b' => 11, 'c' => 12, 'd' => 13, 'e' => 14, 'f' => 15, 'g' => 16, 'h' => 17, 'i' =>  18, 'j' => 19, 'k' => 20, 'l' => 21, 'm' => 22, 'n' => 23, 'o' => 24, 'p' => 25, 'q' => 26, 'r' => 27, 's' => 28, 't' => 29, 'u' => 30, 'v' => 31, 'w' => 32, 'x' => 33, 'y' => 34, 'z' => 35];
+        $iban = strtolower(str_replace(' ', '', $iban));
+        $Countries = [
+            'al' => 28, 'ad' => 24, 'at' => 20, 'az' => 28, 'bh' => 22, 'be' => 16, 'ba' => 20, 'br' => 29, 'bg' => 22, 'cr' => 21, 'hr' => 21, 'cy' => 28, 'cz' => 24, 'dk' => 18, 'do' => 28,
+            'ee' => 20, 'fo '=> 18, 'fi' => 18, 'fr' => 27, 'ge' => 22, 'de' => 22, 'gi' => 23, 'gr' => 27, 'gl' => 18, 'gt' => 28, 'hu' => 28, 'is' => 26, 'ie' => 22, 'il' => 23, 'it' => 27,
+            'jo' => 30, 'kz' => 20, 'kw' => 30, 'lv' => 21, 'lb' => 28, 'li' => 21, 'lt' => 20, 'lu' => 20, 'mk' => 19, 'mt' =>31, 'mr' => 27, 'mu' => 30, 'mc' => 27, 'md' => 24, 'me' => 22, 'nl' => 18, 'no' => 15, 'pk' => 24, 'ps' => 29,
+            'pl' => 28, 'pt' => 25, 'qa' => 29, 'ro' => 24, 'sm' => 27, 'sa' => 24, 'rs' => 22, 'sk' => 24, 'si' => 19, 'es' => 24, 'se' => 24, 'ch' => 21, 'tn' => 24, 'tr' => 26, 'ae' => 23, 'gb' => 22, 'vg' => 24];
+        $Chars =
+            [
+                'a' => 10, 'b' => 11, 'c' => 12, 'd' => 13, 'e' => 14, 'f' => 15, 'g' => 16, 'h' => 17, 'i' =>  18, 'j' => 19, 'k' => 20, 'l' => 21, 'm' => 22, 'n' => 23, 'o' => 24, 'p' => 25, 'q' => 26, 'r' => 27, 's' => 28, 't' => 29, 'u' => 30, 'v' => 31, 'w' => 32, 'x' => 33, 'y' => 34, 'z' => 35];
 
-		if(strlen($iban) == $Countries[substr($iban, 0, 2)]) {
+        if(strlen($iban) == $Countries[substr($iban, 0, 2)]) {
 
-			$MovedChar = substr($iban, 4) . substr($iban, 0, 4);
-			$MovedCharArray = str_split($MovedChar);
-			$NewString = '';
+            $MovedChar = substr($iban, 4) . substr($iban, 0, 4);
+            $MovedCharArray = str_split($MovedChar);
+            $NewString = '';
 
-			foreach($MovedCharArray as $key => $value){
-				if(!is_numeric($MovedCharArray[$key])){
-					$MovedCharArray[$key] = $Chars[$MovedCharArray[$key]];
-				}
-				$NewString .= $MovedCharArray[$key];
-			}
+            foreach($MovedCharArray as $key => $value){
+                if(!is_numeric($MovedCharArray[$key])){
+                    $MovedCharArray[$key] = $Chars[$MovedCharArray[$key]];
+                }
+                $NewString .= $MovedCharArray[$key];
+            }
 
-			if(bcmod($NewString, '97') == 1) {
-				$result = true;
-			}
-		}
+            if(bcmod($NewString, '97') == 1) {
+                $result = true;
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/**
-	 * Checks if required fields for bank accounts are filled in
-	 */
-	public function checkRequired () {
-		$result = '';
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_banks_de')) {
-			$bankObj = $tablesObj->get('static_banks_de');
-		}
+    /**
+     * Checks if required fields for bank accounts are filled in
+     */
+    public function checkRequired () {
+        $result = '';
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_banks_de')) {
+            $bankObj = $tablesObj->get('static_banks_de');
+        }
 
-		foreach ($this->requiredFieldArray as $k => $field) {
-			if (!$this->acArray[$field]) {
-				$result = $field;
-				break;
-			}
+        foreach ($this->requiredFieldArray as $k => $field) {
+            if (!$this->acArray[$field]) {
+                $result = $field;
+                break;
+            }
 
-			$isValid = true;
-			switch($field) {
-				case 'iban':
-					$isValid = self::checkIBAN($this->acArray[$field]);
-					break;
-				case 'bic':
-					if (
-						is_object($bankObj)
-					) {
-						$where_clause = 'sort_code=' .
-							intval(implode('', GeneralUtility::trimExplode(' ', $this->acArray[$field]))) . ' AND level=1';
-						$bankRow = $bankObj->get('', 0, false, $where_clause);
+            $isValid = true;
+            switch($field) {
+                case 'iban':
+                    $isValid = self::checkIBAN($this->acArray[$field]);
+                    break;
+                case 'bic':
+                    if (
+                        is_object($bankObj)
+                    ) {
+                        $where_clause = 'sort_code=' .
+                            intval(implode('', GeneralUtility::trimExplode(' ', $this->acArray[$field]))) . ' AND level=1';
+                        $bankRow = $bankObj->get('', 0, false, $where_clause);
 
-						if (!$bankRow) {
-							$isValid = false;
-						}
-					}
-					break;
-			}
+                        if (!$bankRow) {
+                            $isValid = false;
+                        }
+                    }
+                    break;
+            }
 
-			if (!$isValid) {
-				$result = $field;
-				break;
-			}
-		}
-		return $result;
-	} // checkRequired
+            if (!$isValid) {
+                $result = $field;
+                break;
+            }
+        }
+        return $result;
+    } // checkRequired
 }
 
 

--- a/model/class.tx_ttproducts_address.php
+++ b/model/class.tx_ttproducts_address.php
@@ -42,110 +42,110 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_address extends tx_ttproducts_category_base {
 
-	/**
-	 * Getting all address values into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
-		if ($result) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    /**
+     * Getting all address values into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
+        if ($result) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			$tableconf = $cnf->getTableConf($functablename);
-			$tabledesc = $cnf->getTableDesc($functablename);
+            $tableconf = $cnf->getTableConf($functablename);
+            $tabledesc = $cnf->getTableDesc($functablename);
 
-			$tableObj = $this->getTableObj();
-			$tablename = $this->getTablename();
+            $tableObj = $this->getTableObj();
+            $tablename = $this->getTablename();
 
-			$tableObj->setConfig($tableconf);
-			$defaultFieldArray = $this->getDefaultFieldArray();
-			$tableObj->setDefaultFieldArray($defaultFieldArray);
-			$tableObj->setNewFieldArray();
-			$requiredFields = 'uid,pid,title';
+            $tableObj->setConfig($tableconf);
+            $defaultFieldArray = $this->getDefaultFieldArray();
+            $tableObj->setDefaultFieldArray($defaultFieldArray);
+            $tableObj->setNewFieldArray();
+            $requiredFields = 'uid,pid,title';
 
-			if (!empty($tableconf['requiredFields'])) {
-				$tmp = $tableconf['requiredFields'];
-				$requiredFields = ($tmp ? $tmp : $requiredFields);
-			}
+            if (!empty($tableconf['requiredFields'])) {
+                $tmp = $tableconf['requiredFields'];
+                $requiredFields = ($tmp ? $tmp : $requiredFields);
+            }
 
-			$requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$tableObj->setRequiredFieldArray($requiredListArray);
-			$tableObj->setTCAFieldArray($tablename);
+            $requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $tableObj->setRequiredFieldArray($requiredListArray);
+            $tableObj->setTCAFieldArray($tablename);
 
-			if (isset($tabledesc) && is_array($tabledesc)) {
-				$this->fieldArray = array_merge($this->fieldArray, $tabledesc);
-			}
-		}
-		return $result;
-	} // init
-
-
-	public function getRootCat () {
-		$result = $this->conf['rootAddressID'] ?? '';
-
-		if ($result == '') {
-			$result = '0';
-		}
-
-		return $result;
-	}
+            if (isset($tabledesc) && is_array($tabledesc)) {
+                $this->fieldArray = array_merge($this->fieldArray, $tabledesc);
+            }
+        }
+        return $result;
+    } // init
 
 
-	public function getRelationArray (
-		$dataArray,
-		$excludeCats = '',
-		$rootUids = '',
-		$allowedCats = ''
-	) {
-		$relationArray = [];
-		$rootArray = GeneralUtility::trimExplode(',', $rootUids);
+    public function getRootCat () {
+        $result = $this->conf['rootAddressID'] ?? '';
 
-		if (is_array($dataArray)) {
-			foreach ($dataArray as $k => $row) {
+        if ($result == '') {
+            $result = '0';
+        }
 
-				$uid = $row['uid'];
-				foreach ($row as $field => $value) {
-					$relationArray[$uid][$field] = $value;
-				}
-
-				$labelField = $this->getField($this->getLabelFieldname());
-				$label = '';
-
-				if (strpos($labelField, 'userFunc:') !== false) {
-					$pos = strpos($labelField, ':');
-					$labelFunc = substr($labelField, $pos + 1);
-					$params = ['table' => $this->getTablename(), 'row' => $row];
-					$label = GeneralUtility::callUserFunction($labelFunc, $params, $this);
-				} else {
-					$label = $row[$labelField];
-				}
-
-				$relationArray[$uid][$this->getLabelFieldname()] = $label;
-				$relationArray[$uid]['pid'] = $row['pid'];
-				$relationArray[$uid]['parent_category'] = '';
-			}
-		}
-
-		return $relationArray;
-	}
+        return $result;
+    }
 
 
-	public function fetchAddressArray ($itemArray) {
-		$result = [];
+    public function getRelationArray (
+        $dataArray,
+        $excludeCats = '',
+        $rootUids = '',
+        $allowedCats = ''
+    ) {
+        $relationArray = [];
+        $rootArray = GeneralUtility::trimExplode(',', $rootUids);
 
-		foreach ($itemArray as $sort => $actItemArray) {
-			foreach ($actItemArray as $k1 => $actItem) {
-				$row = $actItem['rec'];
-				$addressUid = $row['address'];
+        if (is_array($dataArray)) {
+            foreach ($dataArray as $k => $row) {
 
-				if ($addressUid) {
-					$addressRow = $this->get($addressUid);
-					$result[$addressUid] = $addressRow;
-				}
-			}
-		}
+                $uid = $row['uid'];
+                foreach ($row as $field => $value) {
+                    $relationArray[$uid][$field] = $value;
+                }
 
-		return $result;
-	}
+                $labelField = $this->getField($this->getLabelFieldname());
+                $label = '';
+
+                if (strpos($labelField, 'userFunc:') !== false) {
+                    $pos = strpos($labelField, ':');
+                    $labelFunc = substr($labelField, $pos + 1);
+                    $params = ['table' => $this->getTablename(), 'row' => $row];
+                    $label = GeneralUtility::callUserFunction($labelFunc, $params, $this);
+                } else {
+                    $label = $row[$labelField];
+                }
+
+                $relationArray[$uid][$this->getLabelFieldname()] = $label;
+                $relationArray[$uid]['pid'] = $row['pid'];
+                $relationArray[$uid]['parent_category'] = '';
+            }
+        }
+
+        return $relationArray;
+    }
+
+
+    public function fetchAddressArray ($itemArray) {
+        $result = [];
+
+        foreach ($itemArray as $sort => $actItemArray) {
+            foreach ($actItemArray as $k1 => $actItem) {
+                $row = $actItem['rec'];
+                $addressUid = $row['address'];
+
+                if ($addressUid) {
+                    $addressRow = $this->get($addressUid);
+                    $result[$addressUid] = $addressRow;
+                }
+            }
+        }
+
+        return $result;
+    }
 }
 
 

--- a/model/class.tx_ttproducts_article.php
+++ b/model/class.tx_ttproducts_article.php
@@ -42,114 +42,114 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_article extends tx_ttproducts_article_base {
-	public $fields = [];
-	public $tt_products; // element of class tx_table_db to get the parent product
-	public $marker = 'ARTICLE';
-	public $type = 'article';
-	public $tableArray;
-	protected $tableAlias = 'article';
+    public $fields = [];
+    public $tt_products; // element of class tx_table_db to get the parent product
+    public $marker = 'ARTICLE';
+    public $type = 'article';
+    public $tableArray;
+    protected $tableAlias = 'article';
 
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableConfig = [];
-			$tableConfig['orderBy'] = $cnf->conf['orderBy'] ?? '';
+        if ($result) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableConfig = [];
+            $tableConfig['orderBy'] = $cnf->conf['orderBy'] ?? '';
 
-			if (!$tableConfig['orderBy']) {
-				$tableConfig['orderBy'] = $this->getOrderBy ();
-			}
+            if (!$tableConfig['orderBy']) {
+                $tableConfig['orderBy'] = $this->getOrderBy ();
+            }
 
-			$tableObj = $this->getTableObj();
-			$tableObj->setConfig($tableConfig);
-			$tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
-		}
+            $tableObj = $this->getTableObj();
+            $tableObj->setConfig($tableConfig);
+            $tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
 
-	public function &getWhereArray ($prodUid, $where, $orderBy = '') { // Todo: consider the $orderBy
-		$rowArray = [];
-		$enableWhere = $this->getTableObj()->enableFields();
-		$where = ($where ? $where . ' ' . $enableWhere : '1=1 ' . $enableWhere);
-		$alias = $this->getAlias();
-		$fromJoin = '';
+    public function &getWhereArray ($prodUid, $where, $orderBy = '') { // Todo: consider the $orderBy
+        $rowArray = [];
+        $enableWhere = $this->getTableObj()->enableFields();
+        $where = ($where ? $where . ' ' . $enableWhere : '1=1 ' . $enableWhere);
+        $alias = $this->getAlias();
+        $fromJoin = '';
 
-		if (in_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['articleMode'], [1, 2])) {
+        if (in_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['articleMode'], [1, 2])) {
 
-			$finalWhere = 'tt_products_products_mm_articles.uid_local=' . intval($prodUid) . ' AND tt_products_products_mm_articles.deleted=0 AND tt_products_products_mm_articles.hidden=0' . ($where!='' ? ' AND '.$where : '');
-			$mmTable = 'tt_products_products_mm_articles';
-			$uidForeignArticle = 'uid_foreign';
-			$fromJoin = 'tt_products_articles ' . $alias . ' JOIN ' . $mmTable . ' ON ' . $alias . '.uid=' . $mmTable . '.' . $uidForeignArticle;
-			$finalOrderBy = $mmTable . '.sorting DESC';
-		} else {
-		//	$fromJoin = 'tt_products_articles ' . $alias;
-			$finalWhere = $alias . '.uid_product=' . intval($prodUid) . ($where ? ' AND ' . $where : '');
-			$finalOrderBy = '';
-		}
-		$res = $this->getTableObj()->exec_SELECTquery('*',$finalWhere,'',$finalOrderBy,'',$fromJoin);
+            $finalWhere = 'tt_products_products_mm_articles.uid_local=' . intval($prodUid) . ' AND tt_products_products_mm_articles.deleted=0 AND tt_products_products_mm_articles.hidden=0' . ($where!='' ? ' AND '.$where : '');
+            $mmTable = 'tt_products_products_mm_articles';
+            $uidForeignArticle = 'uid_foreign';
+            $fromJoin = 'tt_products_articles ' . $alias . ' JOIN ' . $mmTable . ' ON ' . $alias . '.uid=' . $mmTable . '.' . $uidForeignArticle;
+            $finalOrderBy = $mmTable . '.sorting DESC';
+        } else {
+        //	$fromJoin = 'tt_products_articles ' . $alias;
+            $finalWhere = $alias . '.uid_product=' . intval($prodUid) . ($where ? ' AND ' . $where : '');
+            $finalOrderBy = '';
+        }
+        $res = $this->getTableObj()->exec_SELECTquery('*',$finalWhere,'',$finalOrderBy,'',$fromJoin);
 // 		$variantFieldArray = $this->variant->getFieldArray();
 
-		while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-			$uid = intval($row['uid']);
+        while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+            $uid = intval($row['uid']);
 // 			$this->getTableObj()->substituteMarkerArray($row, $variantFieldArray);
-			$this->dataArray[$uid] = $row;	// remember for later queries
-			$uidArray[] = $uid;
-			$rowArray[] = $row;
-		}
-		$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		return $rowArray;
-	}
+            $this->dataArray[$uid] = $row;	// remember for later queries
+            $uidArray[] = $uid;
+            $rowArray[] = $row;
+        }
+        $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        return $rowArray;
+    }
 
 
-	public function getProductField (&$row, $field) {
-		$rc = '';
-		if ($field != 'uid') {
-			$rowProducts = $this->tt_products->get($row['uid_product']);
-			$rc = $rowProducts[$field];
-		} else {
-			$rc = $row['uid_product'];
-		}
-		return $rc;
-	}
+    public function getProductField (&$row, $field) {
+        $rc = '';
+        if ($field != 'uid') {
+            $rowProducts = $this->tt_products->get($row['uid_product']);
+            $rc = $rowProducts[$field];
+        } else {
+            $rc = $row['uid_product'];
+        }
+        return $rc;
+    }
 
 
-	public function getProductRow ($row) {
-		$result = $this->tt_products->get($row['uid_product']);
-		return $result;
-	}
+    public function getProductRow ($row) {
+        $result = $this->tt_products->get($row['uid_product']);
+        return $result;
+    }
 
 
-	public function getRequiredFieldArray ($theCode = '') {
-		$tableConf = $this->getTableConf($theCode);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$rc = [];
-		if (!empty($tableConf['requiredFields'])) {
-			$requiredFields = $tableConf['requiredFields'];
-		} else {
-			$requiredFields = 'uid,pid,category,price,price2,directcost';
-		}
-		$instockField = $cnf->getTableDesc($functablename,'inStock');
-		if ($instockField && !$this->conf['alwaysInStock']) {
-			$requiredFields = $requiredFields . ',' . $instockField;
-		}
+    public function getRequiredFieldArray ($theCode = '') {
+        $tableConf = $this->getTableConf($theCode);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $rc = [];
+        if (!empty($tableConf['requiredFields'])) {
+            $requiredFields = $tableConf['requiredFields'];
+        } else {
+            $requiredFields = 'uid,pid,category,price,price2,directcost';
+        }
+        $instockField = $cnf->getTableDesc($functablename,'inStock');
+        if ($instockField && !$this->conf['alwaysInStock']) {
+            $requiredFields = $requiredFields . ',' . $instockField;
+        }
 
-		$rc = $requiredFields;
-		return $rc;
-	}
+        $rc = $requiredFields;
+        return $rc;
+    }
 
-	public function usesAddParentProductCount ($row) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+    public function usesAddParentProductCount ($row) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		$result = $cnfObj->hasConfig($row, 'addParentProductCount', 'graduated_config');
-		return $result;
-	}
+        $result = $cnfObj->hasConfig($row, 'addParentProductCount', 'graduated_config');
+        return $result;
+    }
 
 }
 

--- a/model/class.tx_ttproducts_article_base.php
+++ b/model/class.tx_ttproducts_article_base.php
@@ -43,372 +43,372 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 abstract class tx_ttproducts_article_base extends tx_ttproducts_table_base {
-	public $table;	 // object of the type tx_table_db
-	public $conf;
-	public $config;
-
-	public $marker;	// marker prefix in the template file. must be overridden
-	public $type; 	// the type of table 'article' or 'product'
-			// this gets in lower case also used for the URL parameter
-	public $variant;       // object for the product variant attributes, must initialized in the init function
-	public $editVariant; 	// object for the product editable variant attributes, must initialized in the init function
-	public $mm_table = ''; // only set if a mm table is used
-	protected $graduatedPriceObj = false;
-
-
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
-
-		if ($result) {
-			$type = $this->getType();
-			$tablename = $this->getTablename();
-			$useArticles = $this->conf['useArticles'] ?? 0;
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$conf = $cnf->getConf();
-
-			if ($type == 'product') {
-				$this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant');
-				$this->variant->init($this, $tablename, $useArticles);
-				$this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant');
-				$this->editVariant->init($this);
-			} else {
-				$this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_dummy');
-				$this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_dummy');
-			}
-			$tableDesc = $this->getTableDesc();
-
-			$this->fieldArray['address'] = (!empty($tableDesc['address']) ? $tableDesc['address'] : 'address');
-			$this->fieldArray['itemnumber'] = (!empty($tableDesc['itemnumber']) ? $tableDesc['itemnumber'] : 'itemnumber');
-
-			if (
-				$type == 'product' ||
-				$type == 'article'
-			) {
-				$graduatedPriceObj = GeneralUtility::makeInstance('tx_ttproducts_graduated_price');
-
-				if ($type == 'product') {
-					$graduatedPriceObj->init(
-						$this,
-						'graduated_price_uid'
-					);
-				} else {
-					$graduatedPriceObj->init(
-						$this,
-						'graduated_price_uid'
-					);
-				}
-				$this->setGraduatedPriceObject($graduatedPriceObj);
-			}
-		}
+    public $table;	 // object of the type tx_table_db
+    public $conf;
+    public $config;
+
+    public $marker;	// marker prefix in the template file. must be overridden
+    public $type; 	// the type of table 'article' or 'product'
+            // this gets in lower case also used for the URL parameter
+    public $variant;       // object for the product variant attributes, must initialized in the init function
+    public $editVariant; 	// object for the product editable variant attributes, must initialized in the init function
+    public $mm_table = ''; // only set if a mm table is used
+    protected $graduatedPriceObj = false;
+
+
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
+
+        if ($result) {
+            $type = $this->getType();
+            $tablename = $this->getTablename();
+            $useArticles = $this->conf['useArticles'] ?? 0;
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $conf = $cnf->getConf();
+
+            if ($type == 'product') {
+                $this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant');
+                $this->variant->init($this, $tablename, $useArticles);
+                $this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant');
+                $this->editVariant->init($this);
+            } else {
+                $this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_dummy');
+                $this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_dummy');
+            }
+            $tableDesc = $this->getTableDesc();
+
+            $this->fieldArray['address'] = (!empty($tableDesc['address']) ? $tableDesc['address'] : 'address');
+            $this->fieldArray['itemnumber'] = (!empty($tableDesc['itemnumber']) ? $tableDesc['itemnumber'] : 'itemnumber');
+
+            if (
+                $type == 'product' ||
+                $type == 'article'
+            ) {
+                $graduatedPriceObj = GeneralUtility::makeInstance('tx_ttproducts_graduated_price');
+
+                if ($type == 'product') {
+                    $graduatedPriceObj->init(
+                        $this,
+                        'graduated_price_uid'
+                    );
+                } else {
+                    $graduatedPriceObj->init(
+                        $this,
+                        'graduated_price_uid'
+                    );
+                }
+                $this->setGraduatedPriceObject($graduatedPriceObj);
+            }
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
 
-	public function setGraduatedPriceObject ($value) {
-		$this->graduatedPriceObject = $value;
-	}
+    public function setGraduatedPriceObject ($value) {
+        $this->graduatedPriceObject = $value;
+    }
 
 
-	public function getGraduatedPriceObject () {
-		return $this->graduatedPriceObject;
-	}
+    public function getGraduatedPriceObject () {
+        return $this->graduatedPriceObject;
+    }
 
 
-	/**
-	 * Reduces the instock value of the orderRecord with the amount and returns the result
-	 *
-	 */
-	public function reduceInStock ($uid, $count) {
-		$tableDesc = $this->getTableDesc();
-		$instockField = $tableDesc['inStock'];
-		$instockField = ($instockField ? $instockField : 'inStock');
+    /**
+     * Reduces the instock value of the orderRecord with the amount and returns the result
+     *
+     */
+    public function reduceInStock ($uid, $count) {
+        $tableDesc = $this->getTableDesc();
+        $instockField = $tableDesc['inStock'];
+        $instockField = ($instockField ? $instockField : 'inStock');
 
-		if (is_array($this->getTableObj()->tableFieldArray[$instockField])) {
-			$uid = intval($uid);
-			$fieldsArray = [];
-			$fieldsArray[$instockField] = $instockField.'-'.$count;
-			$res = $GLOBALS['TYPO3_DB']->exec_UPDATEquery($this->getTableObj()->name, 'uid=\'' . $uid . '\'', $fieldsArray, $instockField);
-		}
-	}
+        if (is_array($this->getTableObj()->tableFieldArray[$instockField])) {
+            $uid = intval($uid);
+            $fieldsArray = [];
+            $fieldsArray[$instockField] = $instockField.'-'.$count;
+            $res = $GLOBALS['TYPO3_DB']->exec_UPDATEquery($this->getTableObj()->name, 'uid=\'' . $uid . '\'', $fieldsArray, $instockField);
+        }
+    }
 
 
-	/**
-	 * Reduces the instock value of the orderRecords with the sold items and returns the result
-	 *
-	 */
-	public function reduceInStockItems ($itemArray, $useArticles) {
-	}
+    /**
+     * Reduces the instock value of the orderRecords with the sold items and returns the result
+     *
+     */
+    public function reduceInStockItems ($itemArray, $useArticles) {
+    }
 
 
 
-	public function getRelated (
-		&$parentFuncTablename,
-		&$parentRows,
-		$multiOrderArray,
-		$uid,
-		$type,
-		$orderBy = ''
-	) {
+    public function getRelated (
+        &$parentFuncTablename,
+        &$parentRows,
+        $multiOrderArray,
+        $uid,
+        $type,
+        $orderBy = ''
+    ) {
 
-	}
+    }
 
 
-	public function getType () {
-		return $this->type;
-	}
+    public function getType () {
+        return $this->type;
+    }
 
 
-	public function getEditVariant () {
-		return $this->editVariant;
-	}
+    public function getEditVariant () {
+        return $this->editVariant;
+    }
 
 
-	public function getVariant () {
-		return $this->variant;
-	}
+    public function getVariant () {
+        return $this->variant;
+    }
 
 
-	public function getFlexQuery ($type,$val=1) {
-		$spacectrl = '[[:space:][:cntrl:]]*';
+    public function getFlexQuery ($type,$val=1) {
+        $spacectrl = '[[:space:][:cntrl:]]*';
 
-		 $rc = '<field index="' . $type . '">' . $spacectrl . '<value index="vDEF">' . ($val ? '1' :  '0') . '</value>' . $spacectrl . '</field>' . $spacectrl;
-		 return $rc;
-	}
+         $rc = '<field index="' . $type . '">' . $spacectrl . '<value index="vDEF">' . ($val ? '1' :  '0') . '</value>' . $spacectrl . '</field>' . $spacectrl;
+         return $rc;
+    }
 
 
-	public function addWhereCat ($catObject, $theCode, $cat, $categoryAnd, $pid_list) {
-		$where = '';
+    public function addWhereCat ($catObject, $theCode, $cat, $categoryAnd, $pid_list) {
+        $where = '';
 
-		return $where;
-	}
+        return $where;
+    }
 
 
-	public function addselectConfCat ($catObject, $cat, &$selectConf) {
-	}
+    public function addselectConfCat ($catObject, $cat, &$selectConf) {
+    }
 
 
-	public function getPageUidsCat ($cat) {
-		$uids = '';
+    public function getPageUidsCat ($cat) {
+        $uids = '';
 
-		return $uids;
-	}
+        return $uids;
+    }
 
 
-	public function getProductField (&$row, $field) {
-		return '';
-	}
+    public function getProductField (&$row, $field) {
+        return '';
+    }
 
 
-	/**
-	 * Returns true if the item has the $check value checked
-	 *
-	 */
-	public function hasAdditional (&$row, $check) {
-		$hasAdditional = false;
-		return $hasAdditional;
-	}
+    /**
+     * Returns true if the item has the $check value checked
+     *
+     */
+    public function hasAdditional (&$row, $check) {
+        $hasAdditional = false;
+        return $hasAdditional;
+    }
 
 
-	public function getWhere ($where, $theCode = '', $orderBy = '') {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableconf = $cnf->getTableConf($this->getFuncTablename(), $theCode);
-		$rc = [];
-		$where = ($where ? $where : '1=1 ') . $this->getTableObj()->enableFields();
+    public function getWhere ($where, $theCode = '', $orderBy = '') {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableconf = $cnf->getTableConf($this->getFuncTablename(), $theCode);
+        $rc = [];
+        $where = ($where ? $where : '1=1 ') . $this->getTableObj()->enableFields();
 
-		// Fetching the products
-		$res = $this->getTableObj()->exec_SELECTquery('*', $where, '', $GLOBALS['TYPO3_DB']->stripOrderBy($orderBy));
-		$translateFields = $cnf->getTranslationFields($tableconf);
+        // Fetching the products
+        $res = $this->getTableObj()->exec_SELECTquery('*', $where, '', $GLOBALS['TYPO3_DB']->stripOrderBy($orderBy));
+        $translateFields = $cnf->getTranslationFields($tableconf);
 
-		while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-
-			foreach ($translateFields as $field => $transfield) {
-				$row[$field] = $row[$transfield];
-			}
-			$rc[$row['uid']] = $this->dataArray[$row['uid']] = $row;
-		}
-		$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		return $rc;
-	}
-
-
-	public function searchWhere ($searchFieldList, $sw, $theCode) {
-		$where = '';
-
-		$tableConf = $this->getTableConf($theCode);
-		$replaceConf = [];
-
-		$bUseLanguageTable = $this->bUseLanguageTable($tableConf);
-		$charRegExp = $this->getCharRegExp($tableConf, $replaceConf);
-
-		if ($bUseLanguageTable) {
-			$where =
-				$this->getTableObj()->searchWhere(
-					$sw,
-					$searchFieldList,
-					true,
-					$charRegExp,
-					$replaceConf
-				);
-		} else {
-			$where =
-				$this->getTableObj()->searchWhere(
-					$sw,
-					$searchFieldList,
-					false,
-					$charRegExp,
-					$replaceConf
-				);
-		}
-
-		return $where;
-	} // searchWhere
-
-
-	public function getCharRegExp ($tableConf, &$replaceConf) {
-
-		$result = '';
-		$replaceConf = [];
-
-		if (isset($tableConf['charRegExp'])) {
-			$result = $tableConf['charRegExp'];
-			if (
-				isset($tableConf['charRegExp.']) &&
-				isset($tableConf['charRegExp.']['replace.']) &&
-				$tableConf['charRegExp.']['replace.']['type'] == 'bothsided'
-			) {
-				foreach ($tableConf['charRegExp.']['replace.'] as $k => $lineReplaceConf) {
-					if (
-						$k != 'type' &&
-						strpos($k, '.') == strlen($k) - 1
-					) {
-						$k1 = substr($k, 0, strlen($k) - 1);
-						if (MathUtility::canBeInterpretedAsInteger($k1)) {
-							$replaceConf = array_merge($replaceConf, $lineReplaceConf);
-						}
-					}
-				}
-			}
-		}
-
-		return $result;
-	}
-
-
-	public function getNeededUrlParams ($functablename, $theCode) {
-		$rc = '';
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableconf = $cnf->getTableConf($functablename, $theCode);
-		if (is_array($tableconf) && isset($tableconf['urlparams'])) {
-			$rc = $tableconf['urlparams'];
-		}
-		return $rc;
-	}
-
-	public function clearSelectableVariantFields (
-		&$targetRow
-	) {
-		$fieldArray = $this->getVariant()->getFieldArray();
-		$selectableArray = $this->getVariant()->getSelectableArray();
-		$count = 0;
-
-		foreach ($fieldArray as $key => $field) {
-			if ($selectableArray[$key]) {
-				$targetRow[$field] = '';
-			}
-		}
-	}
-
-	public function mergeVariantFields (
-		&$targetRow,
-		$sourceRow,
-		$bKeepNotEmpty = true
-	) {
-		$variantFieldArray = $this->getVariant()->getFieldArray();
-
-		if (isset($variantFieldArray) && is_array($variantFieldArray)) {
-			foreach ($variantFieldArray as $field) {
-				if (isset($sourceRow[$field])) {
-					$value = $sourceRow[$field];
-
-					if($bKeepNotEmpty) {
-						if (!$targetRow[$field]) {
-							$targetRow[$field] = $value;
-						}
-					} else {
-						$targetRow[$field] = $value;
-					}
-				}
-			}
-		}
-	}
-
-
-	public function mergeAttributeFields (
-		array &$targetRow,
-		array $sourceRow,
-		$bKeepNotEmpty = true,
-		$bAddValues = false,
-		$bMergeVariants = true,
-		$calculationField = '',
-		$bUseExt = false,
+        while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+
+            foreach ($translateFields as $field => $transfield) {
+                $row[$field] = $row[$transfield];
+            }
+            $rc[$row['uid']] = $this->dataArray[$row['uid']] = $row;
+        }
+        $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        return $rc;
+    }
+
+
+    public function searchWhere ($searchFieldList, $sw, $theCode) {
+        $where = '';
+
+        $tableConf = $this->getTableConf($theCode);
+        $replaceConf = [];
+
+        $bUseLanguageTable = $this->bUseLanguageTable($tableConf);
+        $charRegExp = $this->getCharRegExp($tableConf, $replaceConf);
+
+        if ($bUseLanguageTable) {
+            $where =
+                $this->getTableObj()->searchWhere(
+                    $sw,
+                    $searchFieldList,
+                    true,
+                    $charRegExp,
+                    $replaceConf
+                );
+        } else {
+            $where =
+                $this->getTableObj()->searchWhere(
+                    $sw,
+                    $searchFieldList,
+                    false,
+                    $charRegExp,
+                    $replaceConf
+                );
+        }
+
+        return $where;
+    } // searchWhere
+
+
+    public function getCharRegExp ($tableConf, &$replaceConf) {
+
+        $result = '';
+        $replaceConf = [];
+
+        if (isset($tableConf['charRegExp'])) {
+            $result = $tableConf['charRegExp'];
+            if (
+                isset($tableConf['charRegExp.']) &&
+                isset($tableConf['charRegExp.']['replace.']) &&
+                $tableConf['charRegExp.']['replace.']['type'] == 'bothsided'
+            ) {
+                foreach ($tableConf['charRegExp.']['replace.'] as $k => $lineReplaceConf) {
+                    if (
+                        $k != 'type' &&
+                        strpos($k, '.') == strlen($k) - 1
+                    ) {
+                        $k1 = substr($k, 0, strlen($k) - 1);
+                        if (MathUtility::canBeInterpretedAsInteger($k1)) {
+                            $replaceConf = array_merge($replaceConf, $lineReplaceConf);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+
+    public function getNeededUrlParams ($functablename, $theCode) {
+        $rc = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableconf = $cnf->getTableConf($functablename, $theCode);
+        if (is_array($tableconf) && isset($tableconf['urlparams'])) {
+            $rc = $tableconf['urlparams'];
+        }
+        return $rc;
+    }
+
+    public function clearSelectableVariantFields (
+        &$targetRow
+    ) {
+        $fieldArray = $this->getVariant()->getFieldArray();
+        $selectableArray = $this->getVariant()->getSelectableArray();
+        $count = 0;
+
+        foreach ($fieldArray as $key => $field) {
+            if ($selectableArray[$key]) {
+                $targetRow[$field] = '';
+            }
+        }
+    }
+
+    public function mergeVariantFields (
+        &$targetRow,
+        $sourceRow,
+        $bKeepNotEmpty = true
+    ) {
+        $variantFieldArray = $this->getVariant()->getFieldArray();
+
+        if (isset($variantFieldArray) && is_array($variantFieldArray)) {
+            foreach ($variantFieldArray as $field) {
+                if (isset($sourceRow[$field])) {
+                    $value = $sourceRow[$field];
+
+                    if($bKeepNotEmpty) {
+                        if (!$targetRow[$field]) {
+                            $targetRow[$field] = $value;
+                        }
+                    } else {
+                        $targetRow[$field] = $value;
+                    }
+                }
+            }
+        }
+    }
+
+
+    public function mergeAttributeFields (
+        array &$targetRow,
+        array $sourceRow,
+        $bKeepNotEmpty = true,
+        $bAddValues = false,
+        $bMergeVariants = true,
+        $calculationField = '',
+        $bUseExt = false,
         $mergePrices = true
-	) {
-		$fieldArray = [];
-		$fieldArray['data'] = ['itemnumber', 'image', 'smallimage'];
-		$fieldArray['number'] = ['weight', 'inStock'];
-		$fieldArray['price'] = ['price', 'price2', 'deposit', 'directcost'];
-		if (
-			$calculationField != '' &&
-			isset($sourceRow[$calculationField])
-		) {
-			$fieldArray['price'][] = $calculationField;
-		}
-		$bIsAddedPrice = false;
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableDesc = $this->getTableDesc();
+    ) {
+        $fieldArray = [];
+        $fieldArray['data'] = ['itemnumber', 'image', 'smallimage'];
+        $fieldArray['number'] = ['weight', 'inStock'];
+        $fieldArray['price'] = ['price', 'price2', 'deposit', 'directcost'];
+        if (
+            $calculationField != '' &&
+            isset($sourceRow[$calculationField])
+        ) {
+            $fieldArray['price'][] = $calculationField;
+        }
+        $bIsAddedPrice = false;
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableDesc = $this->getTableDesc();
 
-		if (
-			isset($tableDesc['conf.']) &&
-			is_array($tableDesc['conf.']) &&
-			isset($tableDesc['conf.']['mergeAppendFields'])
-		) {
-			$mergeAppendArray = GeneralUtility::trimExplode(',', $tableDesc['conf.']['mergeAppendFields']);
-			$fieldArray['text'] = $mergeAppendArray;
-		} else {
-			$mergeAppendArray = [];
-		}
+        if (
+            isset($tableDesc['conf.']) &&
+            is_array($tableDesc['conf.']) &&
+            isset($tableDesc['conf.']['mergeAppendFields'])
+        ) {
+            $mergeAppendArray = GeneralUtility::trimExplode(',', $tableDesc['conf.']['mergeAppendFields']);
+            $fieldArray['text'] = $mergeAppendArray;
+        } else {
+            $mergeAppendArray = [];
+        }
 
-		$fieldArray['text'][] = 'title';
-		$fieldArray['text'][] = 'subtitle';
-		$fieldArray['text'][] = 'note';
-		$fieldArray['text'][] = 'note2';
-		$fieldArray['text'] = array_unique($fieldArray['text']);
+        $fieldArray['text'][] = 'title';
+        $fieldArray['text'][] = 'subtitle';
+        $fieldArray['text'][] = 'note';
+        $fieldArray['text'][] = 'note2';
+        $fieldArray['text'] = array_unique($fieldArray['text']);
 
-		$previouslyAddedPrice = 0;
+        $previouslyAddedPrice = 0;
 
-		if (
-			$bUseExt &&
+        if (
+            $bUseExt &&
             $mergePrices &&
-			isset($targetRow['ext']) &&
-			is_array($targetRow['ext']) &&
-			isset($targetRow['ext']['addedPrice'])
-		) {
-			$previouslyAddedPrice = $targetRow['addedPrice'];
-		}
+            isset($targetRow['ext']) &&
+            is_array($targetRow['ext']) &&
+            isset($targetRow['ext']['addedPrice'])
+        ) {
+            $previouslyAddedPrice = $targetRow['addedPrice'];
+        }
 
-		$bIsAddedPrice = $cnfObj->hasConfig($sourceRow, 'isAddedPrice');
+        $bIsAddedPrice = $cnfObj->hasConfig($sourceRow, 'isAddedPrice');
 
-		foreach ($fieldArray as $type => $fieldTypeArray) {
-			foreach ($fieldTypeArray as $k => $field) {
+        foreach ($fieldArray as $type => $fieldTypeArray) {
+            foreach ($fieldTypeArray as $k => $field) {
 
-				if (isset($sourceRow[$field])) {
-					$value = $sourceRow[$field];
+                if (isset($sourceRow[$field])) {
+                    $value = $sourceRow[$field];
 
-					if ($type == 'price') {
+                    if ($type == 'price') {
                         if ($mergePrices) {
                             \JambageCom\TtProducts\Api\PriceApi::mergeRows(
                                 $targetRow,
@@ -421,68 +421,68 @@ abstract class tx_ttproducts_article_base extends tx_ttproducts_table_base {
                                 $bUseExt
                             );
                         }
-					} else if (
-						($type == 'text') ||
-						($type == 'data') ||
-						($type == 'number')
-					) {
-						if($bKeepNotEmpty) {
-							if (
-								$type == 'number' && !round($targetRow[$field], 16) ||
-								$type != 'number' && empty($targetRow[$field])
-							) {
-								$targetRow[$field] = $value;
-							}
-						} else { // $bKeepNotEmpty == false
-							if (
-								$type == 'number' &&
-								(
-									!round($targetRow[$field], 16) ||
-									round($value, 16) ||
-									($field == 'inStock')
-								)
-									||
-								$type != 'number' &&
-								(empty($targetRow[$field]) || !empty($value))
-							) {
-								if (
-									($bAddValues == true) &&
-									in_array($field, $mergeAppendArray)
-								) {
+                    } else if (
+                        ($type == 'text') ||
+                        ($type == 'data') ||
+                        ($type == 'number')
+                    ) {
+                        if($bKeepNotEmpty) {
+                            if (
+                                $type == 'number' && !round($targetRow[$field], 16) ||
+                                $type != 'number' && empty($targetRow[$field])
+                            ) {
+                                $targetRow[$field] = $value;
+                            }
+                        } else { // $bKeepNotEmpty == false
+                            if (
+                                $type == 'number' &&
+                                (
+                                    !round($targetRow[$field], 16) ||
+                                    round($value, 16) ||
+                                    ($field == 'inStock')
+                                )
+                                    ||
+                                $type != 'number' &&
+                                (empty($targetRow[$field]) || !empty($value))
+                            ) {
+                                if (
+                                    ($bAddValues == true) &&
+                                    in_array($field, $mergeAppendArray)
+                                ) {
                                     if (!isset($targetRow[$field])) {
                                         $targetRow[$field] = '';
                                     }
-									$targetRow[$field] .= ' ' . $value;
-								} else {
-									$targetRow[$field] = $value;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		// copy the normal fields
+                                    $targetRow[$field] .= ' ' . $value;
+                                } else {
+                                    $targetRow[$field] = $value;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // copy the normal fields
 
-		if ($bMergeVariants) {
-			$this->mergeVariantFields(
-				$targetRow,
-				$sourceRow,
-				$bKeepNotEmpty
-			);
-		}
-		return true;
-	} // mergeAttributeFields
-
-
-	public function mergeGraduatedPrice (
-		&$targetRow,
-		$count
-	) {
-	}
+        if ($bMergeVariants) {
+            $this->mergeVariantFields(
+                $targetRow,
+                $sourceRow,
+                $bKeepNotEmpty
+            );
+        }
+        return true;
+    } // mergeAttributeFields
 
 
-	public function getTotalDiscount (&$row, $pid = 0) {
-	}
+    public function mergeGraduatedPrice (
+        &$targetRow,
+        $count
+    ) {
+    }
+
+
+    public function getTotalDiscount (&$row, $pid = 0) {
+    }
 }
 

--- a/model/class.tx_ttproducts_basket.php
+++ b/model/class.tx_ttproducts_basket.php
@@ -46,42 +46,42 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_basket implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
+    public $conf;
 
-		// Internal: initBasket():
-	public $recs = []; 		// in initBasket this is set to the recs-array of fe_user.
+        // Internal: initBasket():
+    public $recs = []; 		// in initBasket this is set to the recs-array of fe_user.
 // 	public $order = []; 	// order data
-	public $giftnumber;				// current counter of the gifts
+    public $giftnumber;				// current counter of the gifts
 
-	public $itemArray = [];	// the items in the basket; database row, how many (quantity, count) and the price; this has replaced the former $calculatedBasket
+    public $itemArray = [];	// the items in the basket; database row, how many (quantity, count) and the price; this has replaced the former $calculatedBasket
 
-	public $giftServiceRow;
-	protected $maxTax;
-	protected $categoryQuantity = [];
-	protected $categoryArray = [];
-	protected $uidArray = []; // uids of the items in the basket
+    public $giftServiceRow;
+    protected $maxTax;
+    protected $categoryQuantity = [];
+    protected $categoryArray = [];
+    protected $uidArray = []; // uids of the items in the basket
 
-	public $basketExtra; // deprecated. do not use it
+    public $basketExtra; // deprecated. do not use it
 
-	public function __construct ()
+    public function __construct ()
     {
         $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
         $this->conf = $cnfObj->conf;        
     }
 
-	public function init (
-		$pibaseClass,
-		$updateMode,
-		$bStoreBasket
-	) {
-		$this->setMaxTax(0.0);
+    public function init (
+        $pibaseClass,
+        $updateMode,
+        $bStoreBasket
+    ) {
+        $this->setMaxTax(0.0);
 
-		$formerBasket = tx_ttproducts_control_basket::getRecs();
-		$pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->recs = $formerBasket;	// Sets it internally
-		$parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
-		$basketApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\BasketApi::class);
+        $formerBasket = tx_ttproducts_control_basket::getRecs();
+        $pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->recs = $formerBasket;	// Sets it internally
+        $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
+        $basketApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\BasketApi::class);
         $piVars = $parameterApi->getPiVars();
         $gpVars = GeneralUtility::_GP('tt_products');
         $payment =
@@ -104,969 +104,969 @@ class tx_ttproducts_basket implements \TYPO3\CMS\Core\SingletonInterface {
             }
         }
 
-		$this->setItemArray([]);
+        $this->setItemArray([]);
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$funcTablename = tx_ttproducts_control_basket::getFuncTablename();
-		$viewTableObj = $tablesObj->get($funcTablename);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+        $viewTableObj = $tablesObj->get($funcTablename);
 
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-		$basketExtRaw = tx_ttproducts_control_basket::getBasketExtRaw();
-		$basketInputConf = $cnfObj->getBasketConf('view', 'input');
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $basketExtRaw = tx_ttproducts_control_basket::getBasketExtRaw();
+        $basketInputConf = $cnfObj->getBasketConf('view', 'input');
 
-		if (isset($basketInputConf) && is_array($basketInputConf)) {
-			foreach ($basketInputConf as $lineNo => $inputConf) {
-				if (
-					strpos($lineNo, '.') !== false &&
-					$inputConf['type'] == 'radio' &&
-					$inputConf['where'] &&
-					!empty($inputConf['name'])
-				) {
-					$radioUid = GeneralUtility::_GP($inputConf['name']);
-					if ($radioUid) {
-						$rowArray = $viewTableObj->get('', 0, false, $inputConf['where']);
+        if (isset($basketInputConf) && is_array($basketInputConf)) {
+            foreach ($basketInputConf as $lineNo => $inputConf) {
+                if (
+                    strpos($lineNo, '.') !== false &&
+                    $inputConf['type'] == 'radio' &&
+                    $inputConf['where'] &&
+                    !empty($inputConf['name'])
+                ) {
+                    $radioUid = GeneralUtility::_GP($inputConf['name']);
+                    if ($radioUid) {
+                        $rowArray = $viewTableObj->get('', 0, false, $inputConf['where']);
 
-						if (!empty($rowArray)) {
-							foreach($rowArray as $uid => $row) {
-								if ($uid == $radioUid) {
-									$basketExtRaw[$uid]['quantity'] = 1;
-								} else {
-									unset($basketExt[$uid]);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+                        if (!empty($rowArray)) {
+                            foreach($rowArray as $uid => $row) {
+                                if ($uid == $radioUid) {
+                                    $basketExtRaw[$uid]['quantity'] = 1;
+                                } else {
+                                    unset($basketExt[$uid]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		if (!is_array($basketExt)) {
-			$basketExt = [];
-		}
-		tx_ttproducts_control_basket::setBasketExt($basketExt);
+        if (!is_array($basketExt)) {
+            $basketExt = [];
+        }
+        tx_ttproducts_control_basket::setBasketExt($basketExt);
 
         if (isset($this->basketExt['gift']) && is_array($this->basketExt['gift'])) {
             $this->giftnumber = count($this->basketExt['gift']) + 1;
         }
-		$newGiftData = GeneralUtility::_GP('ttp_gift');
-		$extVars = $piVars['variants'] ?? '';
-		$extVars = ($extVars ? $extVars : GeneralUtility::_GP('ttp_extvars'));
-		$uid = $piVars['product'] ?? '';
-		$uid = ($uid ? $uid : GeneralUtility::_GP('tt_products'));
-		$sameGiftData = true;
-		$identGiftnumber = 0;
+        $newGiftData = GeneralUtility::_GP('ttp_gift');
+        $extVars = $piVars['variants'] ?? '';
+        $extVars = ($extVars ? $extVars : GeneralUtility::_GP('ttp_extvars'));
+        $uid = $piVars['product'] ?? '';
+        $uid = ($uid ? $uid : GeneralUtility::_GP('tt_products'));
+        $sameGiftData = true;
+        $identGiftnumber = 0;
 
-		$addMemo = $piVars['addmemo'] ?? '';
-		if ($addMemo) {
-			$basketExtRaw = '';
-			$newGiftData = '';
-		}
+        $addMemo = $piVars['addmemo'] ?? '';
+        if ($addMemo) {
+            $basketExtRaw = '';
+            $newGiftData = '';
+        }
 
-			// Call all changeBasket hooks
-		if (
+            // Call all changeBasket hooks
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasket']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasket'])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasket'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'changeBasket')) {
-					$hookObj->changeBasket(
-						$this,
-						$basketExt,
-						$basketExtRaw
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasket'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'changeBasket')) {
+                    $hookObj->changeBasket(
+                        $this,
+                        $basketExt,
+                        $basketExtRaw
                     );
-				}
-			}
-		}
+                }
+            }
+        }
 
-		if ($newGiftData) {
-			$giftnumber = GeneralUtility::_GP('giftnumber');
-			if ($updateMode) {
-				$basketExt['gift'][$giftnumber] = $newGiftData;
-				$giftcount = intval($basketExt['gift'][$giftnumber]['item'][$uid][$extVars]);
-				if ($giftcount == 0) {
-					$this->removeGift($giftnumber, $uid, $extVars);
-				}
-				$count = 0;
-				foreach ($basketExt['gift'] as $prevgiftnumber => $rec) {
-					$count += $rec['item'][$uid][$extVars];
-				}
-				// update the general basket entry for this product
-				$basketExt[$uid][$extVars] = $count;
-			} else {
-				if (is_array($basketExt['gift'])) {
-					foreach ($basketExt['gift'] as $prevgiftnumber => $rec) {
-						$sameGiftData = true;
-						foreach ($rec as $field => $value) {
-							// only the 'field' field can be different
-							if (
-								$field != 'item' &&
-								$field != 'note' &&
-								$value != $newGiftData[$field]
-							) {
-								$sameGiftData = false;
-								break;
-							}
-						}
+        if ($newGiftData) {
+            $giftnumber = GeneralUtility::_GP('giftnumber');
+            if ($updateMode) {
+                $basketExt['gift'][$giftnumber] = $newGiftData;
+                $giftcount = intval($basketExt['gift'][$giftnumber]['item'][$uid][$extVars]);
+                if ($giftcount == 0) {
+                    $this->removeGift($giftnumber, $uid, $extVars);
+                }
+                $count = 0;
+                foreach ($basketExt['gift'] as $prevgiftnumber => $rec) {
+                    $count += $rec['item'][$uid][$extVars];
+                }
+                // update the general basket entry for this product
+                $basketExt[$uid][$extVars] = $count;
+            } else {
+                if (is_array($basketExt['gift'])) {
+                    foreach ($basketExt['gift'] as $prevgiftnumber => $rec) {
+                        $sameGiftData = true;
+                        foreach ($rec as $field => $value) {
+                            // only the 'field' field can be different
+                            if (
+                                $field != 'item' &&
+                                $field != 'note' &&
+                                $value != $newGiftData[$field]
+                            ) {
+                                $sameGiftData = false;
+                                break;
+                            }
+                        }
 
-						if ($sameGiftData) {
-							$identGiftnumber = $prevgiftnumber;
-							// always use the latest note
-							$basketExt['gift'][$identGiftnumber]['note'] = $newGiftData['note'];
-							break;
-						}
-					}
-				} else {
-					$sameGiftData = false;
-				}
-				if (!$sameGiftData) {
-					$basketExt['gift'][$this->giftnumber] = $newGiftData;
-				}
-			}
-		}
+                        if ($sameGiftData) {
+                            $identGiftnumber = $prevgiftnumber;
+                            // always use the latest note
+                            $basketExt['gift'][$identGiftnumber]['note'] = $newGiftData['note'];
+                            break;
+                        }
+                    }
+                } else {
+                    $sameGiftData = false;
+                }
+                if (!$sameGiftData) {
+                    $basketExt['gift'][$this->giftnumber] = $newGiftData;
+                }
+            }
+        }
 
-		if (is_array($basketExtRaw)) {
+        if (is_array($basketExtRaw)) {
             $damUid = 0;
-			if (isset($basketExtRaw['dam'])) {
-				$damUid = intval($basketExtRaw['dam']);
-			}
+            if (isset($basketExtRaw['dam'])) {
+                $damUid = intval($basketExtRaw['dam']);
+            }
 
-			foreach($basketExtRaw as $uid => $basketItem) {
-				if (
-					MathUtility::canBeInterpretedAsInteger($uid)
-				) {
-					if (isset($basketItem['quantity'])) {
-						if (
-							isset($basketExtRaw['dam'])
-						) {
-							foreach($basketItem as $damUid => $damBasketItem) {
-								$this->addItem(
-									$viewTableObj,
-									$uid,
-									'',
-									$damUid,
-									$damBasketItem,
-									$updateMode,
-									$basketExt,
-									$bStoreBasket,
-									$newGiftData,
-									$identGiftnumber,
-									$sameGiftData
-								);
-							}
-						} else {
-							$this->addItem(
-								$viewTableObj,
-								$uid,
-								'',
-								$damUid,
-								$basketItem,
-								$updateMode,
-								$basketExt,
-								$bStoreBasket,
-								$newGiftData,
-								$identGiftnumber,
-								$sameGiftData
-							);
-						}
-					} else {
-						$addItems = false;
-						foreach($basketItem as $basketKey => $basketValue) {
-							if (
-								isset($basketValue) &&
-								is_array($basketValue) &&
-								isset($basketValue['quantity'])
-							) {
-								$addItems = true;
-								$this->addItem(
-									$viewTableObj,
-									$uid,
-									$basketKey,
-									'',
-									$basketValue,
-									$updateMode,
-									$basketExt,
-									$bStoreBasket,
-									$newGiftData,
-									$identGiftnumber,
-									$sameGiftData
-								);
-							}
-						}
+            foreach($basketExtRaw as $uid => $basketItem) {
+                if (
+                    MathUtility::canBeInterpretedAsInteger($uid)
+                ) {
+                    if (isset($basketItem['quantity'])) {
+                        if (
+                            isset($basketExtRaw['dam'])
+                        ) {
+                            foreach($basketItem as $damUid => $damBasketItem) {
+                                $this->addItem(
+                                    $viewTableObj,
+                                    $uid,
+                                    '',
+                                    $damUid,
+                                    $damBasketItem,
+                                    $updateMode,
+                                    $basketExt,
+                                    $bStoreBasket,
+                                    $newGiftData,
+                                    $identGiftnumber,
+                                    $sameGiftData
+                                );
+                            }
+                        } else {
+                            $this->addItem(
+                                $viewTableObj,
+                                $uid,
+                                '',
+                                $damUid,
+                                $basketItem,
+                                $updateMode,
+                                $basketExt,
+                                $bStoreBasket,
+                                $newGiftData,
+                                $identGiftnumber,
+                                $sameGiftData
+                            );
+                        }
+                    } else {
+                        $addItems = false;
+                        foreach($basketItem as $basketKey => $basketValue) {
+                            if (
+                                isset($basketValue) &&
+                                is_array($basketValue) &&
+                                isset($basketValue['quantity'])
+                            ) {
+                                $addItems = true;
+                                $this->addItem(
+                                    $viewTableObj,
+                                    $uid,
+                                    $basketKey,
+                                    '',
+                                    $basketValue,
+                                    $updateMode,
+                                    $basketExt,
+                                    $bStoreBasket,
+                                    $newGiftData,
+                                    $identGiftnumber,
+                                    $sameGiftData
+                                );
+                            }
+                        }
 
-						if ($addItems) {
-						} else {
-							$this->addItem(
-								$viewTableObj,
-								$uid,
-								'',
-								'',
-								$basketItem,
-								$updateMode,
-								$basketExt,
-								$bStoreBasket,
-								$newGiftData,
-								$identGiftnumber,
-								$sameGiftData
-							);
-						}
-					}
-				}
-			}
+                        if ($addItems) {
+                        } else {
+                            $this->addItem(
+                                $viewTableObj,
+                                $uid,
+                                '',
+                                '',
+                                $basketItem,
+                                $updateMode,
+                                $basketExt,
+                                $bStoreBasket,
+                                $newGiftData,
+                                $identGiftnumber,
+                                $sameGiftData
+                            );
+                        }
+                    }
+                }
+            }
 
-			// I did not find another possibility to delete elements completely from a multidimensional array
-			// than to recreate the array
-			$basketExtNew = [];
-			foreach($basketExt as $tmpUid => $tmpSubArr) {
-				if (is_array($tmpSubArr) && count($tmpSubArr)) {
-					foreach($tmpSubArr as $tmpExtVar => $tmpCount) {
+            // I did not find another possibility to delete elements completely from a multidimensional array
+            // than to recreate the array
+            $basketExtNew = [];
+            foreach($basketExt as $tmpUid => $tmpSubArr) {
+                if (is_array($tmpSubArr) && count($tmpSubArr)) {
+                    foreach($tmpSubArr as $tmpExtVar => $tmpCount) {
 
-						if (
-							$tmpCount > 0 &&
-							(
-								$this->conf['quantityIsFloat'] ||
-								MathUtility::canBeInterpretedAsInteger($tmpCount)
-							)
-						) {
-							$basketExtNew[$tmpUid][$tmpExtVar] = $basketExt[$tmpUid][$tmpExtVar];
-							if (
-								isset($basketExt[$tmpUid][$tmpExtVar . '.']) &&
-								is_array($basketExt[$tmpUid][$tmpExtVar . '.'])
-							) {
-								$basketExtNew[$tmpUid][$tmpExtVar . '.'] = $basketExt[$tmpUid][$tmpExtVar . '.'];
-							}
-						} else if (is_array($tmpCount)) {
-							$basketExtNew[$tmpUid][$tmpExtVar] = $tmpCount;
-						} else {
-							// nothing
-						}
-					}
-				} else {
-					$basketExtNew[$tmpUid] = $tmpSubArr;
-				}
-			}
-			$basketExt = $basketExtNew;
+                        if (
+                            $tmpCount > 0 &&
+                            (
+                                $this->conf['quantityIsFloat'] ||
+                                MathUtility::canBeInterpretedAsInteger($tmpCount)
+                            )
+                        ) {
+                            $basketExtNew[$tmpUid][$tmpExtVar] = $basketExt[$tmpUid][$tmpExtVar];
+                            if (
+                                isset($basketExt[$tmpUid][$tmpExtVar . '.']) &&
+                                is_array($basketExt[$tmpUid][$tmpExtVar . '.'])
+                            ) {
+                                $basketExtNew[$tmpUid][$tmpExtVar . '.'] = $basketExt[$tmpUid][$tmpExtVar . '.'];
+                            }
+                        } else if (is_array($tmpCount)) {
+                            $basketExtNew[$tmpUid][$tmpExtVar] = $tmpCount;
+                        } else {
+                            // nothing
+                        }
+                    }
+                } else {
+                    $basketExtNew[$tmpUid] = $tmpSubArr;
+                }
+            }
+            $basketExt = $basketExtNew;
 
-			if ($bStoreBasket) {
+            if ($bStoreBasket) {
 
-				if (is_array($basketExt) && count($basketExt)) {
-					tx_ttproducts_control_basket::storeBasketExt($basketExt);
-				} else {
-					tx_ttproducts_control_basket::storeBasketExt([]);
-				}
-			}
-		}
+                if (is_array($basketExt) && count($basketExt)) {
+                    tx_ttproducts_control_basket::storeBasketExt($basketExt);
+                } else {
+                    tx_ttproducts_control_basket::storeBasketExt([]);
+                }
+            }
+        }
 
-		tx_ttproducts_control_basket::setBasketExt($basketExt);
+        tx_ttproducts_control_basket::setBasketExt($basketExt);
 
-		return true;
-	} // init
-
-
-	public function setCategoryQuantity ($categoryQuantity) {
-		$this->categoryQuantity = $categoryQuantity;
-	}
+        return true;
+    } // init
 
 
-	public function getCategoryQuantity () {
-		return $this->categoryQuantity;
-	}
+    public function setCategoryQuantity ($categoryQuantity) {
+        $this->categoryQuantity = $categoryQuantity;
+    }
 
 
-	public function setCategoryArray ($categoryArray) {
-		$this->categoryArray = $categoryArray;
-	}
+    public function getCategoryQuantity () {
+        return $this->categoryQuantity;
+    }
 
 
-	public function getCategoryArray () {
-		return $this->categoryArray;
-	}
+    public function setCategoryArray ($categoryArray) {
+        $this->categoryArray = $categoryArray;
+    }
 
 
-	public function getRecs () {
-		return $this->recs;
-	}
+    public function getCategoryArray () {
+        return $this->categoryArray;
+    }
 
 
-	public function getAllVariants ($funcTablename, $row, $variantRow) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTable = $tablesObj->get($funcTablename);
+    public function getRecs () {
+        return $this->recs;
+    }
+
+
+    public function getAllVariants ($funcTablename, $row, $variantRow) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTable = $tablesObj->get($funcTablename);
 
 // 		$variant = $itemTable->variant->getVariantFromRawRow($row);
-		$variant = $itemTable->variant->getVariantFromProductRow($row, $variantRow, $cnfObj->getUseArticles());
+        $variant = $itemTable->variant->getVariantFromProductRow($row, $variantRow, $cnfObj->getUseArticles());
 
-		$editVariant = $itemTable->editVariant->getVariantFromRawRow($row);
-		$allVariants = $variant . ($editVariant != '' ? '|editVariant:' . $editVariant : '');
+        $editVariant = $itemTable->editVariant->getVariantFromRawRow($row);
+        $allVariants = $variant . ($editVariant != '' ? '|editVariant:' . $editVariant : '');
 
-		return $allVariants;
-	}
-
-
-	public function checkEditVariants () {
-		$funcTablename = tx_ttproducts_control_basket::getFuncTablename();
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTable = $tablesObj->get($funcTablename);
-		$result = [];
-		$itemArray = $this->getItemArray();
-
-		foreach ($itemArray as $sort => $actItemArray) {
-			foreach ($actItemArray as $k1 => $actItem) {
-				$row = $actItem['rec'];
-				$editConfig = $itemTable->editVariant->getValidConfig($row);
-				$validEditVariant = true;
-
-				if (is_array($editConfig)) {
-					$validEditVariant = $itemTable->editVariant->checkValid($editConfig, $row);
-				}
-
-				if ($validEditVariant !== true) {
-					$result[$row['uid']] =
-						[
-							'rec' => $row,
-							'index1' => $sort,
-							'index2' => $k1,
-							'error' => $validEditVariant
-						];
-				}
-			}
-		}
-
-		if (empty($result)) {
-			$result = true;
-		}
-
-		return $result;
-	}
+        return $allVariants;
+    }
 
 
-	public function removeEditVariants ($removeArray) {
-		$modified = false;
-		$itemArray = $this->getItemArray();
- 		$removeBasketExt = [];
+    public function checkEditVariants () {
+        $funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTable = $tablesObj->get($funcTablename);
+        $result = [];
+        $itemArray = $this->getItemArray();
 
-		if (is_array($removeArray)) {
-			foreach ($removeArray as $uid => $removePart) {
-				if (
-					isset($removePart['index1']) &&
-					isset($removePart['index2']) &&
-					isset($itemArray[$removePart['index1']][$removePart['index2']]) &&
-					isset($removePart['rec'])
-				) {
-					unset($itemArray[$removePart['index1']][$removePart['index2']]);
+        foreach ($itemArray as $sort => $actItemArray) {
+            foreach ($actItemArray as $k1 => $actItem) {
+                $row = $actItem['rec'];
+                $editConfig = $itemTable->editVariant->getValidConfig($row);
+                $validEditVariant = true;
 
-					$row = $removePart['rec'];
-					$extArray = $row['ext'] ?? [];
-					$extVarLine = $extArray['extVarLine'];
-					$removeBasketExt[$uid][$extVarLine] = true;
-					$modified = true;
-				}
-			}
-		}
+                if (is_array($editConfig)) {
+                    $validEditVariant = $itemTable->editVariant->checkValid($editConfig, $row);
+                }
 
-		if ($modified) {
-			$this->setItemArray($itemArray);
-			tx_ttproducts_control_basket::removeFromBasketExt($removeBasketExt);
-		}
-	}
+                if ($validEditVariant !== true) {
+                    $result[$row['uid']] =
+                        [
+                            'rec' => $row,
+                            'index1' => $sort,
+                            'index2' => $k1,
+                            'error' => $validEditVariant
+                        ];
+                }
+            }
+        }
+
+        if (empty($result)) {
+            $result = true;
+        }
+
+        return $result;
+    }
 
 
-	public function getRadioInputArray (
-		$row
-	) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$basketConf = $cnfObj->getBasketConf('view', 'input');
-		$result = false;
-		if (!empty($basketConf)) {
-			foreach ($basketConf as $lineNo => $inputConf) {
-				if (strpos($lineNo, '.') !== false)	{
-					$bIsValid = tx_ttproducts_sql::isValid($row, $inputConf['where']);
-					if ($bIsValid && $inputConf['type'] == 'radio') {
-						$result = $inputConf;
-					}
-				}
-			}
-		}
-		return $result;
-	}
+    public function removeEditVariants ($removeArray) {
+        $modified = false;
+        $itemArray = $this->getItemArray();
+        $removeBasketExt = [];
 
-	public function setItemArray ($itemArray) {
-		$this->itemArray = $itemArray;
-	}
+        if (is_array($removeArray)) {
+            foreach ($removeArray as $uid => $removePart) {
+                if (
+                    isset($removePart['index1']) &&
+                    isset($removePart['index2']) &&
+                    isset($itemArray[$removePart['index1']][$removePart['index2']]) &&
+                    isset($removePart['rec'])
+                ) {
+                    unset($itemArray[$removePart['index1']][$removePart['index2']]);
 
-	public function getItemArray () {
-		return $this->itemArray;
-	}
+                    $row = $removePart['rec'];
+                    $extArray = $row['ext'] ?? [];
+                    $extVarLine = $extArray['extVarLine'];
+                    $removeBasketExt[$uid][$extVarLine] = true;
+                    $modified = true;
+                }
+            }
+        }
 
-	public function isEmpty () {
-		$itemArray = $this->getItemArray();
-		$result = empty($itemArray);
-		return $result;
-	}
+        if ($modified) {
+            $this->setItemArray($itemArray);
+            tx_ttproducts_control_basket::removeFromBasketExt($removeBasketExt);
+        }
+    }
 
-	public function addItem (
-		$viewTableObj,
-		$uid,
-		$externalVariant,
-		$damUid,
-		$item,
-		$updateMode,
-		&$basketExt,
-		$bStoreBasket,
-		$newGiftData,
-		$identGiftnumber,
-		$sameGiftData
-	) {
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
 
-		// quantities for single values are stored in an array. This is necessary because a HTML checkbox does not send any values if it has been unchecked
-		if (
-			isset($item) &&
-			is_array($item) &&
-			isset($item['quantity']) &&
-			is_array($item['quantity'])
-		) {
-			reset($item['quantity']);
-			$item['quantity'] = current($item['quantity']);
-		}
+    public function getRadioInputArray (
+        $row
+    ) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $basketConf = $cnfObj->getBasketConf('view', 'input');
+        $result = false;
+        if (!empty($basketConf)) {
+            foreach ($basketConf as $lineNo => $inputConf) {
+                if (strpos($lineNo, '.') !== false)	{
+                    $bIsValid = tx_ttproducts_sql::isValid($row, $inputConf['where']);
+                    if ($bIsValid && $inputConf['type'] == 'radio') {
+                        $result = $inputConf;
+                    }
+                }
+            }
+        }
+        return $result;
+    }
 
-		if ($updateMode) {
-			foreach($item as $md5 => $quantity) {
-				$quantity = $priceObj->toNumber($this->conf['quantityIsFloat'], $quantity);
+    public function setItemArray ($itemArray) {
+        $this->itemArray = $itemArray;
+    }
 
-				if (
+    public function getItemArray () {
+        return $this->itemArray;
+    }
+
+    public function isEmpty () {
+        $itemArray = $this->getItemArray();
+        $result = empty($itemArray);
+        return $result;
+    }
+
+    public function addItem (
+        $viewTableObj,
+        $uid,
+        $externalVariant,
+        $damUid,
+        $item,
+        $updateMode,
+        &$basketExt,
+        $bStoreBasket,
+        $newGiftData,
+        $identGiftnumber,
+        $sameGiftData
+    ) {
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+
+        // quantities for single values are stored in an array. This is necessary because a HTML checkbox does not send any values if it has been unchecked
+        if (
+            isset($item) &&
+            is_array($item) &&
+            isset($item['quantity']) &&
+            is_array($item['quantity'])
+        ) {
+            reset($item['quantity']);
+            $item['quantity'] = current($item['quantity']);
+        }
+
+        if ($updateMode) {
+            foreach($item as $md5 => $quantity) {
+                $quantity = $priceObj->toNumber($this->conf['quantityIsFloat'], $quantity);
+
+                if (
                     isset($basketExt[$uid]) &&
                     is_array($basketExt[$uid]) &&
                     $md5 != 'additional'
                 ) {
-					foreach($basketExt[$uid] as $allVariants => $tmp) {
-						$actMd5 = md5($allVariants);
+                    foreach($basketExt[$uid] as $allVariants => $tmp) {
+                        $actMd5 = md5($allVariants);
 
-							// useArticles if you have different prices and therefore articles for color, size, additional and gradings
-						if ($actMd5 == $md5) {
-							$count = $this->getMaxCount($quantity, $uid);
-							$basketExt[$uid][$allVariants] = $count;
+                            // useArticles if you have different prices and therefore articles for color, size, additional and gradings
+                        if ($actMd5 == $md5) {
+                            $count = $this->getMaxCount($quantity, $uid);
+                            $basketExt[$uid][$allVariants] = $count;
 
-							if (isset($item['additional']) && is_array($item['additional']) &&
-							isset($item['additional'][$actMd5]['giftservice']) && is_array($item['additional'][$actMd5]['giftservice'])) {
-								if (isset($basketExt[$uid][$allVariants . '.']) && !is_array($basketExt[$uid][$allVariants . '.'])) {
-									$basketExt[$uid][$allVariants . '.'] = [];
-								}
+                            if (isset($item['additional']) && is_array($item['additional']) &&
+                            isset($item['additional'][$actMd5]['giftservice']) && is_array($item['additional'][$actMd5]['giftservice'])) {
+                                if (isset($basketExt[$uid][$allVariants . '.']) && !is_array($basketExt[$uid][$allVariants . '.'])) {
+                                    $basketExt[$uid][$allVariants . '.'] = [];
+                                }
 
-								if (isset($basketExt[$uid][$allVariants . '.']['additional']) && !is_array($basketExt[$uid][$allVariants . '.']['additional'])) {
-									$basketExt[$uid][$allVariants . '.']['additional'] = [];
-								}
-								$bHasGiftService = $item['additional'][$actMd5]['giftservice']['1'];
-								if ($bHasGiftService) {
-									$basketExt[$uid][$allVariants . '.']['additional']['giftservice'] = '1';
-								} else {
-									unset($basketExt[$uid][$allVariants . '.']);
-								}
-							}
+                                if (isset($basketExt[$uid][$allVariants . '.']['additional']) && !is_array($basketExt[$uid][$allVariants . '.']['additional'])) {
+                                    $basketExt[$uid][$allVariants . '.']['additional'] = [];
+                                }
+                                $bHasGiftService = $item['additional'][$actMd5]['giftservice']['1'];
+                                if ($bHasGiftService) {
+                                    $basketExt[$uid][$allVariants . '.']['additional']['giftservice'] = '1';
+                                } else {
+                                    unset($basketExt[$uid][$allVariants . '.']);
+                                }
+                            }
 
-							if (
+                            if (
                                 isset($basketExt['gift']) &&
                                 is_array($basketExt['gift'])
                             ) {
-								$count = count($basketExt['gift']);
-								$giftCount = 0;
-								$restQuantity = $quantity;
-								for ($giftnumber = 1; $giftnumber <= $count; ++$giftnumber) {
-									if ($restQuantity == 0) {
-										$this->removeGift($giftnumber, $uid, $allVariants);
-									} else {
-										if ($basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] > $restQuantity) {
-											$basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $restQuantity;
-											$restQuantity = 0;
-										} else if ($giftnumber < $count) {
-											$restQuantity -= $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants];
-										} else {
-											$basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $restQuantity;
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		} else {
-			if (!isset($item['quantity'])) {
-				return;
-			}
+                                $count = count($basketExt['gift']);
+                                $giftCount = 0;
+                                $restQuantity = $quantity;
+                                for ($giftnumber = 1; $giftnumber <= $count; ++$giftnumber) {
+                                    if ($restQuantity == 0) {
+                                        $this->removeGift($giftnumber, $uid, $allVariants);
+                                    } else {
+                                        if ($basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] > $restQuantity) {
+                                            $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $restQuantity;
+                                            $restQuantity = 0;
+                                        } else if ($giftnumber < $count) {
+                                            $restQuantity -= $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants];
+                                        } else {
+                                            $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $restQuantity;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            if (!isset($item['quantity'])) {
+                return;
+            }
 
-			$variant = $viewTableObj->variant->getVariantFromRawRow($item);
-			$editVariant = $viewTableObj->editVariant->getVariantFromRawRow($item);
-			$allVariants =
-				$variant .
-					($editVariant != '' ? '|editVariant:' . $editVariant : '') .
-					($externalVariant != '' ? '|records:' . $externalVariant : '');
+            $variant = $viewTableObj->variant->getVariantFromRawRow($item);
+            $editVariant = $viewTableObj->editVariant->getVariantFromRawRow($item);
+            $allVariants =
+                $variant .
+                    ($editVariant != '' ? '|editVariant:' . $editVariant : '') .
+                    ($externalVariant != '' ? '|records:' . $externalVariant : '');
 
-			if ($damUid) {
-				$tableVariant = $viewTableObj->variant->getTableUid('tx_dam', $damUid);
-				$allVariants .= $tableVariant;
-			}
-			$oldcount = $basketExt[$uid][$allVariants] ?? 0;
-			$quantity = 0;
-			$quantity = $priceObj->toNumber($this->conf['quantityIsFloat'], $item['quantity']);
-			$count = $this->getMaxCount($quantity, $uid);
+            if ($damUid) {
+                $tableVariant = $viewTableObj->variant->getTableUid('tx_dam', $damUid);
+                $allVariants .= $tableVariant;
+            }
+            $oldcount = $basketExt[$uid][$allVariants] ?? 0;
+            $quantity = 0;
+            $quantity = $priceObj->toNumber($this->conf['quantityIsFloat'], $item['quantity']);
+            $count = $this->getMaxCount($quantity, $uid);
 
-			if ($count >= 0 && $bStoreBasket) {
-				$newcount = $count;
+            if ($count >= 0 && $bStoreBasket) {
+                $newcount = $count;
 
-				if ($newGiftData) {
-					$giftnumber = 0;
-					if ($sameGiftData) {
-						$giftnumber = $identGiftnumber;
-						$oldcount -= $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants];
-					} else {
-						$giftnumber = $this->giftnumber;
-					}
-					$newcount += $oldcount;
-					$basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $count;
-					if ($count == 0) {
-						$this->removeGift($giftnumber, $uid, $allVariants);
-					}
-				}
+                if ($newGiftData) {
+                    $giftnumber = 0;
+                    if ($sameGiftData) {
+                        $giftnumber = $identGiftnumber;
+                        $oldcount -= $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants];
+                    } else {
+                        $giftnumber = $this->giftnumber;
+                    }
+                    $newcount += $oldcount;
+                    $basketExt['gift'][$giftnumber]['item'][$uid][$allVariants] = $count;
+                    if ($count == 0) {
+                        $this->removeGift($giftnumber, $uid, $allVariants);
+                    }
+                }
 
-				if ($newcount) {
-					if ($this->conf['alwaysUpdateOrderAmount'] == 1) {
-						$basketExt[$uid][$allVariants] = $newcount;
-					} else {
-						$basketExt[$uid][$allVariants] = $oldcount + $newcount;
-					}
-				} else {
-					unset($basketExt[$uid][$allVariants]);
-				}
-			}
-		}
-	}
-
-
-	/**
-	 * Removes a gift from the basket
-	 *
-	 * @param		int		 index of the gift
-	 * @param 		int			uid of the product
-	 * @param		string		variant of the product
-	 * @return	  void
- 	 */
-	public function removeGift ($giftnumber, $uid, $variant) {
-
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-
-		if($basketExt['gift'][$giftnumber]['item'][$uid][$variant] >= 0) {
-			unset($basketExt['gift'][$giftnumber]['item'][$uid][$variant]);
-			if (!count($basketExt['gift'][$giftnumber]['item'][$uid])) {
-				unset($basketExt['gift'][$giftnumber]['item'][$uid]);
-			}
-			if (!($basketExt['gift'][$giftnumber]['item'])) {
-				unset($basketExt['gift'][$giftnumber]);
-			}
-		}
-
-		tx_ttproducts_control_basket::storeBasketExt($basketExt);
-	}
+                if ($newcount) {
+                    if ($this->conf['alwaysUpdateOrderAmount'] == 1) {
+                        $basketExt[$uid][$allVariants] = $newcount;
+                    } else {
+                        $basketExt[$uid][$allVariants] = $oldcount + $newcount;
+                    }
+                } else {
+                    unset($basketExt[$uid][$allVariants]);
+                }
+            }
+        }
+    }
 
 
-	public function getMaxCount ($quantity, $uid = 0) {
-		$count = 0;
+    /**
+     * Removes a gift from the basket
+     *
+     * @param		int		 index of the gift
+     * @param 		int			uid of the product
+     * @param		string		variant of the product
+     * @return	  void
+     */
+    public function removeGift ($giftnumber, $uid, $variant) {
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$prodTable = $tablesObj->get('tt_products');
-		$row = $prodTable->get($uid);
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
 
-		if($row['basketmaxquantity'] > 0 && $quantity > $row['basketmaxquantity']) {
-			$basketmaxquantity = MathUtility::convertToPositiveInteger($row['basketmaxquantity']);
-			$count = MathUtility::forceIntegerInRange($quantity, 0, $basketmaxquantity, 0);
-			$quantity = $count; // reduce the quantitiy to the product's maximum allowed quantity
-		}
+        if($basketExt['gift'][$giftnumber]['item'][$uid][$variant] >= 0) {
+            unset($basketExt['gift'][$giftnumber]['item'][$uid][$variant]);
+            if (!count($basketExt['gift'][$giftnumber]['item'][$uid])) {
+                unset($basketExt['gift'][$giftnumber]['item'][$uid]);
+            }
+            if (!($basketExt['gift'][$giftnumber]['item'])) {
+                unset($basketExt['gift'][$giftnumber]);
+            }
+        }
 
-		if (
-			$this->conf['basketMaxQuantity'] == 'inStock' &&
-			!$this->conf['alwaysInStock'] &&
-			!empty($uid)
-		) {
-			$count = MathUtility::forceIntegerInRange($quantity, 0, $row['inStock'], 0);
-		} elseif ($this->conf['basketMaxQuantity'] == 'creditpoint' && !empty($uid)) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
-			$missingCreditpoints = 0;
-			$creditpointsObj->getBasketMissingCreditpoints($row['creditpoints'] * $quantity, $missingCreditpoints, $tmp);
-
-			if ($quantity > 1 && $missingCreditpoints > 0) {
-				$reduceQuantity = intval($missingCreditpoints / $row['creditpoints']);
-				if ($missingCreditpoints > $reduceQuantity * $row['creditpoints']) {
-					$reduceQuantity += 1;
-				}
-				if ($quantity - $reduceQuantity >= 1) {
-					$count = $quantity - $reduceQuantity;
-				} else {
-					$count = 0;
-				}
-			} else {
-				$count = ($missingCreditpoints > 0 ? 0 : $quantity);
-			}
-		} elseif ($this->conf['quantityIsFloat']) {
-			$count = (float) $quantity;
-			if ($count < 0) {
-				$count = 0;
-			}
-			if ($count > $this->conf['basketMaxQuantity']) {
-				$count = $this->conf['basketMaxQuantity'];
-			}
-		} else {
-			$count = MathUtility::forceIntegerInRange($quantity, 0, $this->conf['basketMaxQuantity'], 0);
-		}
-
-		return $count;
-	}
+        tx_ttproducts_control_basket::storeBasketExt($basketExt);
+    }
 
 
-	/**
-	 * Returns a clear 'recs[tt_products]' array - so clears the basket.
-	 */
-	public function getClearBasketRecord () {
+    public function getMaxCount ($quantity, $uid = 0) {
+        $count = 0;
 
-			// Returns a basket-record cleared of tt_product items
-		unset($this->recs['tt_products']);
-		unset($this->recs['personinfo']);
-		unset($this->recs['delivery']);
-		unset($this->recs['creditcard']);
-		unset($this->recs['account']);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $prodTable = $tablesObj->get('tt_products');
+        $row = $prodTable->get($uid);
 
-		return ($this->recs);
-	} // getClearBasketRecord
+        if($row['basketmaxquantity'] > 0 && $quantity > $row['basketmaxquantity']) {
+            $basketmaxquantity = MathUtility::convertToPositiveInteger($row['basketmaxquantity']);
+            $count = MathUtility::forceIntegerInRange($quantity, 0, $basketmaxquantity, 0);
+            $quantity = $count; // reduce the quantitiy to the product's maximum allowed quantity
+        }
 
+        if (
+            $this->conf['basketMaxQuantity'] == 'inStock' &&
+            !$this->conf['alwaysInStock'] &&
+            !empty($uid)
+        ) {
+            $count = MathUtility::forceIntegerInRange($quantity, 0, $row['inStock'], 0);
+        } elseif ($this->conf['basketMaxQuantity'] == 'creditpoint' && !empty($uid)) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
+            $missingCreditpoints = 0;
+            $creditpointsObj->getBasketMissingCreditpoints($row['creditpoints'] * $quantity, $missingCreditpoints, $tmp);
 
-	/**
-	 * Empties the shopping basket!
-	 */
-	public function clearBasket ($bForce = false) {
-		if (
-			$this->conf['debug'] != '1' ||
-			$bForce
-		) {
-			// TODO: delete only records from relevant pages
-				// Empties the shopping basket!
-			$basketRecord = $this->getClearBasketRecord();
-			tx_ttproducts_control_basket::setRecs($basketRecord);
-			tx_ttproducts_control_basket::store('recs', $basketRecord);
-			tx_ttproducts_control_basket::setBasketExt([]);
-			tx_ttproducts_control_basket::store('basketExt', []);
-			tx_ttproducts_control_basket::store('order', []);
-			$this->setItemArray([]);
+            if ($quantity > 1 && $missingCreditpoints > 0) {
+                $reduceQuantity = intval($missingCreditpoints / $row['creditpoints']);
+                if ($missingCreditpoints > $reduceQuantity * $row['creditpoints']) {
+                    $reduceQuantity += 1;
+                }
+                if ($quantity - $reduceQuantity >= 1) {
+                    $count = $quantity - $reduceQuantity;
+                } else {
+                    $count = 0;
+                }
+            } else {
+                $count = ($missingCreditpoints > 0 ? 0 : $quantity);
+            }
+        } elseif ($this->conf['quantityIsFloat']) {
+            $count = (float) $quantity;
+            if ($count < 0) {
+                $count = 0;
+            }
+            if ($count > $this->conf['basketMaxQuantity']) {
+                $count = $this->conf['basketMaxQuantity'];
+            }
+        } else {
+            $count = MathUtility::forceIntegerInRange($quantity, 0, $this->conf['basketMaxQuantity'], 0);
+        }
 
-		}
-		tx_ttproducts_control_basket::store('ac', []);
-		tx_ttproducts_control_basket::store('cc', []);
-		tx_ttproducts_control_basket::store('cp', []);
-		tx_ttproducts_control_basket::store('vo', []);
-	} // clearBasket
-
-
-	public function isInBasket ($prod_uid) {
-		$rc = false;
-		$itemArray = $this->getItemArray();
-		if (count($itemArray)) {
-			// loop over all items in the basket indexed by a sort string
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					if ($prod_uid == $row['uid']) {
-						$rc = true;
-						break;
-					}
-				}
-				if ($rc == true) {
-					break;
-				}
-			}
-		}
-		return $rc;
-	}
+        return $count;
+    }
 
 
-	// get gradutated prices for all products in a list view or a single product in a single view
+    /**
+     * Returns a clear 'recs[tt_products]' array - so clears the basket.
+     */
+    public function getClearBasketRecord () {
+
+            // Returns a basket-record cleared of tt_product items
+        unset($this->recs['tt_products']);
+        unset($this->recs['personinfo']);
+        unset($this->recs['delivery']);
+        unset($this->recs['creditcard']);
+        unset($this->recs['account']);
+
+        return ($this->recs);
+    } // getClearBasketRecord
+
+
+    /**
+     * Empties the shopping basket!
+     */
+    public function clearBasket ($bForce = false) {
+        if (
+            $this->conf['debug'] != '1' ||
+            $bForce
+        ) {
+            // TODO: delete only records from relevant pages
+                // Empties the shopping basket!
+            $basketRecord = $this->getClearBasketRecord();
+            tx_ttproducts_control_basket::setRecs($basketRecord);
+            tx_ttproducts_control_basket::store('recs', $basketRecord);
+            tx_ttproducts_control_basket::setBasketExt([]);
+            tx_ttproducts_control_basket::store('basketExt', []);
+            tx_ttproducts_control_basket::store('order', []);
+            $this->setItemArray([]);
+
+        }
+        tx_ttproducts_control_basket::store('ac', []);
+        tx_ttproducts_control_basket::store('cc', []);
+        tx_ttproducts_control_basket::store('cp', []);
+        tx_ttproducts_control_basket::store('vo', []);
+    } // clearBasket
+
+
+    public function isInBasket ($prod_uid) {
+        $rc = false;
+        $itemArray = $this->getItemArray();
+        if (count($itemArray)) {
+            // loop over all items in the basket indexed by a sort string
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    if ($prod_uid == $row['uid']) {
+                        $rc = true;
+                        break;
+                    }
+                }
+                if ($rc == true) {
+                    break;
+                }
+            }
+        }
+        return $rc;
+    }
+
+
+    // get gradutated prices for all products in a list view or a single product in a single view
 // 	public function getGraduatedPrices ($uid)	{
 // 		$graduatedPriceObj = GeneralUtility::makeInstance('tx_ttproducts_graduated_price');
 // 		$this->formulaArray = $graduatedPriceObj->getFormulasByItem($uid);
 // 	}
 
 
-	public function get ($uid, $variant) {
-		$rc = [];
-		$itemArray = $this->getItemArray();
-		foreach ($itemArray as $sort => $actItemArray) {
-			foreach ($actItemArray as $k1 => $actItem) {
-				$row = $actItem['rec'];
-				if (
-					$row['uid'] == $uid &&
-					isset($row['ext']) &&
-					is_array($row['ext']) &&
-					isset($row['ext']['tt_products']) &&
-					is_array($row['ext']['tt_products'])
-				)  {
-					$extVarArray = $row['ext']['tt_products'][0];
-					if (
-						$extVarArray['uid'] == $uid &&
-						$extVarArray['vars'] == $variant
-					) {
-						$rc = $row;
-					}
-				}
-			}
-		}
-		return $rc;
-	}
+    public function get ($uid, $variant) {
+        $rc = [];
+        $itemArray = $this->getItemArray();
+        foreach ($itemArray as $sort => $actItemArray) {
+            foreach ($actItemArray as $k1 => $actItem) {
+                $row = $actItem['rec'];
+                if (
+                    $row['uid'] == $uid &&
+                    isset($row['ext']) &&
+                    is_array($row['ext']) &&
+                    isset($row['ext']['tt_products']) &&
+                    is_array($row['ext']['tt_products'])
+                )  {
+                    $extVarArray = $row['ext']['tt_products'][0];
+                    if (
+                        $extVarArray['uid'] == $uid &&
+                        $extVarArray['vars'] == $variant
+                    ) {
+                        $rc = $row;
+                    }
+                }
+            }
+        }
+        return $rc;
+    }
 
 
-	public function getUidArray () {
-		return $this->uidArray;
-	}
+    public function getUidArray () {
+        return $this->uidArray;
+    }
 
 
-	public function setUidArray ($uidArray) {
-		$this->uidArray = $uidArray;
-	}
+    public function setUidArray ($uidArray) {
+        $this->uidArray = $uidArray;
+    }
 
 
-	public function getQuantityArray ($uidArray, &$rowArray) {
-		$rc = [];
-		$itemArray = $this->getItemArray();
+    public function getQuantityArray ($uidArray, &$rowArray) {
+        $rc = [];
+        $itemArray = $this->getItemArray();
 
-		if (isset($rowArray) && is_array($rowArray)) {
-			// loop over all items in the basket indexed by a sort string
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
+        if (isset($rowArray) && is_array($rowArray)) {
+            // loop over all items in the basket indexed by a sort string
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
 
-					$row = $actItem['rec'];
-					$uid = $row['uid'];
-					$count = $actItem['count'];
-					$extArray = $row['ext'] ?? [];
+                    $row = $actItem['rec'];
+                    $uid = $row['uid'];
+                    $count = $actItem['count'];
+                    $extArray = $row['ext'] ?? [];
 
-					if (
-						in_array($uid, $uidArray) &&
-						isset($extArray) &&
-						is_array($extArray) &&
-						isset($extArray) &&
-						is_array($extArray)
-					) {
-						foreach ($rowArray as $functablename => $functableRowArray) {
-							$subExtArray = $extArray[$functablename];
-							if (isset($subExtArray) && is_array($subExtArray)) {
-								foreach ($functableRowArray as $subRow) {
-									$extItem = ['uid' => $subRow['uid']];
-									if (in_array($extItem, $subExtArray)) {
-										$rc[$uid][$functablename][$subRow['uid']] = $actItem['count'];
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		return $rc;
-	}
+                    if (
+                        in_array($uid, $uidArray) &&
+                        isset($extArray) &&
+                        is_array($extArray) &&
+                        isset($extArray) &&
+                        is_array($extArray)
+                    ) {
+                        foreach ($rowArray as $functablename => $functableRowArray) {
+                            $subExtArray = $extArray[$functablename];
+                            if (isset($subExtArray) && is_array($subExtArray)) {
+                                foreach ($functableRowArray as $subRow) {
+                                    $extItem = ['uid' => $subRow['uid']];
+                                    if (in_array($extItem, $subExtArray)) {
+                                        $rc[$uid][$functablename][$subRow['uid']] = $actItem['count'];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return $rc;
+    }
 
 
-	public function getItem ( // ToDo: Den Preis aus dem Download und der PDF Datei berücksichtigen
-		$basketExt,
-		$basketExtra,
-		$basketRecs,
-		$row, // must come from table tt_products
-		$fetchMode,
-		$funcTablename = '',
-		$externalRowArray = [], // Download
-		$bEnableTaxZero = false
-	) {
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
-		$pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
+    public function getItem ( // ToDo: Den Preis aus dem Download und der PDF Datei berücksichtigen
+        $basketExt,
+        $basketExtra,
+        $basketRecs,
+        $row, // must come from table tt_products
+        $fetchMode,
+        $funcTablename = '',
+        $externalRowArray = [], // Download
+        $bEnableTaxZero = false
+    ) {
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
 
-		$prodFuncTablename = 'tt_products';
-		$roundFormat = tx_ttproducts_control_basket::getRoundFormat();
-		$discountRoundFormat = tx_ttproducts_control_basket::getRoundFormat('discount');
+        $prodFuncTablename = 'tt_products';
+        $roundFormat = tx_ttproducts_control_basket::getRoundFormat();
+        $discountRoundFormat = tx_ttproducts_control_basket::getRoundFormat('discount');
 
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$pricetablescalc = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $pricetablescalc = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
 
-		$priceRow = $row;
-		$recordPrice = 0;
-		$articleDiscountPrice = 0;
-		$extArray = $row['ext'] ?? [];
+        $priceRow = $row;
+        $recordPrice = 0;
+        $articleDiscountPrice = 0;
+        $extArray = $row['ext'] ?? [];
 
-		if (!$funcTablename) {
-			$funcTablename = tx_ttproducts_control_basket::getFuncTablename();
-		}
+        if (!$funcTablename) {
+            $funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+        }
 
-		$item = [];
+        $item = [];
 
-		$viewTableObj = $tablesObj->get($prodFuncTablename);
-		$variant = '';
+        $viewTableObj = $tablesObj->get($prodFuncTablename);
+        $variant = '';
 
-		if ($fetchMode == 'useExt') {
-			$variant = $viewTableObj->getVariant()->getVariantFromRow($row);
-			$priceRow =
-				$viewTableObj->getRowFromExt(
-					$prodFuncTablename,
-					$row,
-					$cnfObj->getUseArticles(),
-					false
-				);
-		} else if ($fetchMode == 'rawRow') {
-			$variant = $viewTableObj->getVariant()->getVariantFromRawRow($row);
-		} else if ($fetchMode == 'firstVariant') {
+        if ($fetchMode == 'useExt') {
+            $variant = $viewTableObj->getVariant()->getVariantFromRow($row);
+            $priceRow =
+                $viewTableObj->getRowFromExt(
+                    $prodFuncTablename,
+                    $row,
+                    $cnfObj->getUseArticles(),
+                    false
+                );
+        } else if ($fetchMode == 'rawRow') {
+            $variant = $viewTableObj->getVariant()->getVariantFromRawRow($row);
+        } else if ($fetchMode == 'firstVariant') {
 
             $variantRow = $viewTableObj->getVariant()->getVariantRow($row, []);
-			$variant =
-				$viewTableObj->getVariant()->getVariantFromProductRow(
-					$row,
-					$variantRow,
-					$cnfObj->getUseArticles()
-				);
-		} else {
-			debug ($tmp, 'internal error in tt_products method getItem'); // keep this
-		}
-		$totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
-		$viewTableObj->getTotalDiscount($row, tx_ttproducts_control_basket::getPidListObj()->getPidlist());
-		if (isset($row[$totalDiscountField])) {
-			$priceRow[$totalDiscountField] = $row[$totalDiscountField];
-		}
+            $variant =
+                $viewTableObj->getVariant()->getVariantFromProductRow(
+                    $row,
+                    $variantRow,
+                    $cnfObj->getUseArticles()
+                );
+        } else {
+            debug ($tmp, 'internal error in tt_products method getItem'); // keep this
+        }
+        $totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
+        $viewTableObj->getTotalDiscount($row, tx_ttproducts_control_basket::getPidListObj()->getPidlist());
+        if (isset($row[$totalDiscountField])) {
+            $priceRow[$totalDiscountField] = $row[$totalDiscountField];
+        }
 
-		if (
-			$funcTablename != 'tt_products' &&
-			isset($externalRowArray) &&
-			is_array($externalRowArray) &&
-			!empty($externalRowArray)
-		) {
-			$newPrice = $priceRow['price'];
-			$priceIsModified = \JambageCom\TtProducts\Api\BasketApi::getRecordvariantAndPriceFromRows(
-				$recordVariant,
-				$newPrice,
-				$externalUidArray,
-				$externalRowArray
-			);
-			if ($priceIsModified) {
-				$recordPrice = $priceRow['price'] = $newPrice;
-			}
-			$variant .= $recordVariant;
-		}
+        if (
+            $funcTablename != 'tt_products' &&
+            isset($externalRowArray) &&
+            is_array($externalRowArray) &&
+            !empty($externalRowArray)
+        ) {
+            $newPrice = $priceRow['price'];
+            $priceIsModified = \JambageCom\TtProducts\Api\BasketApi::getRecordvariantAndPriceFromRows(
+                $recordVariant,
+                $newPrice,
+                $externalUidArray,
+                $externalRowArray
+            );
+            if ($priceIsModified) {
+                $recordPrice = $priceRow['price'] = $newPrice;
+            }
+            $variant .= $recordVariant;
+        }
 
-		if (isset($extArray['tx_dam']) && is_array($extArray['tx_dam'])) {
-			reset($extArray['tx_dam']);
-			$firstDam = current($extArray['tx_dam']);
-			$extUid = $firstDam['uid'];
-			$tableVariant =
-				$viewTableObj->variant->getTableUid(
-					'tx_dam',
-					$extUid
-				);
-			$variant .= $tableVariant;
-		}
+        if (isset($extArray['tx_dam']) && is_array($extArray['tx_dam'])) {
+            reset($extArray['tx_dam']);
+            $firstDam = current($extArray['tx_dam']);
+            $extUid = $firstDam['uid'];
+            $tableVariant =
+                $viewTableObj->variant->getTableUid(
+                    'tx_dam',
+                    $extUid
+                );
+            $variant .= $tableVariant;
+        }
 
-		if (isset($extArray['editVariant'])) {
-			$variant .= '|' . $extArray['editVariant'];
-		}
+        if (isset($extArray['editVariant'])) {
+            $variant .= '|' . $extArray['editVariant'];
+        }
 
-		$count =
-			tx_ttproducts_control_basket::getBasketCount(
-				$row,
-				$variant,
-				$this->conf['quantityIsFloat']
-			);
+        $count =
+            tx_ttproducts_control_basket::getBasketCount(
+                $row,
+                $variant,
+                $this->conf['quantityIsFloat']
+            );
 
-		if (
-			!$count &&
-			is_array($this->giftServiceRow) &&
-			$row['uid'] == $this->giftServiceRow['uid']
-		) {
-			$count = 1;
-		}
+        if (
+            !$count &&
+            is_array($this->giftServiceRow) &&
+            $row['uid'] == $this->giftServiceRow['uid']
+        ) {
+            $count = 1;
+        }
 
-		if (
-			$count > $priceRow['inStock'] &&
-			!$this->conf['alwaysInStock']
-		) {
-			$count = $priceRow['inStock'];
-		}
+        if (
+            $count > $priceRow['inStock'] &&
+            !$this->conf['alwaysInStock']
+        ) {
+            $count = $priceRow['inStock'];
+        }
 
-		if (!$this->conf['quantityIsFloat']) {
-			$count = intval($count);
-		}
+        if (!$this->conf['quantityIsFloat']) {
+            $count = intval($count);
+        }
 
-		if (
-			isset($priceRow['ext']) &&
-			isset($priceRow['ext']['tt_products_articles']) &&
-			is_array($priceRow['ext']['tt_products_articles'])
-		) {
-			$articleRowArray = $priceRow['ext']['tt_products_articles'];
-			$articleObj = $tablesObj->get('tt_products_articles', false);
-			$graduatedPriceObj = $articleObj->getGraduatedPriceObject();
-			$storedPrice = $priceRow['price'];
-			$priceRow['price'] = $row['price']; // undo former price additions from articles
-			if ($recordPrice) {
-				$priceRow['price'] = $recordPrice;
-			}
-			$previouslyAddedPrice = 0;
-			if (
-				isset($targetRow['ext']['addedPrice'])
-			) {
-				$previouslyAddedPrice = $priceRow['addedPrice'];
-			}
+        if (
+            isset($priceRow['ext']) &&
+            isset($priceRow['ext']['tt_products_articles']) &&
+            is_array($priceRow['ext']['tt_products_articles'])
+        ) {
+            $articleRowArray = $priceRow['ext']['tt_products_articles'];
+            $articleObj = $tablesObj->get('tt_products_articles', false);
+            $graduatedPriceObj = $articleObj->getGraduatedPriceObject();
+            $storedPrice = $priceRow['price'];
+            $priceRow['price'] = $row['price']; // undo former price additions from articles
+            if ($recordPrice) {
+                $priceRow['price'] = $recordPrice;
+            }
+            $previouslyAddedPrice = 0;
+            if (
+                isset($targetRow['ext']['addedPrice'])
+            ) {
+                $previouslyAddedPrice = $priceRow['addedPrice'];
+            }
 
-			$parentProductCount =
-				tx_ttproducts_control_basket::getBasketCount(
-					$row,
-					$variant,
-					$this->conf['quantityIsFloat'],
-					true
-				);
+            $parentProductCount =
+                tx_ttproducts_control_basket::getBasketCount(
+                    $row,
+                    $variant,
+                    $this->conf['quantityIsFloat'],
+                    true
+                );
 
-			foreach ($articleRowArray as $articleRow) {
-				if (
-					is_object($graduatedPriceObj) &&
-					$graduatedPriceObj->hasDiscountPrice($articleRow)
-				) {
-					$calculationCount = $count;
-					$usesParentProductCount = $articleObj->usesAddParentProductCount($articleRow);
-					if ($usesParentProductCount) {
-						$calculationCount = $parentProductCount;
-					}
+            foreach ($articleRowArray as $articleRow) {
+                if (
+                    is_object($graduatedPriceObj) &&
+                    $graduatedPriceObj->hasDiscountPrice($articleRow)
+                ) {
+                    $calculationCount = $count;
+                    $usesParentProductCount = $articleObj->usesAddParentProductCount($articleRow);
+                    if ($usesParentProductCount) {
+                        $calculationCount = $parentProductCount;
+                    }
 
-					$calculatedPrice =
-						$pricetablesCalculator->getDiscountPrice(
-							$graduatedPriceObj,
-							$articleRow,
-							$articleRow['price'],
-							$calculationCount
-						);
+                    $calculatedPrice =
+                        $pricetablesCalculator->getDiscountPrice(
+                            $graduatedPriceObj,
+                            $articleRow,
+                            $articleRow['price'],
+                            $calculationCount
+                        );
 
-					if ($calculatedPrice !== false) {
-						$articleRow[$calculationField] = $calculatedPrice;
-					}
-				}
+                    if ($calculatedPrice !== false) {
+                        $articleRow[$calculationField] = $calculatedPrice;
+                    }
+                }
 
-				$bIsAddedPrice = $cnfObj->hasConfig($articleRow, 'isAddedPrice');
+                $bIsAddedPrice = $cnfObj->hasConfig($articleRow, 'isAddedPrice');
 
-				\JambageCom\TtProducts\Api\PriceApi::mergeRows(
-					$priceRow,
-					$articleRow,
-					'price',
-					$bIsAddedPrice,
-					$previouslyAddedPrice,
-					$calculationField,
-					false,
-					true
-				);
-			}
+                \JambageCom\TtProducts\Api\PriceApi::mergeRows(
+                    $priceRow,
+                    $articleRow,
+                    'price',
+                    $bIsAddedPrice,
+                    $previouslyAddedPrice,
+                    $calculationField,
+                    false,
+                    true
+                );
+            }
 
-			$articleDiscountPrice = $priceRow['price'];
-			$priceRow[$calculationField] = $row[$calculationField] = $articleDiscountPrice;
-			$priceRow['price'] = $storedPrice;
-		}
+            $articleDiscountPrice = $priceRow['price'];
+            $priceRow[$calculationField] = $row[$calculationField] = $articleDiscountPrice;
+            $priceRow['price'] = $storedPrice;
+        }
 
         $graduatedPriceObj = $viewTableObj->getGraduatedPriceObject();
         if (
@@ -1088,448 +1088,448 @@ class tx_ttproducts_basket implements \TYPO3\CMS\Core\SingletonInterface {
             }
         }
 
-		$taxInfoArray = '';
-		$priceTaxArray = $priceObj->getPriceTaxArray(
-			$taxInfoArray,
-			$this->conf['discountPriceMode'] ?? '',
-			$basketExtra,
-			$basketRecs,
-			'price',
-			$roundFormat,
-			$discountRoundFormat,
-			$priceRow,
-			$totalDiscountField,
-			$bEnableTaxZero
-		);
-		$price2TaxArray = $priceObj->getPriceTaxArray(
-			$taxInfoArray,
-			$this->conf['discountPriceMode'] ?? '',
-			$basketExtra,
-			$basketRecs,
-			'price2',
-			$roundFormat,
-			$discountRoundFormat,
-			$priceRow,
-			$totalDiscountField,
-			$bEnableTaxZero
-		);
-		$priceTaxArray =
-			array_merge($priceTaxArray, $price2TaxArray);
+        $taxInfoArray = '';
+        $priceTaxArray = $priceObj->getPriceTaxArray(
+            $taxInfoArray,
+            $this->conf['discountPriceMode'] ?? '',
+            $basketExtra,
+            $basketRecs,
+            'price',
+            $roundFormat,
+            $discountRoundFormat,
+            $priceRow,
+            $totalDiscountField,
+            $bEnableTaxZero
+        );
+        $price2TaxArray = $priceObj->getPriceTaxArray(
+            $taxInfoArray,
+            $this->conf['discountPriceMode'] ?? '',
+            $basketExtra,
+            $basketRecs,
+            'price2',
+            $roundFormat,
+            $discountRoundFormat,
+            $priceRow,
+            $totalDiscountField,
+            $bEnableTaxZero
+        );
+        $priceTaxArray =
+            array_merge($priceTaxArray, $price2TaxArray);
 
-		$tax = $priceTaxArray['taxperc'];
-		$oldPriceTaxArray = $priceObj->convertOldPriceArray($priceTaxArray);
-		$depositArray = $priceObj->getPriceTaxArray(
-			$taxInfoArray,
-			'',
-			$basketExtra,
-			$basketRecs,
-			'deposit',
-			'',
-			'',
-			$priceRow,
-			''
-		);
+        $tax = $priceTaxArray['taxperc'];
+        $oldPriceTaxArray = $priceObj->convertOldPriceArray($priceTaxArray);
+        $depositArray = $priceObj->getPriceTaxArray(
+            $taxInfoArray,
+            '',
+            $basketExtra,
+            $basketRecs,
+            'deposit',
+            '',
+            '',
+            $priceRow,
+            ''
+        );
 
-		$priceObj->convertIntoRow($row, $priceTaxArray);
-		$item = array (
-			'count' => $count,
-			'weight' => $priceRow['weight'],
-			'totalTax' => 0,
-			'totalNoTax' => 0,
-			'tax' => $tax,
-			'rec' => $row,
-		);
+        $priceObj->convertIntoRow($row, $priceTaxArray);
+        $item = array (
+            'count' => $count,
+            'weight' => $priceRow['weight'],
+            'totalTax' => 0,
+            'totalNoTax' => 0,
+            'tax' => $tax,
+            'rec' => $row,
+        );
 
-		if (
-			isset($taxInfoArray) &&
-			is_array($taxInfoArray) &&
-			!empty($taxInfoArray)
-		) {
-			$item['taxInfo'] = $taxInfoArray;
-		}
+        if (
+            isset($taxInfoArray) &&
+            is_array($taxInfoArray) &&
+            !empty($taxInfoArray)
+        ) {
+            $item['taxInfo'] = $taxInfoArray;
+        }
 
-		$item = array_merge($item, $oldPriceTaxArray);	// Todo: remove this line
-		$item = array_merge($item, $depositArray);
+        $item = array_merge($item, $oldPriceTaxArray);	// Todo: remove this line
+        $item = array_merge($item, $depositArray);
 
-		if (
-			isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem']) &&
-			is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem'])
-		) {
-			foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'changeBasketItem')) {
-					$hookObj->changeBasketItem(
-						$row,
-						$fetchMode,
-						$prodFuncTablename,
-						$item
-					);
-				}
-			}
-		}
+        if (
+            isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem']) &&
+            is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem'])
+        ) {
+            foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['changeBasketItem'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'changeBasketItem')) {
+                    $hookObj->changeBasketItem(
+                        $row,
+                        $fetchMode,
+                        $prodFuncTablename,
+                        $item
+                    );
+                }
+            }
+        }
 
-		return $item;
-	} // getItem
+        return $item;
+    } // getItem
 
 
-	public function getItemRow (
-		array $row,
-		$bextVarLine,
-		$useArticles,
-		$funcTablename,
-		$mergeAttributeFields = true
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewTableObj = $tablesObj->get($funcTablename);
-		$variantSeparator = $viewTableObj->getVariant()->getSplitSeparator();
+    public function getItemRow (
+        array $row,
+        $bextVarLine,
+        $useArticles,
+        $funcTablename,
+        $mergeAttributeFields = true
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewTableObj = $tablesObj->get($funcTablename);
+        $variantSeparator = $viewTableObj->getVariant()->getSplitSeparator();
 
-		$uid = $row['uid'];
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $uid = $row['uid'];
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
 
-		$bextVarArray = GeneralUtility::trimExplode('|', $bextVarLine);
-		$bextVars = $bextVarArray[0];
-		$currRow = $row;
+        $bextVarArray = GeneralUtility::trimExplode('|', $bextVarLine);
+        $bextVars = $bextVarArray[0];
+        $currRow = $row;
 
-		if ($useArticles != 3) {
-			$viewTableObj->variant->modifyRowFromVariant(
-				$currRow,
-				$bextVars
-			);
-		}
+        if ($useArticles != 3) {
+            $viewTableObj->variant->modifyRowFromVariant(
+                $currRow,
+                $bextVars
+            );
+        }
 
-		$extTable = $funcTablename;
-		$extUid = $uid;
-		$extArray =
-			[
-				'uid' => $extUid,
-				'vars' => $bextVars
-			];
-		$currRow['ext'][$extTable][] = $extArray;
+        $extTable = $funcTablename;
+        $extUid = $uid;
+        $extArray =
+            [
+                'uid' => $extUid,
+                'vars' => $bextVars
+            ];
+        $currRow['ext'][$extTable][] = $extArray;
 
-		foreach ($bextVarArray as $k => $bextVar) {
+        foreach ($bextVarArray as $k => $bextVar) {
 
-			if (
-				strpos($bextVar, 'tx_dam') === 0 &&
-				isset($bextVarArray[$k + 1])
-			) {
-				$extTable = 'tx_dam';
-				$extUid = intval($bextVarArray[$k + 1]);
-				$damObj = $tablesObj->get('tx_dam');
-				$damObj->modifyItemRow($currRow, $extUid);
-				$currRow['ext'][$extTable][] = ['uid' => $extUid];
-			}
+            if (
+                strpos($bextVar, 'tx_dam') === 0 &&
+                isset($bextVarArray[$k + 1])
+            ) {
+                $extTable = 'tx_dam';
+                $extUid = intval($bextVarArray[$k + 1]);
+                $damObj = $tablesObj->get('tx_dam');
+                $damObj->modifyItemRow($currRow, $extUid);
+                $currRow['ext'][$extTable][] = ['uid' => $extUid];
+            }
 
-			if (strpos($bextVar, 'editVariant:') === 0) {
-				$editVariant = str_replace('editVariant:', '', $bextVar);
-				$variantArray =
-					preg_split(
-						'/[\h]*' . tx_ttproducts_variant_int::INTERNAL_VARIANT_SEPARATOR . '[\h]*/',
-						$editVariant,
-						-1,
-						PREG_SPLIT_NO_EMPTY
-					);
+            if (strpos($bextVar, 'editVariant:') === 0) {
+                $editVariant = str_replace('editVariant:', '', $bextVar);
+                $variantArray =
+                    preg_split(
+                        '/[\h]*' . tx_ttproducts_variant_int::INTERNAL_VARIANT_SEPARATOR . '[\h]*/',
+                        $editVariant,
+                        -1,
+                        PREG_SPLIT_NO_EMPTY
+                    );
 
-				$editVariantRow = [];
-				foreach ($variantArray as $variant) {
-					$parts = explode('=>', $variant);
-					if (
-						isset($parts) &&
-						is_array($parts) &&
-						count($parts) == 2
-					) {
-						$editVariantRow[$parts['0']] = $parts['1'];
-					}
-				}
-				$currRow = array_merge($currRow, $editVariantRow);
-				$currRow['ext']['editVariant'] = $bextVar;
-			}
+                $editVariantRow = [];
+                foreach ($variantArray as $variant) {
+                    $parts = explode('=>', $variant);
+                    if (
+                        isset($parts) &&
+                        is_array($parts) &&
+                        count($parts) == 2
+                    ) {
+                        $editVariantRow[$parts['0']] = $parts['1'];
+                    }
+                }
+                $currRow = array_merge($currRow, $editVariantRow);
+                $currRow['ext']['editVariant'] = $bextVar;
+            }
 
-			if (($pos = strpos($bextVar, 'records:')) === 0) {
-				$recordVariant = substr($bextVar, $pos + strlen('records:'));
-				$variantArray = explode(tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR, $recordVariant);
-				$recordVariantRow = [];
-				foreach ($variantArray as $variant) {
-					$parts = explode('=', $variant);
-					if (isset($parts) && is_array($parts) && count($parts) == 2) {
-						$funcTablename = tx_ttproducts_model_control::getParamsTable($parts['0']);
-						if ($funcTablename !== false) {
-							$localTableObj = $tablesObj->get($funcTablename);
-							$recordRow = $localTableObj->get(intval($parts['1']));
-							if (!empty($recordRow)) {
-								$recordVariantRow[$funcTablename] = $recordRow;
-							}
-						}
-					}
-				}
-				$currRow['ext']['records'] = $recordVariantRow;
-			}
-		}
-		// $currRow['extVars'] = $bextVars;
-		$currRow['ext']['extVarLine'] = $bextVarLine;
+            if (($pos = strpos($bextVar, 'records:')) === 0) {
+                $recordVariant = substr($bextVar, $pos + strlen('records:'));
+                $variantArray = explode(tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR, $recordVariant);
+                $recordVariantRow = [];
+                foreach ($variantArray as $variant) {
+                    $parts = explode('=', $variant);
+                    if (isset($parts) && is_array($parts) && count($parts) == 2) {
+                        $funcTablename = tx_ttproducts_model_control::getParamsTable($parts['0']);
+                        if ($funcTablename !== false) {
+                            $localTableObj = $tablesObj->get($funcTablename);
+                            $recordRow = $localTableObj->get(intval($parts['1']));
+                            if (!empty($recordRow)) {
+                                $recordVariantRow[$funcTablename] = $recordRow;
+                            }
+                        }
+                    }
+                }
+                $currRow['ext']['records'] = $recordVariantRow;
+            }
+        }
+        // $currRow['extVars'] = $bextVars;
+        $currRow['ext']['extVarLine'] = $bextVarLine;
 
-		if (
-			in_array($useArticles, [1, 3]) &&
-			$funcTablename == 'tt_products'
-		) {
-			// get the article uid with these colors, sizes and gradings
-			$articleRowArray = [];
+        if (
+            in_array($useArticles, [1, 3]) &&
+            $funcTablename == 'tt_products'
+        ) {
+            // get the article uid with these colors, sizes and gradings
+            $articleRowArray = [];
 
-			if ($useArticles == 1) {
-				$articleRow =
-					$viewTableObj->getArticleRow(
-						$currRow,
-						'BASKET',
-						false
-					);
+            if ($useArticles == 1) {
+                $articleRow =
+                    $viewTableObj->getArticleRow(
+                        $currRow,
+                        'BASKET',
+                        false
+                    );
 
-				if ($articleRow) {
-					$articleRowArray[] = $articleRow;
-				}
-			} else if ($useArticles == 3) {
-				$articleRowArray =
-					$viewTableObj->getArticleRowsFromVariant(
-						$currRow,
-						'BASKET',
-						$bextVars
-					);
-			}
+                if ($articleRow) {
+                    $articleRowArray[] = $articleRow;
+                }
+            } else if ($useArticles == 3) {
+                $articleRowArray =
+                    $viewTableObj->getArticleRowsFromVariant(
+                        $currRow,
+                        'BASKET',
+                        $bextVars
+                    );
+            }
 
-			if (
-				isset($articleRowArray) &&
-				is_array($articleRowArray) &&
-				count($articleRowArray)
-			) {
-				foreach ($articleRowArray as $articleRow) {
+            if (
+                isset($articleRowArray) &&
+                is_array($articleRowArray) &&
+                count($articleRowArray)
+            ) {
+                foreach ($articleRowArray as $articleRow) {
 
-						// use the fields of the article instead of the product
-					// $viewTableObj->mergeAttributeFields($currRow, $articleRow, false, true); Preis wird sonst doppelt addiert!
-					$currRow['ext']['tt_products_articles'][] = ['uid' => $articleRow['uid']];
-				}
-			}
-		} else if ($useArticles == 2) {
-			$productRow = $viewTableObj->getProductRow($currRow);
-			$viewTableObj->mergeAttributeFields(
-				$currRow,
-				$productRow,
-				true,
-				false,
-				true,
-				'',
-				false
-			);
-		}
+                        // use the fields of the article instead of the product
+                    // $viewTableObj->mergeAttributeFields($currRow, $articleRow, false, true); Preis wird sonst doppelt addiert!
+                    $currRow['ext']['tt_products_articles'][] = ['uid' => $articleRow['uid']];
+                }
+            }
+        } else if ($useArticles == 2) {
+            $productRow = $viewTableObj->getProductRow($currRow);
+            $viewTableObj->mergeAttributeFields(
+                $currRow,
+                $productRow,
+                true,
+                false,
+                true,
+                '',
+                false
+            );
+        }
 
-		if ($useArticles == 3) {
-			$viewTableObj->variant->modifyRowFromVariant(
-				$currRow,
-				$bextVars
-			);
-		}
+        if ($useArticles == 3) {
+            $viewTableObj->variant->modifyRowFromVariant(
+                $currRow,
+                $bextVars
+            );
+        }
 
-		if (
-			isset($articleRowArray) &&
-			is_array($articleRowArray)  &&
-			!empty($articleRowArray)
-		) {
-			$currRowTmp = $currRow; // this has turned out to be necessary!
-			$currRow['ext']['mergeArticles'] = $currRowTmp;
+        if (
+            isset($articleRowArray) &&
+            is_array($articleRowArray)  &&
+            !empty($articleRowArray)
+        ) {
+            $currRowTmp = $currRow; // this has turned out to be necessary!
+            $currRow['ext']['mergeArticles'] = $currRowTmp;
 
-			if ($mergeAttributeFields) {
-				$pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
-				$count =
-					tx_ttproducts_control_basket::getBasketCount(
-						$currRow,
-						$bextVarLine,
-						$this->conf['quantityIsFloat']
-					);
-				$parentProductCount =
-					tx_ttproducts_control_basket::getBasketCount(
-						$currRow,
-						$bextVarLine,
-						$this->conf['quantityIsFloat'],
-						true
-					);
-				$articleObj = $tablesObj->get('tt_products_articles', false);
-				$graduatedPriceObj = $articleObj->getGraduatedPriceObject();
+            if ($mergeAttributeFields) {
+                $pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
+                $count =
+                    tx_ttproducts_control_basket::getBasketCount(
+                        $currRow,
+                        $bextVarLine,
+                        $this->conf['quantityIsFloat']
+                    );
+                $parentProductCount =
+                    tx_ttproducts_control_basket::getBasketCount(
+                        $currRow,
+                        $bextVarLine,
+                        $this->conf['quantityIsFloat'],
+                        true
+                    );
+                $articleObj = $tablesObj->get('tt_products_articles', false);
+                $graduatedPriceObj = $articleObj->getGraduatedPriceObject();
 
-				foreach ($articleRowArray as $articleRow) {
-					if (
-						is_object($graduatedPriceObj) &&
-						$graduatedPriceObj->hasDiscountPrice($articleRow)
-					) {
-						$calculationCount = $count;
-						$usesParentProductCount = $articleObj->usesAddParentProductCount($articleRow);
-						if ($usesParentProductCount) {
-							$calculationCount = $parentProductCount;
-						}
+                foreach ($articleRowArray as $articleRow) {
+                    if (
+                        is_object($graduatedPriceObj) &&
+                        $graduatedPriceObj->hasDiscountPrice($articleRow)
+                    ) {
+                        $calculationCount = $count;
+                        $usesParentProductCount = $articleObj->usesAddParentProductCount($articleRow);
+                        if ($usesParentProductCount) {
+                            $calculationCount = $parentProductCount;
+                        }
 
-						$calculatedPrice =
-							$pricetablesCalculator->getDiscountPrice(
-								$graduatedPriceObj,
-								$articleRow,
-								$articleRow['price'],
-								$calculationCount
-							);
+                        $calculatedPrice =
+                            $pricetablesCalculator->getDiscountPrice(
+                                $graduatedPriceObj,
+                                $articleRow,
+                                $articleRow['price'],
+                                $calculationCount
+                            );
 
-						if ($calculatedPrice !== false) {
-							$articleRow[$calculationField] = $calculatedPrice;
-						}
-					}
-					$viewTableObj->mergeAttributeFields(
-						$currRow['ext']['mergeArticles'],
-						$articleRow,
-						false,
-						true,
-						true,
-						$calculationField,
-						false
-					);
-				}
-			}
-		}
+                        if ($calculatedPrice !== false) {
+                            $articleRow[$calculationField] = $calculatedPrice;
+                        }
+                    }
+                    $viewTableObj->mergeAttributeFields(
+                        $currRow['ext']['mergeArticles'],
+                        $articleRow,
+                        false,
+                        true,
+                        true,
+                        $calculationField,
+                        false
+                    );
+                }
+            }
+        }
 
-		return $currRow;
-	}
+        return $currRow;
+    }
 
-	public function create (
-		$theCode,
-		$basketExt,
-		$basketExtra,
-		$basketRecs,
-		$useArticles,
-		$priceTaxNotVarying,
-		$funcTablename
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->conf;
-		$itemTableConf = $cnfObj->getTableConf($funcTablename, $theCode);
-		$viewTableObj = $tablesObj->get($funcTablename, false);
-		$orderBy = $viewTableObj->getTableObj()->transformOrderby($itemTableConf['orderBy']);
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+    public function create (
+        $theCode,
+        $basketExt,
+        $basketExtra,
+        $basketRecs,
+        $useArticles,
+        $priceTaxNotVarying,
+        $funcTablename
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->conf;
+        $itemTableConf = $cnfObj->getTableConf($funcTablename, $theCode);
+        $viewTableObj = $tablesObj->get($funcTablename, false);
+        $orderBy = $viewTableObj->getTableObj()->transformOrderby($itemTableConf['orderBy']);
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
         $calculatedArray = [
             'count' => 0,
             'weight' => 0
         ];
-		$calculObj->setBaseCalculatedArray($calculatedArray);
+        $calculObj->setBaseCalculatedArray($calculatedArray);
 
-		$uidArr = [];
+        $uidArr = [];
 
-		foreach($basketExt as $uidTmp => $v) {
+        foreach($basketExt as $uidTmp => $v) {
 
-			if ($uidTmp != 'gift' && !in_array($uidTmp, $uidArr)) {
-				$uidArr[] = intval($uidTmp);
-			}
-		}
+            if ($uidTmp != 'gift' && !in_array($uidTmp, $uidArr)) {
+                $uidArr[] = intval($uidTmp);
+            }
+        }
 
-		if (count($uidArr) == 0) {
-			return;
-		}
+        if (count($uidArr) == 0) {
+            return;
+        }
 
-		$pidListObj = tx_ttproducts_control_basket::getPidListObj();
-		$pid_list = $pidListObj->getPidlist();
+        $pidListObj = tx_ttproducts_control_basket::getPidListObj();
+        $pid_list = $pidListObj->getPidlist();
 
-		$where = 'uid IN (' . implode(',', $uidArr) . ')' . ($pid_list != '' ? ' AND pid IN (' . $pid_list . ')' : '') . $viewTableObj->getTableObj()->enableFields();
+        $where = 'uid IN (' . implode(',', $uidArr) . ')' . ($pid_list != '' ? ' AND pid IN (' . $pid_list . ')' : '') . $viewTableObj->getTableObj()->enableFields();
 
-		$rcArray = $viewTableObj->getWhere($where, $theCode, $orderBy);
+        $rcArray = $viewTableObj->getWhere($where, $theCode, $orderBy);
 
-		$productsArray = [];
-		$prodCount = 0;
-		$bAddGiftService = false;
+        $productsArray = [];
+        $prodCount = 0;
+        $bAddGiftService = false;
 
-		foreach ($rcArray as $uid => $row) {
+        foreach ($rcArray as $uid => $row) {
 
-			$viewTableObj->getTableObj()->transformRow($row, TT_PRODUCTS_EXT);
-			$pid = $row['pid'];
-			$uid = $row['uid'];
-			$isValidPage = $pidListObj->getPageArray($pid);
+            $viewTableObj->getTableObj()->transformRow($row, TT_PRODUCTS_EXT);
+            $pid = $row['pid'];
+            $uid = $row['uid'];
+            $isValidPage = $pidListObj->getPageArray($pid);
 
-			// only the basket items for the pages belonging to this shop shall be used here
-			if ($isValidPage) {
+            // only the basket items for the pages belonging to this shop shall be used here
+            if ($isValidPage) {
 
-				foreach ($basketExt[$uid] as $bextVarLine => $bRow) {
-					if (substr($bextVarLine, -1) == '.') {
-						// this is an additional array which is no basket item
-						if ($conf['whereGiftService']) {
-							$bAddGiftService = true;
-						}
-						continue;
-					}
+                foreach ($basketExt[$uid] as $bextVarLine => $bRow) {
+                    if (substr($bextVarLine, -1) == '.') {
+                        // this is an additional array which is no basket item
+                        if ($conf['whereGiftService']) {
+                            $bAddGiftService = true;
+                        }
+                        continue;
+                    }
 
-					$currRow =
-						$this->getItemRow(
-							$row,
-							$bextVarLine,
-							$useArticles,
-							$funcTablename
-						);
-					$productsArray[$prodCount] = $currRow;
-				  	$prodCount++;
-				}
-			}
-		}
+                    $currRow =
+                        $this->getItemRow(
+                            $row,
+                            $bextVarLine,
+                            $useArticles,
+                            $funcTablename
+                        );
+                    $productsArray[$prodCount] = $currRow;
+                    $prodCount++;
+                }
+            }
+        }
 
-		if ($bAddGiftService) {
-			$where = $conf['whereGiftService'].' AND pid IN (' . $pidListObj->getPidlist() . ')' . $viewTableObj->getTableObj()->enableFields();
-			$giftServiceArray = $viewTableObj->getWhere($where);
-			if (isset($giftServiceArray) && is_array($giftServiceArray)) {
-				reset($giftServiceArray);
-				$this->giftServiceRow = current($giftServiceArray);
-				if (isset($this->giftServiceRow) && is_array($this->giftServiceRow)) {
-					$productsArray[$prodCount++] = $this->giftServiceRow;
-				}
-			}
-		}
-		$itemArray = []; // array of the items in the basket
-		$maxTax = 0;
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$uidArray = [];
-		$categoryQuantity = [];
-		$categoryArray = [];
+        if ($bAddGiftService) {
+            $where = $conf['whereGiftService'].' AND pid IN (' . $pidListObj->getPidlist() . ')' . $viewTableObj->getTableObj()->enableFields();
+            $giftServiceArray = $viewTableObj->getWhere($where);
+            if (isset($giftServiceArray) && is_array($giftServiceArray)) {
+                reset($giftServiceArray);
+                $this->giftServiceRow = current($giftServiceArray);
+                if (isset($this->giftServiceRow) && is_array($this->giftServiceRow)) {
+                    $productsArray[$prodCount++] = $this->giftServiceRow;
+                }
+            }
+        }
+        $itemArray = []; // array of the items in the basket
+        $maxTax = 0;
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $uidArray = [];
+        $categoryQuantity = [];
+        $categoryArray = [];
         $bEnableTaxZero = true; // Die Produkte im Warenkorb werden sofort umgerechnet, damit sie die korrigierten Steuern und Preise enthalten. Hier ist die Steuer 0 erlaubt und darf später nicht mehr durch TAXpercentage überschrieben werden.
 
-		foreach ($productsArray as $k1 => $row) {
+        foreach ($productsArray as $k1 => $row) {
 
-			$uid = $row['uid'];
-			$taxInfoArray = [];
-			$tax =
-				$taxObj->getTax(
-					$taxInfoArray,
-					$row,
-					$basketExtra,
-					$this->getRecs(),
-					false
-				);
+            $uid = $row['uid'];
+            $taxInfoArray = [];
+            $tax =
+                $taxObj->getTax(
+                    $taxInfoArray,
+                    $row,
+                    $basketExtra,
+                    $this->getRecs(),
+                    false
+                );
             $row['tax'] = floatval($tax); // Steuer 0 muss durch TAXpercentage überschrieben werden. Mögliche XCLASS und andere Steuern berücksichtigen.
 
-			$calculatedTax =
-				$taxObj->getFieldCalculatedValue(
-					$row['tax'],
-					$basketExtra
-				);
-			if ($calculatedTax !== false) {
-				$tax = $calculatedTax;
-			}
+            $calculatedTax =
+                $taxObj->getFieldCalculatedValue(
+                    $row['tax'],
+                    $basketExtra
+                );
+            if ($calculatedTax !== false) {
+                $tax = $calculatedTax;
+            }
 
             if ($tax > $maxTax) {
                 $maxTax = $tax;
             }
 
-			$externalRowArray = [];
+            $externalRowArray = [];
 
-			if (
-				isset($row['ext']) &&
-				isset($row['ext']['records']) &&
-				is_array($row['ext']['records'])
-			) {
-				$externalRowArray = $row['ext']['records'];
-				end($externalRowArray);
-				$funcTablename = key($externalRowArray);
-				$lastRowArray = current($externalRowArray);
-				reset($externalRowArray);
-			}
+            if (
+                isset($row['ext']) &&
+                isset($row['ext']['records']) &&
+                is_array($row['ext']['records'])
+            ) {
+                $externalRowArray = $row['ext']['records'];
+                end($externalRowArray);
+                $funcTablename = key($externalRowArray);
+                $lastRowArray = current($externalRowArray);
+                reset($externalRowArray);
+            }
 
-			$newTax = floatval($tax);
+            $newTax = floatval($tax);
             if ($row['tax'] != $newTax) {
                 if (!$priceTaxNotVarying) {
                     $oldTaxFactor = 1 + $row['tax'] / 100;
@@ -1539,198 +1539,198 @@ class tx_ttproducts_basket implements \TYPO3\CMS\Core\SingletonInterface {
                     $row['price'] = $price * $newTaxFactor;
                 }
                 $row['tax'] = $newTax; // $row['tax'] ausfüllen, weil der Steuersatz bereits ermittelt worden ist.
-			}
+            }
 
-			$newItem =
-				$this->getItem(
-					$basketExt,
-					$basketExtra,
-					$basketRecs,
-					$row,
-					'useExt',
-					$funcTablename,
-					$externalRowArray, // new Download
-					$bEnableTaxZero
-				);
+            $newItem =
+                $this->getItem(
+                    $basketExt,
+                    $basketExtra,
+                    $basketRecs,
+                    $row,
+                    'useExt',
+                    $funcTablename,
+                    $externalRowArray, // new Download
+                    $bEnableTaxZero
+                );
 
-			$count = $newItem['count'];
+            $count = $newItem['count'];
 
-			if($count > 0) {
-				$weight = $newItem['weight'];
-				$itemArray[$row[$viewTableObj->fieldArray['itemnumber']]][] = $newItem;
-				$calculatedArray['count'] += $count;
+            if($count > 0) {
+                $weight = $newItem['weight'];
+                $itemArray[$row[$viewTableObj->fieldArray['itemnumber']]][] = $newItem;
+                $calculatedArray['count'] += $count;
                 if (empty($calculatedArray['weight'])) {
                     $calculatedArray['weight'] = 0;
                 }
-				$calculatedArray['weight'] += $weight * $count;
+                $calculatedArray['weight'] += $weight * $count;
 
-				$currentCategory = $row['category'];
-				$categoryArray[$currentCategory] = 1;
+                $currentCategory = $row['category'];
+                $categoryArray[$currentCategory] = 1;
                 if (!isset($categoryQuantity[$currentCategory])) {
                     $categoryQuantity[$currentCategory] = 0;
                 }
-				$categoryQuantity[$currentCategory] += $count;
-			}
-			// if reseller is logged in then take 'price2', default is 'price'
-			$uidArray[] = $uid;
-		}
-		$this->setItemArray($itemArray);
-		$this->setCategoryQuantity($categoryQuantity);
-		$this->setCategoryArray($categoryArray);
-		$this->setMaxTax($maxTax);
-		$this->setUidArray($uidArray);
-		$calculObj->setBaseCalculatedArray($calculatedArray);
-	}
+                $categoryQuantity[$currentCategory] += $count;
+            }
+            // if reseller is logged in then take 'price2', default is 'price'
+            $uidArray[] = $uid;
+        }
+        $this->setItemArray($itemArray);
+        $this->setCategoryQuantity($categoryQuantity);
+        $this->setCategoryArray($categoryArray);
+        $this->setMaxTax($maxTax);
+        $this->setUidArray($uidArray);
+        $calculObj->setBaseCalculatedArray($calculatedArray);
+    }
 
 
-	public function setMaxTax ($tax) {
-		$this->maxTax = $tax;
-	}
+    public function setMaxTax ($tax) {
+        $this->maxTax = $tax;
+    }
 
 
-	public function getMaxTax () {
-		return $this->maxTax;
-	}
+    public function getMaxTax () {
+        return $this->maxTax;
+    }
 
 
-	// get a virtual basket
-	public function getItemArrayFromRow (
-		$row,
-		$basketExt,
-		$basketExtra,
-		$basketRecs,
-		$funcTablename,
-		$externalRowArray = [], // Download
-		$bEnableTaxZero = false
-	) {
-		$prodFuncTablename = 'tt_products';
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewTableObj = $tablesObj->get($prodFuncTablename);
+    // get a virtual basket
+    public function getItemArrayFromRow (
+        $row,
+        $basketExt,
+        $basketExtra,
+        $basketRecs,
+        $funcTablename,
+        $externalRowArray = [], // Download
+        $bEnableTaxZero = false
+    ) {
+        $prodFuncTablename = 'tt_products';
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewTableObj = $tablesObj->get($prodFuncTablename);
 
-		$result = false;
+        $result = false;
 
-		if (isset($row) && is_array($row)) {
-			$itemArray = [];
+        if (isset($row) && is_array($row)) {
+            $itemArray = [];
 
-			$newItem =
-				$this->getItem(
-					$basketExt,
-					$basketExtra,
-					$basketRecs,
-					$row,
-					'useExt',
-					$funcTablename,
-					$externalRowArray, // Download
-					$bEnableTaxZero
-				);
+            $newItem =
+                $this->getItem(
+                    $basketExt,
+                    $basketExtra,
+                    $basketRecs,
+                    $row,
+                    'useExt',
+                    $funcTablename,
+                    $externalRowArray, // Download
+                    $bEnableTaxZero
+                );
 
-			if (!empty($newItem)) {
-				$count = $newItem['count'];
-				$weight = $newItem['weight'];
-				$itemArray[$row[$viewTableObj->fieldArray['itemnumber']]][] = $newItem;
-				$result = $itemArray;
-			}
-		}
-		return $result;
-	}
-
-
-	// get a virtual basket
-	public function getMergedRowFromItemArray (array $itemArray, $basketExtra) {
-
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
-		$row = false;
-		if (count($itemArray)) {
-			$row = [];
-		}
-
-		foreach ($itemArray as $sort => $actItemArray) {
-
-			foreach ($actItemArray as $k1 => $actItem) {
-				$row = $actItem['rec'];
-				$extArray = $row['ext'] ?? [];
-				if (
-					isset($extArray) &&
-					is_array($extArray)
-				) {
-					if (
-						isset($extArray['mergeArticles']) &&
-						is_array($extArray['mergeArticles'])
-					) {
-						$mergeRow = $extArray['mergeArticles'];
-						$row = $mergeRow;
-						unset($extArray['mergeArticles']);
-						$row['ext'] = $extArray;
-					}
-				}
-
-				if (isset($actItem[$calculationField]))  {
-					$row[$calculationField] = $actItem[$calculationField];
-				}
-				break;
-			}
-			break;
-		}
-		return $row;
-	}
+            if (!empty($newItem)) {
+                $count = $newItem['count'];
+                $weight = $newItem['weight'];
+                $itemArray[$row[$viewTableObj->fieldArray['itemnumber']]][] = $newItem;
+                $result = $itemArray;
+            }
+        }
+        return $result;
+    }
 
 
-	public function calculate (&$itemArray) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$useArticles = $cnfObj->getUseArticles();
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-		$calculObj->calculate(
-			tx_ttproducts_control_basket::getBasketExt(),
-			tx_ttproducts_control_basket::getBasketExtra(),
-			tx_ttproducts_control_basket::getRecs(),
-			tx_ttproducts_control_basket::getFuncTablename(),
-			$useArticles,
-			$this->getMaxTax(),
-			tx_ttproducts_control_basket::getRoundFormat(),
-			$itemArray
-		);
-	}
+    // get a virtual basket
+    public function getMergedRowFromItemArray (array $itemArray, $basketExtra) {
+
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $row = false;
+        if (count($itemArray)) {
+            $row = [];
+        }
+
+        foreach ($itemArray as $sort => $actItemArray) {
+
+            foreach ($actItemArray as $k1 => $actItem) {
+                $row = $actItem['rec'];
+                $extArray = $row['ext'] ?? [];
+                if (
+                    isset($extArray) &&
+                    is_array($extArray)
+                ) {
+                    if (
+                        isset($extArray['mergeArticles']) &&
+                        is_array($extArray['mergeArticles'])
+                    ) {
+                        $mergeRow = $extArray['mergeArticles'];
+                        $row = $mergeRow;
+                        unset($extArray['mergeArticles']);
+                        $row['ext'] = $extArray;
+                    }
+                }
+
+                if (isset($actItem[$calculationField]))  {
+                    $row[$calculationField] = $actItem[$calculationField];
+                }
+                break;
+            }
+            break;
+        }
+        return $row;
+    }
 
 
-	public function calculateSums () {
-		$getShopCountryCode = '';
-		$pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($this->conf);
-		$creditpoints = tx_ttproducts_creditpoints_div::getUsedCreditpoints($this->recs);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$staticTaxObj = $tablesObj->get('static_taxes', false);
-		if (
-			is_object($staticTaxObj) &&
-			$staticTaxObj->isValid()
-		) {
-			$getShopCountryCode = $staticTaxObj->getShopCountryCode();
-		}
-
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-		$calculObj->calculateSums(
-			tx_ttproducts_control_basket::getRoundFormat(),
-			$pricefactor,
-			$creditpoints,
-			$getShopCountryCode
-		);
-	}
+    public function calculate (&$itemArray) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $useArticles = $cnfObj->getUseArticles();
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+        $calculObj->calculate(
+            tx_ttproducts_control_basket::getBasketExt(),
+            tx_ttproducts_control_basket::getBasketExtra(),
+            tx_ttproducts_control_basket::getRecs(),
+            tx_ttproducts_control_basket::getFuncTablename(),
+            $useArticles,
+            $this->getMaxTax(),
+            tx_ttproducts_control_basket::getRoundFormat(),
+            $itemArray
+        );
+    }
 
 
-	public function getCalculatedSums () {
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-		$calculatedArray = $calculObj->getCalculatedArray();
-		return $calculatedArray;
-	}
+    public function calculateSums () {
+        $getShopCountryCode = '';
+        $pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($this->conf);
+        $creditpoints = tx_ttproducts_creditpoints_div::getUsedCreditpoints($this->recs);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $staticTaxObj = $tablesObj->get('static_taxes', false);
+        if (
+            is_object($staticTaxObj) &&
+            $staticTaxObj->isValid()
+        ) {
+            $getShopCountryCode = $staticTaxObj->getShopCountryCode();
+        }
+
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+        $calculObj->calculateSums(
+            tx_ttproducts_control_basket::getRoundFormat(),
+            $pricefactor,
+            $creditpoints,
+            $getShopCountryCode
+        );
+    }
 
 
-	public function addVoucherSums () {
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-		$calculObj->addVoucherSums();
-	}
+    public function getCalculatedSums () {
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+        $calculatedArray = $calculObj->getCalculatedArray();
+        return $calculatedArray;
+    }
 
 
-	public function getCalculatedArray () {
-		$calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
-		$rc = $calculObj->getCalculatedArray();
-		return $rc;
-	}
+    public function addVoucherSums () {
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+        $calculObj->addVoucherSums();
+    }
+
+
+    public function getCalculatedArray () {
+        $calculObj = GeneralUtility::makeInstance('tx_ttproducts_basket_calculate');
+        $rc = $calculObj->getCalculatedArray();
+        return $rc;
+    }
 }

--- a/model/class.tx_ttproducts_basket_calculate.php
+++ b/model/class.tx_ttproducts_basket_calculate.php
@@ -44,74 +44,74 @@ use JambageCom\TtProducts\Api\PaymentShippingHandling;
 
 class tx_ttproducts_basket_calculate implements \TYPO3\CMS\Core\SingletonInterface {
 
-	protected $calculatedArray = [];
-	protected $baseCalculatedArray = [];
+    protected $calculatedArray = [];
+    protected $baseCalculatedArray = [];
 
 
-	public function getBaseCalculatedArray () {
-		return $this->baseCalculatedArray;
-	}
+    public function getBaseCalculatedArray () {
+        return $this->baseCalculatedArray;
+    }
 
-	public function setBaseCalculatedArray (array $calculatedArray) {
-		$this->baseCalculatedArray = $calculatedArray;
-	}
+    public function setBaseCalculatedArray (array $calculatedArray) {
+        $this->baseCalculatedArray = $calculatedArray;
+    }
 
-	public function getCalculatedArray () {
-		return $this->calculatedArray;
-	}
+    public function getCalculatedArray () {
+        return $this->calculatedArray;
+    }
 
-	public function setCalculatedArray ($calculatedArray) {
-		$this->calculatedArray = $calculatedArray;
-	}
+    public function setCalculatedArray ($calculatedArray) {
+        $this->calculatedArray = $calculatedArray;
+    }
 
-	static public function getRealDiscount (
-		$calculatedArray,
-		$tax = true
-	) {
-		$result = 0;
-		if ($tax) {
-			$result =
-				$calculatedArray['price0Tax']['goodstotal']['ALL'] -
-				$calculatedArray['priceTax']['goodstotal']['ALL'];
-		} else {
-			$result =
-				$calculatedArray['price0NoTax']['goodstotal']['ALL'] -
-				$calculatedArray['priceNoTax']['goodstotal']['ALL'];
-		}
+    static public function getRealDiscount (
+        $calculatedArray,
+        $tax = true
+    ) {
+        $result = 0;
+        if ($tax) {
+            $result =
+                $calculatedArray['price0Tax']['goodstotal']['ALL'] -
+                $calculatedArray['priceTax']['goodstotal']['ALL'];
+        } else {
+            $result =
+                $calculatedArray['price0NoTax']['goodstotal']['ALL'] -
+                $calculatedArray['priceNoTax']['goodstotal']['ALL'];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	static public function getGoodsTotalTax (
-		$basketExtra,
-		$basketRecs,
-		$itemArray
-	) {
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$goodsTotalTax = 0;
+    static public function getGoodsTotalTax (
+        $basketExtra,
+        $basketRecs,
+        $itemArray
+    ) {
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $goodsTotalTax = 0;
 
-		foreach ($itemArray as $sort => $actItemArray) {
-			foreach ($actItemArray as $k1 => $actItem) {
-				$row = $actItem['rec'];
-				$count = $actItem['count'];
-				$tax = $actItem['tax'];
-				$priceTax = $actItem['priceTax'];
-				$priceNoTax = $actItem['priceNoTax'];
-				$totalNoTax = $priceNoTax * $count;
-				$goodsTotalTax +=
-					$priceObj->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$totalNoTax,
-						true,
-						$row,
-						false,
-						false
-					);
-			}
-		}
-		return $goodsTotalTax;
-	}
+        foreach ($itemArray as $sort => $actItemArray) {
+            foreach ($actItemArray as $k1 => $actItem) {
+                $row = $actItem['rec'];
+                $count = $actItem['count'];
+                $tax = $actItem['tax'];
+                $priceTax = $actItem['priceTax'];
+                $priceNoTax = $actItem['priceNoTax'];
+                $totalNoTax = $priceNoTax * $count;
+                $goodsTotalTax +=
+                    $priceObj->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $totalNoTax,
+                        true,
+                        $row,
+                        false,
+                        false
+                    );
+            }
+        }
+        return $goodsTotalTax;
+    }
 
     public function clear ($taxMode = 1)
     {
@@ -164,712 +164,712 @@ class tx_ttproducts_basket_calculate implements \TYPO3\CMS\Core\SingletonInterfa
         $this->calculatedArray['handling']['0']['priceNoTax'] = 0;        
     }
 
-	/**
-	 * This calculates the totals. Very important function.
-	This function also calculates the internal arrays
+    /**
+     * This calculates the totals. Very important function.
+    This function also calculates the internal arrays
 
-	$itemArray	The basked elements, how many (quantity, count) and the price
-	$this->calculatedArray	- Sums of goods, shipping, payment and total amount WITH TAX included
+    $itemArray	The basked elements, how many (quantity, count) and the price
+    $this->calculatedArray	- Sums of goods, shipping, payment and total amount WITH TAX included
 
-	... which holds the total amount, the final list of products and the price of payment and shipping!!
-	 */
-	public function calculate (
-		$basketExt,
-		$basketExtra,
-		$basketRecs,
-		$funcTablename,
-		$useArticles,
-		$maxTax,
-		$roundFormat, // Todo: remove unused format
-		&$itemArray
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    ... which holds the total amount, the final list of products and the price of payment and shipping!!
+     */
+    public function calculate (
+        $basketExt,
+        $basketExtra,
+        $basketRecs,
+        $funcTablename,
+        $useArticles,
+        $maxTax,
+        $roundFormat, // Todo: remove unused format
+        &$itemArray
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 // 		$paymentshippingObj = GeneralUtility::makeInstance('tx_ttproducts_paymentshipping');
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewTableObj = $tablesObj->get($funcTablename);
-		$conf = $cnf->conf;
-		$shippingTax = '';
-		$taxInfoArray = '';
-		$bEnableTaxZero = false;
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
-		$calculationAdditionField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED_ADDITION;
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewTableObj = $tablesObj->get($funcTablename);
+        $conf = $cnf->conf;
+        $shippingTax = '';
+        $taxInfoArray = '';
+        $bEnableTaxZero = false;
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $calculationAdditionField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED_ADDITION;
 
-		$iso3Seller = \JambageCom\TtProducts\Api\PaymentApi::getStoreIso3('DEU');
-		$iso3Buyer = \JambageCom\TtProducts\Api\CustomerApi::getBillingIso3('DEU');
+        $iso3Seller = \JambageCom\TtProducts\Api\PaymentApi::getStoreIso3('DEU');
+        $iso3Buyer = \JambageCom\TtProducts\Api\CustomerApi::getBillingIso3('DEU');
 
         $this->clear($conf['TAXmode']);
 
-		if (tx_ttproducts_static_tax::isInstalled()) {
-			$shippingTax =
-				$taxObj->getTax(
-					$taxInfoArray,
-					[],
-					$basketExtra,
-					$basketRecs,
-					$bEnableTaxZero
-				);
-		} else {
-			$shippingTax =
-				PaymentShippingHandling::getTaxPercentage(
-					$basketExtra,
-					'shipping',
-					''
-				);
-		}
+        if (tx_ttproducts_static_tax::isInstalled()) {
+            $shippingTax =
+                $taxObj->getTax(
+                    $taxInfoArray,
+                    [],
+                    $basketExtra,
+                    $basketRecs,
+                    $bEnableTaxZero
+                );
+        } else {
+            $shippingTax =
+                PaymentShippingHandling::getTaxPercentage(
+                    $basketExtra,
+                    'shipping',
+                    ''
+                );
+        }
 
-		$calculatedTax =
-			$taxObj->getFieldCalculatedValue(
-				$shippingTax,
-				$basketExtra
-			);
-		if ($calculatedTax !== false) {
-			$shippingTax = $calculatedTax;
-		}
+        $calculatedTax =
+            $taxObj->getFieldCalculatedValue(
+                $shippingTax,
+                $basketExtra
+            );
+        if ($calculatedTax !== false) {
+            $shippingTax = $calculatedTax;
+        }
 
-		if ($shippingTax > $maxTax) {
-			$maxTax = $shippingTax;
-		} else if (!isset($shippingTax)) {
-			$shippingTax = $maxTax;
-		}
-		$shippingRow = ['tax' => floatval($shippingTax)];
+        if ($shippingTax > $maxTax) {
+            $maxTax = $shippingTax;
+        } else if (!isset($shippingTax)) {
+            $shippingTax = $maxTax;
+        }
+        $shippingRow = ['tax' => floatval($shippingTax)];
 
-		if (
-			isset($itemArray) &&
-			is_array($itemArray) &&
-			!empty($itemArray)
-		) {
-			$discountPrice = GeneralUtility::makeInstance('tx_ttproducts_discountprice');
-			$getDiscount = $discountPrice->getDiscountPrice($conf);
+        if (
+            isset($itemArray) &&
+            is_array($itemArray) &&
+            !empty($itemArray)
+        ) {
+            $discountPrice = GeneralUtility::makeInstance('tx_ttproducts_discountprice');
+            $getDiscount = $discountPrice->getDiscountPrice($conf);
 
-			$priceReduction = [];
+            $priceReduction = [];
 
-				// Check if a special group price can be used
-			if ($getDiscount == 1) {
-				$discountArray = [];
-				$goodsTotalTax =
-					self::getGoodsTotalTax(
-						$basketExtra,
-						$basketRecs,
-						$itemArray
-					);
+                // Check if a special group price can be used
+            if ($getDiscount == 1) {
+                $discountArray = [];
+                $goodsTotalTax =
+                    self::getGoodsTotalTax(
+                        $basketExtra,
+                        $basketRecs,
+                        $itemArray
+                    );
 
-				$discountPrice->getCalculatedData(
-					$itemArray,
-					$conf['discountprice.'],
-					'calc',
-					$priceReduction,
-					$discountArray,
-					$goodsTotalTax,
-					false,
-					$conf['TAXincluded'],
-					true
-				);
-			}
+                $discountPrice->getCalculatedData(
+                    $itemArray,
+                    $conf['discountprice.'],
+                    'calc',
+                    $priceReduction,
+                    $discountArray,
+                    $goodsTotalTax,
+                    false,
+                    $conf['TAXincluded'],
+                    true
+                );
+            }
 
-			// set the 'calcprice' in itemArray
-			if (isset($conf['pricecalc.'])) {
-				$pricecalc = GeneralUtility::makeInstance('tx_ttproducts_pricecalc');
-				$discountArray = [];
+            // set the 'calcprice' in itemArray
+            if (isset($conf['pricecalc.'])) {
+                $pricecalc = GeneralUtility::makeInstance('tx_ttproducts_pricecalc');
+                $discountArray = [];
 
-				// do the price calculation
-				$pricecalc->getCalculatedData(
-					$itemArray,
-					$conf['pricecalc.'],
-					'calc',
-					$priceReduction,
-					$discountArray,
-					'',
-					false,
-					$conf['TAXincluded'],
-					true
-				);
-			}
+                // do the price calculation
+                $pricecalc->getCalculatedData(
+                    $itemArray,
+                    $conf['pricecalc.'],
+                    'calc',
+                    $priceReduction,
+                    $discountArray,
+                    '',
+                    false,
+                    $conf['TAXincluded'],
+                    true
+                );
+            }
 
-			$pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
-			$discountArray = [];
+            $pricetablesCalculator = GeneralUtility::makeInstance('tx_ttproducts_pricetablescalc');
+            $discountArray = [];
 
-			$tmp = '';
-			$pricetablesCalculator->getCalculatedData(
-				$itemArray,
-				$tmp,
-				'calc',
-				$priceReduction,
-				$discountArray,
-				'',
-				true,
-				$conf['TAXincluded'],
-				true
-			);
-			$bulkilyFeeTax = floatval($conf['bulkilyFeeTax']);
+            $tmp = '';
+            $pricetablesCalculator->getCalculatedData(
+                $itemArray,
+                $tmp,
+                'calc',
+                $priceReduction,
+                $discountArray,
+                '',
+                true,
+                $conf['TAXincluded'],
+                true
+            );
+            $bulkilyFeeTax = floatval($conf['bulkilyFeeTax']);
 
-			// loop over all items in the basket indexed by a sort string
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					$count = $actItem['count'];
-					$tax = $actItem['tax'];
-					$taxInfo = [];
-					if (isset($actItem['taxInfo'])) {
-						$taxInfo = $actItem['taxInfo'];
-					}
-					$priceTax = $actItem['priceTax'];
-					$priceNoTax = $actItem['priceNoTax'];
-					$price0Tax = $actItem['price0Tax'];
-					$price0NoTax = $actItem['price0NoTax'];
-					$price2Tax = $actItem['price2Tax'];
-					$price2NoTax = $actItem['price2NoTax'];
-					$bEnableTaxZero =
-						tx_ttproducts_gifts_div::useTaxZero(
-							$row,
-							$conf['gift.'] ?? '',
-							$conf['whereGift'] ?? ''
-						);
+            // loop over all items in the basket indexed by a sort string
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    $count = $actItem['count'];
+                    $tax = $actItem['tax'];
+                    $taxInfo = [];
+                    if (isset($actItem['taxInfo'])) {
+                        $taxInfo = $actItem['taxInfo'];
+                    }
+                    $priceTax = $actItem['priceTax'];
+                    $priceNoTax = $actItem['priceNoTax'];
+                    $price0Tax = $actItem['price0Tax'];
+                    $price0NoTax = $actItem['price0NoTax'];
+                    $price2Tax = $actItem['price2Tax'];
+                    $price2NoTax = $actItem['price2NoTax'];
+                    $bEnableTaxZero =
+                        tx_ttproducts_gifts_div::useTaxZero(
+                            $row,
+                            $conf['gift.'] ?? '',
+                            $conf['whereGift'] ?? ''
+                        );
 
-					if (!empty($actItem[$calculationAdditionField])) {
-						if (isset($actItem[$calculationField])) {
-							$actItem[$calculationField] += $actItem[$calculationAdditionField];
-						} else {
-							$extArray = $row['ext'];
-							if (
-								is_array($extArray) &&
-								!empty($extArray['mergeArticles'])
-							) {
-								$mergeRow = $extArray['mergeArticles'];
-							} else {
-								$mergeRow = $row;
-							}
+                    if (!empty($actItem[$calculationAdditionField])) {
+                        if (isset($actItem[$calculationField])) {
+                            $actItem[$calculationField] += $actItem[$calculationAdditionField];
+                        } else {
+                            $extArray = $row['ext'];
+                            if (
+                                is_array($extArray) &&
+                                !empty($extArray['mergeArticles'])
+                            ) {
+                                $mergeRow = $extArray['mergeArticles'];
+                            } else {
+                                $mergeRow = $row;
+                            }
 
-							$actItem[$calculationField] =
-								$priceObj->getResellerPrice(
-									$basketExtra,
-									$basketRecs,
-									$mergeRow,
-									1
-								) +
-								$actItem[$calculationAdditionField];
-						}
-					}
+                            $actItem[$calculationField] =
+                                $priceObj->getResellerPrice(
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $mergeRow,
+                                    1
+                                ) +
+                                $actItem[$calculationAdditionField];
+                        }
+                    }
 
-					// has the price been calculated before take it if it gets cheaper now
-					if (
-						isset($actItem[$calculationField]) /*&& ($actItem['calcprice'] < $actItem['priceTax']) */
-					) {
-						$itemArray[$sort][$k1]['priceTax'] = $priceObj->getModePrice(
-							$basketExtra,
-							$basketRecs,
-							$conf['TAXmode'],
-							$actItem[$calculationField],
-							true,
-							$row,
-							$conf['TAXincluded'],
-							$bEnableTaxZero
-						);
-						$itemArray[$sort][$k1]['priceNoTax'] = $priceObj->getModePrice(
-							$basketExtra,
-							$basketRecs,
-							$conf['TAXmode'],
-							$actItem[$calculationField],
-							false,
-							$row,
-							$conf['TAXincluded'],
-							$bEnableTaxZero
-						);
-					}
-					if (isset($actItem[$calculationField])) {
-						$itemArray[$sort][$k1][$calculationField] = $actItem[$calculationField];
-					}
+                    // has the price been calculated before take it if it gets cheaper now
+                    if (
+                        isset($actItem[$calculationField]) /*&& ($actItem['calcprice'] < $actItem['priceTax']) */
+                    ) {
+                        $itemArray[$sort][$k1]['priceTax'] = $priceObj->getModePrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $conf['TAXmode'],
+                            $actItem[$calculationField],
+                            true,
+                            $row,
+                            $conf['TAXincluded'],
+                            $bEnableTaxZero
+                        );
+                        $itemArray[$sort][$k1]['priceNoTax'] = $priceObj->getModePrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $conf['TAXmode'],
+                            $actItem[$calculationField],
+                            false,
+                            $row,
+                            $conf['TAXincluded'],
+                            $bEnableTaxZero
+                        );
+                    }
+                    if (isset($actItem[$calculationField])) {
+                        $itemArray[$sort][$k1][$calculationField] = $actItem[$calculationField];
+                    }
 
-					//  multiplicate it with the count :
-					$itemArray[$sort][$k1]['totalNoTax'] = $itemArray[$sort][$k1]['priceNoTax'] * $count;
-					$itemArray[$sort][$k1]['total0NoTax'] = $itemArray[$sort][$k1]['price0NoTax'] * $count;
-					$itemArray[$sort][$k1]['total2NoTax'] = $itemArray[$sort][$k1]['price2NoTax'] * $count;
-					$totalDepositNoTax = ($itemArray[$sort][$k1]['depositnotax'] ?? 0) * $count;
+                    //  multiplicate it with the count :
+                    $itemArray[$sort][$k1]['totalNoTax'] = $itemArray[$sort][$k1]['priceNoTax'] * $count;
+                    $itemArray[$sort][$k1]['total0NoTax'] = $itemArray[$sort][$k1]['price0NoTax'] * $count;
+                    $itemArray[$sort][$k1]['total2NoTax'] = $itemArray[$sort][$k1]['price2NoTax'] * $count;
+                    $totalDepositNoTax = ($itemArray[$sort][$k1]['depositnotax'] ?? 0) * $count;
 
-					$this->calculatedArray['price0NoTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['total0NoTax'];
-					$this->calculatedArray['priceNoTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['totalNoTax'];
-					if (!isset($this->calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$row['category']])) {
+                    $this->calculatedArray['price0NoTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['total0NoTax'];
+                    $this->calculatedArray['priceNoTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['totalNoTax'];
+                    if (!isset($this->calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$row['category']])) {
                         $this->calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$row['category']] = 0;
-					}
-					$this->calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$row['category']] += $itemArray[$sort][$k1]['totalNoTax'];
-					$this->calculatedArray['price2NoTax']['goodstotal']['ALL'] += $price2NoTax * $count;
-					$this->calculatedArray['depositnotax']['goodstotal']['ALL'] += $totalDepositNoTax;
+                    }
+                    $this->calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$row['category']] += $itemArray[$sort][$k1]['totalNoTax'];
+                    $this->calculatedArray['price2NoTax']['goodstotal']['ALL'] += $price2NoTax * $count;
+                    $this->calculatedArray['depositnotax']['goodstotal']['ALL'] += $totalDepositNoTax;
 
-					$this->calculatedArray['noDiscountPriceTax']['goodstotal']['ALL']  +=
-						$priceObj->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$row['oldpricenotax'] * $actItem['count'],
-							true,
-							$row,
-							$conf['TAXincluded'],
-							$bEnableTaxZero
-						);
-					$this->calculatedArray['noDiscountPriceNoTax']['goodstotal']['ALL'] +=
-						$priceObj->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$row['oldpricenotax'] * $actItem['count'],   // $price0Tax
-							false,
-							$row,
-							$conf['TAXincluded'],
-							$bEnableTaxZero
-						);
+                    $this->calculatedArray['noDiscountPriceTax']['goodstotal']['ALL']  +=
+                        $priceObj->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $row['oldpricenotax'] * $actItem['count'],
+                            true,
+                            $row,
+                            $conf['TAXincluded'],
+                            $bEnableTaxZero
+                        );
+                    $this->calculatedArray['noDiscountPriceNoTax']['goodstotal']['ALL'] +=
+                        $priceObj->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $row['oldpricenotax'] * $actItem['count'],   // $price0Tax
+                            false,
+                            $row,
+                            $conf['TAXincluded'],
+                            $bEnableTaxZero
+                        );
 
-					if ($conf['TAXmode'] == '1') {
-						$taxstr = strval(number_format($tax, 2)); // needed for floating point taxes as in Swizzerland
+                    if ($conf['TAXmode'] == '1') {
+                        $taxstr = strval(number_format($tax, 2)); // needed for floating point taxes as in Swizzerland
 
-						$itemArray[$sort][$k1]['totalTax'] =
-							$priceObj->getPrice(
-								$basketExtra,
-								$basketRecs,
-								$itemArray[$sort][$k1]['totalNoTax'],
-								true,
-								$row,
-								false,
-								$bEnableTaxZero
-							);
+                        $itemArray[$sort][$k1]['totalTax'] =
+                            $priceObj->getPrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $itemArray[$sort][$k1]['totalNoTax'],
+                                true,
+                                $row,
+                                false,
+                                $bEnableTaxZero
+                            );
 
-						$itemArray[$sort][$k1]['total0Tax'] =
-							$priceObj->getPrice(
-								$basketExtra,
-								$basketRecs,
-								$itemArray[$sort][$k1]['total0NoTax'],
-								true,
-								$row,
-								false,
-								$bEnableTaxZero
-							);
+                        $itemArray[$sort][$k1]['total0Tax'] =
+                            $priceObj->getPrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $itemArray[$sort][$k1]['total0NoTax'],
+                                true,
+                                $row,
+                                false,
+                                $bEnableTaxZero
+                            );
                         if (!isset($this->calculatedArray['priceNoTax']['goodssametaxtotal']['ALL'][$taxstr])) {
                             $this->calculatedArray['priceNoTax']['goodssametaxtotal']['ALL'][$taxstr] = 0;
                         }
-						$this->calculatedArray['priceNoTax']['goodssametaxtotal']['ALL'][$taxstr] +=  $itemArray[$sort][$k1]['totalNoTax'];
-						if (!isset($this->calculatedArray['price2NoTax']['goodssametaxtotal']['ALL'][$taxstr])) {
+                        $this->calculatedArray['priceNoTax']['goodssametaxtotal']['ALL'][$taxstr] +=  $itemArray[$sort][$k1]['totalNoTax'];
+                        if (!isset($this->calculatedArray['price2NoTax']['goodssametaxtotal']['ALL'][$taxstr])) {
                             $this->calculatedArray['price2NoTax']['goodssametaxtotal']['ALL'][$taxstr] = 0;
                         }
-						$this->calculatedArray['price2NoTax']['goodssametaxtotal']['ALL'][$taxstr] += $itemArray[$sort][$k1]['total2NoTax'];
-						if (!isset($this->calculatedArray['categoryPriceNoTax']['goodssametaxtotal']['ALL'][$taxstr][$row['category']])) {
+                        $this->calculatedArray['price2NoTax']['goodssametaxtotal']['ALL'][$taxstr] += $itemArray[$sort][$k1]['total2NoTax'];
+                        if (!isset($this->calculatedArray['categoryPriceNoTax']['goodssametaxtotal']['ALL'][$taxstr][$row['category']])) {
                             $this->calculatedArray['categoryPriceNoTax']['goodssametaxtotal']['ALL'][$taxstr][$row['category']] = 0;
                         }
-						$this->calculatedArray['categoryPriceNoTax']['goodssametaxtotal']['ALL'][$taxstr][$row['category']] +=  $itemArray[$sort][$k1]['totalNoTax'];
-						if (!isset($this->calculatedArray['price0NoTax']['goodssametaxtotal']['ALL'][$taxstr])) {
+                        $this->calculatedArray['categoryPriceNoTax']['goodssametaxtotal']['ALL'][$taxstr][$row['category']] +=  $itemArray[$sort][$k1]['totalNoTax'];
+                        if (!isset($this->calculatedArray['price0NoTax']['goodssametaxtotal']['ALL'][$taxstr])) {
                             $this->calculatedArray['price0NoTax']['goodssametaxtotal']['ALL'][$taxstr] = 0;
                         }
-						$this->calculatedArray['price0NoTax']['goodssametaxtotal']['ALL'][$taxstr] += $itemArray[$sort][$k1]['total0NoTax'];
+                        $this->calculatedArray['price0NoTax']['goodssametaxtotal']['ALL'][$taxstr] += $itemArray[$sort][$k1]['total0NoTax'];
 
                         if (!isset($this->calculatedArray['depositnotax']['goodssametaxtotal']['ALL'][$taxstr])) {
                             $this->calculatedArray['depositnotax']['goodssametaxtotal']['ALL'][$taxstr] = 0;
                         }
                         $this->calculatedArray['depositnotax']['goodssametaxtotal']['ALL'][$taxstr] += $totalDepositNoTax;
 
-						if (!empty($taxInfo)) {
-							foreach ($taxInfo as $countryCode => $countryRows) {
-								foreach ($countryRows as $k => $taxRow) {
-									$countryTax = strval($taxRow['tx_rate'], 2);
+                        if (!empty($taxInfo)) {
+                            foreach ($taxInfo as $countryCode => $countryRows) {
+                                foreach ($countryRows as $k => $taxRow) {
+                                    $countryTax = strval($taxRow['tx_rate'], 2);
 
                                     if (!isset($this->calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$countryTax])) {
                                         $this->calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$countryTax] = 0;
                                     }
-									$this->calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$countryTax] +=  $itemArray[$sort][$k1]['totalNoTax'];
-									if (!isset($this->calculatedArray['priceNoTax']['goodstotal'][$countryCode])) {
+                                    $this->calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$countryTax] +=  $itemArray[$sort][$k1]['totalNoTax'];
+                                    if (!isset($this->calculatedArray['priceNoTax']['goodstotal'][$countryCode])) {
                                         $this->calculatedArray['priceNoTax']['goodstotal'][$countryCode] = 0;
                                     }
-									$this->calculatedArray['priceNoTax']['goodstotal'][$countryCode] += $itemArray[$sort][$k1]['totalNoTax'];
-								}
-							}
-						}
-					} else if ($conf['TAXmode'] == '2') {
-						$itemArray[$sort][$k1]['totalTax'] = $itemArray[$sort][$k1]['priceTax'] * $count;
-						$itemArray[$sort][$k1]['total0Tax'] = $itemArray[$sort][$k1]['price0Tax'] * $count;
-						$totalDepositTax = $itemArray[$sort][$k1]['deposittax'] * $count;
+                                    $this->calculatedArray['priceNoTax']['goodstotal'][$countryCode] += $itemArray[$sort][$k1]['totalNoTax'];
+                                }
+                            }
+                        }
+                    } else if ($conf['TAXmode'] == '2') {
+                        $itemArray[$sort][$k1]['totalTax'] = $itemArray[$sort][$k1]['priceTax'] * $count;
+                        $itemArray[$sort][$k1]['total0Tax'] = $itemArray[$sort][$k1]['price0Tax'] * $count;
+                        $totalDepositTax = $itemArray[$sort][$k1]['deposittax'] * $count;
 
-							// Fills this array with the product records. Reason: Sorting them by category (based on the page, they reside on)
-						$this->calculatedArray['priceTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['totalTax'];
-						$this->calculatedArray['price0Tax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['total0Tax'];
-						$this->calculatedArray['priceTax']['goodsdeposittotal']['ALL'] += $itemArray[$sort][$k1]['totalDepositTax'];
+                            // Fills this array with the product records. Reason: Sorting them by category (based on the page, they reside on)
+                        $this->calculatedArray['priceTax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['totalTax'];
+                        $this->calculatedArray['price0Tax']['goodstotal']['ALL'] += $itemArray[$sort][$k1]['total0Tax'];
+                        $this->calculatedArray['priceTax']['goodsdeposittotal']['ALL'] += $itemArray[$sort][$k1]['totalDepositTax'];
 
-						if (!isset($this->calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$row['category']])) {
+                        if (!isset($this->calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$row['category']])) {
                             $this->calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$row['category']] = 0;
                         }
-						$this->calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$row['category']] +=  $itemArray[$sort][$k1]['totalTax'];
+                        $this->calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$row['category']] +=  $itemArray[$sort][$k1]['totalTax'];
 
-						$this->calculatedArray['price2Tax']['goodstotal']['ALL'] += $price2Tax * $count;
+                        $this->calculatedArray['price2Tax']['goodstotal']['ALL'] += $price2Tax * $count;
 
-						$value = $row['handling'] ?? 0;
-						$this->calculatedArray['handling']['0']['priceTax'] +=
-							$priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value,
-								true,
-								$shippingRow,
-								$conf['TAXincluded'],
-								true
-							);
-						$value = $row['shipping'] ?? 0;
-						$this->calculatedArray['shipping']['priceTax'] +=
-							$priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value,
-								true,
-								$shippingRow,
-								$conf['TAXincluded'],
-								true
-							);
-						$value = $row['shipping2'] ?? 0;
+                        $value = $row['handling'] ?? 0;
+                        $this->calculatedArray['handling']['0']['priceTax'] +=
+                            $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value,
+                                true,
+                                $shippingRow,
+                                $conf['TAXincluded'],
+                                true
+                            );
+                        $value = $row['shipping'] ?? 0;
+                        $this->calculatedArray['shipping']['priceTax'] +=
+                            $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value,
+                                true,
+                                $shippingRow,
+                                $conf['TAXincluded'],
+                                true
+                            );
+                        $value = $row['shipping2'] ?? 0;
 
-						if ($count > 1) {
-							$this->calculatedArray['shipping']['priceTax'] +=
-								$priceObj->getModePrice(
-									$basketExtra,
-									$basketRecs,
-									$conf['TAXmode'],
-									$value * ($count-1),
-									true,
-									$shippingRow,
-									$conf['TAXincluded'],
-									true
-								);
-						}
-					}
+                        if ($count > 1) {
+                            $this->calculatedArray['shipping']['priceTax'] +=
+                                $priceObj->getModePrice(
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $conf['TAXmode'],
+                                    $value * ($count-1),
+                                    true,
+                                    $shippingRow,
+                                    $conf['TAXincluded'],
+                                    true
+                                );
+                        }
+                    }
 
-					$value = $row['handling'] ?? 0;
-					$this->calculatedArray['handling']['0']['priceNoTax'] +=
-						$priceObj->getModePrice(
-							$basketExtra,
-							$basketRecs,
-							$conf['TAXmode'],
-							$value,
-							false,
-							$shippingRow,
-							$conf['TAXincluded'],
-							true
-						);
+                    $value = $row['handling'] ?? 0;
+                    $this->calculatedArray['handling']['0']['priceNoTax'] +=
+                        $priceObj->getModePrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $conf['TAXmode'],
+                            $value,
+                            false,
+                            $shippingRow,
+                            $conf['TAXincluded'],
+                            true
+                        );
 
-					$value = $row['shipping'] ?? 0;
-					$this->calculatedArray['shipping']['priceNoTax'] +=
-						$priceObj->getModePrice(
-							$basketExtra,
-							$basketRecs,
-							$conf['TAXmode'],
-							$value,
-							false,
-							$shippingRow,
-							$conf['TAXincluded'],
-							true
-						);
+                    $value = $row['shipping'] ?? 0;
+                    $this->calculatedArray['shipping']['priceNoTax'] +=
+                        $priceObj->getModePrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $conf['TAXmode'],
+                            $value,
+                            false,
+                            $shippingRow,
+                            $conf['TAXincluded'],
+                            true
+                        );
 
-					$value = $row['shipping2'] ?? 0;
-					if ($count > 1) {
-						$this->calculatedArray['shipping']['priceNoTax'] +=
-							$priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value * ($count - 1),
-								false,
-								$shippingRow,
-								$conf['TAXincluded'],
-								true
-							);
-					}
-				} // foreach ($actItemArray as $k1 => $actItem) {
-			} // foreach ($itemArray
+                    $value = $row['shipping2'] ?? 0;
+                    if ($count > 1) {
+                        $this->calculatedArray['shipping']['priceNoTax'] +=
+                            $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value * ($count - 1),
+                                false,
+                                $shippingRow,
+                                $conf['TAXincluded'],
+                                true
+                            );
+                    }
+                } // foreach ($actItemArray as $k1 => $actItem) {
+            } // foreach ($itemArray
 
-			PaymentShippingHandling::getScriptPrices(
-				$this->calculatedArray,
-				$itemArray,
-				$basketExtra,
-				'payment'
-			);
-			PaymentShippingHandling::getScriptPrices(
-				$this->calculatedArray,
-				$itemArray,
-				$basketExtra,
-				'shipping'
-			);
-			PaymentShippingHandling::getScriptPrices(
-				$this->calculatedArray,
-				$itemArray,
-				$basketExtra,
-				'handling'
-			);
-			$this->calculatedArray['maxtax']['goodstotal']['ALL'] = $maxTax;
+            PaymentShippingHandling::getScriptPrices(
+                $this->calculatedArray,
+                $itemArray,
+                $basketExtra,
+                'payment'
+            );
+            PaymentShippingHandling::getScriptPrices(
+                $this->calculatedArray,
+                $itemArray,
+                $basketExtra,
+                'shipping'
+            );
+            PaymentShippingHandling::getScriptPrices(
+                $this->calculatedArray,
+                $itemArray,
+                $basketExtra,
+                'handling'
+            );
+            $this->calculatedArray['maxtax']['goodstotal']['ALL'] = $maxTax;
 
-			$taxRow = [];
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {	// TODO: remove this because it has been moved to the shipping configuration
-					$row = $actItem['rec'];
-					if (!empty($row['bulkily'])) {
-						$value = floatval($this->conf['bulkilyAddition']) * $basketExt[$row['uid']][$viewTableObj->getVariant()->getVariantFromRow($row)];
-						$tax = ($bulkilyFeeTax != '' ? $bulkilyFeeTax : $shippingTax);
-						$taxRow['tax'] = floatval($tax);
-						$this->calculatedArray['shipping']['priceTax'] +=
-							$priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value,
-								true,
-								$taxRow,
-								$conf['TAXincluded'],
-								false
-							);
-						$this->calculatedArray['shipping']['priceNoTax'] +=
-							$priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value,
-								false,
-								$taxRow,
-								$conf['TAXincluded'],
-								false
-							);
-					}
-				}
-			}
+            $taxRow = [];
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {	// TODO: remove this because it has been moved to the shipping configuration
+                    $row = $actItem['rec'];
+                    if (!empty($row['bulkily'])) {
+                        $value = floatval($this->conf['bulkilyAddition']) * $basketExt[$row['uid']][$viewTableObj->getVariant()->getVariantFromRow($row)];
+                        $tax = ($bulkilyFeeTax != '' ? $bulkilyFeeTax : $shippingTax);
+                        $taxRow['tax'] = floatval($tax);
+                        $this->calculatedArray['shipping']['priceTax'] +=
+                            $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value,
+                                true,
+                                $taxRow,
+                                $conf['TAXincluded'],
+                                false
+                            );
+                        $this->calculatedArray['shipping']['priceNoTax'] +=
+                            $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value,
+                                false,
+                                $taxRow,
+                                $conf['TAXincluded'],
+                                false
+                            );
+                    }
+                }
+            }
 
-			if ($conf['TAXmode'] == '1') {
-				$controlCalcArray =
-					[
-						'priceTax' => 'priceNoTax',
-						'price0Tax' => 'price0NoTax',
-						'price2Tax' => 'price2NoTax',
-						'deposittax' => 'depositnotax'
-					];
+            if ($conf['TAXmode'] == '1') {
+                $controlCalcArray =
+                    [
+                        'priceTax' => 'priceNoTax',
+                        'price0Tax' => 'price0NoTax',
+                        'price2Tax' => 'price2NoTax',
+                        'deposittax' => 'depositnotax'
+                    ];
 
-				$taxRow = [];
-				foreach ($controlCalcArray as $keyTax => $keyNoTax) {
-					foreach ($this->calculatedArray[$keyNoTax]['goodssametaxtotal'] as $countryIndex => $taxArray) {
-						$priceTax = 0;
+                $taxRow = [];
+                foreach ($controlCalcArray as $keyTax => $keyNoTax) {
+                    foreach ($this->calculatedArray[$keyNoTax]['goodssametaxtotal'] as $countryIndex => $taxArray) {
+                        $priceTax = 0;
 
-						foreach ($taxArray as $tax => $value) {
-							$taxRow['tax'] = floatval($tax);
-							$newPriceTax = $priceObj->getModePrice(
-								$basketExtra,
-								$basketRecs,
-								$conf['TAXmode'],
-								$value,
-								true,
-								$taxRow,
-								false,
-								true
-							);
-							$priceTax += $newPriceTax;
+                        foreach ($taxArray as $tax => $value) {
+                            $taxRow['tax'] = floatval($tax);
+                            $newPriceTax = $priceObj->getModePrice(
+                                $basketExtra,
+                                $basketRecs,
+                                $conf['TAXmode'],
+                                $value,
+                                true,
+                                $taxRow,
+                                false,
+                                true
+                            );
+                            $priceTax += $newPriceTax;
 
                             $this->calculatedArray[$keyNoTax]['sametaxtotal'][$countryIndex][$tax] = $value;
                             $this->calculatedArray[$keyTax]['sametaxtotal'][$countryIndex][$tax] = $newPriceTax;
                             $this->calculatedArray[$keyTax]['goodssametaxtotal'][$countryIndex][$tax] = $newPriceTax;
-						}
+                        }
 
-						$this->calculatedArray[$keyTax]['goodstotal'][$countryIndex] = $priceTax;
-					}
-				}
+                        $this->calculatedArray[$keyTax]['goodstotal'][$countryIndex] = $priceTax;
+                    }
+                }
 
-				$controlCatCalcCatArray = ['categoryPriceTax' => 'categoryPriceNoTax'];
-				foreach ($controlCatCalcCatArray as $keyTax => $keyNoTax) {
-					$priceTaxArray = [];
-					$priceTax = 0;
-					foreach ($this->calculatedArray[$keyNoTax]['goodssametaxtotal']['ALL'] as $tax => $catArray) {
-						$taxRow['tax'] = floatval($tax);
-						if (is_array($catArray)) {
-							foreach ($catArray as $cat => $value) {
-								$newPriceTax =
-									$priceObj->getModePrice(
-										$basketExtra,
-										$basketRecs,
-										$conf['TAXmode'],
-										$value,
-										true,
-										$taxRow,
-										false,
-										true
-									);
-								$priceTax += $newPriceTax;
-								$this->calculatedArray[$keyNoTax]['sametaxtotal']['ALL'][$cat][$tax] = $value;
-								$this->calculatedArray[$keyTax]['sametaxtotal']['ALL'][$cat][$tax] = $newPriceTax;
-							}
-						}
-					}
-					$this->calculatedArray[$keyTax]['goodstotal']['ALL'] = $priceTaxArray;
-				}
-				$this->calculatedArray['handling']['0']['priceTax'] =
-					$priceObj->getModePrice(
-						$basketExtra,
-						$basketRecs,
-						$conf['TAXmode'],
-						$this->calculatedArray['handling']['0']['priceNoTax'],
-						true,
-						$shippingRow,
-						false,
-						true
-					);
-				$this->calculatedArray['shipping']['priceTax'] =
-					$priceObj->getModePrice(
-						$basketExtra,
-						$basketRecs,
-						$conf['TAXmode'],
-						$this->calculatedArray['shipping']['priceNoTax'],
-						true,
-						$shippingRow,
-						false,
-						true
-					);
-			}
-		} // if (count($itemArray))
-		$paymentTax = PaymentShippingHandling::getTaxPercentage($basketExtra, 'payment', '');
-		if ($paymentTax > $maxTax) {
-			$maxTax = $paymentTax;
-		} else if ($paymentTax == '') {
-			$paymentTax = $maxTax;
-		}
-		$paymentRow = ['tax' => floatval($paymentTax)];
+                $controlCatCalcCatArray = ['categoryPriceTax' => 'categoryPriceNoTax'];
+                foreach ($controlCatCalcCatArray as $keyTax => $keyNoTax) {
+                    $priceTaxArray = [];
+                    $priceTax = 0;
+                    foreach ($this->calculatedArray[$keyNoTax]['goodssametaxtotal']['ALL'] as $tax => $catArray) {
+                        $taxRow['tax'] = floatval($tax);
+                        if (is_array($catArray)) {
+                            foreach ($catArray as $cat => $value) {
+                                $newPriceTax =
+                                    $priceObj->getModePrice(
+                                        $basketExtra,
+                                        $basketRecs,
+                                        $conf['TAXmode'],
+                                        $value,
+                                        true,
+                                        $taxRow,
+                                        false,
+                                        true
+                                    );
+                                $priceTax += $newPriceTax;
+                                $this->calculatedArray[$keyNoTax]['sametaxtotal']['ALL'][$cat][$tax] = $value;
+                                $this->calculatedArray[$keyTax]['sametaxtotal']['ALL'][$cat][$tax] = $newPriceTax;
+                            }
+                        }
+                    }
+                    $this->calculatedArray[$keyTax]['goodstotal']['ALL'] = $priceTaxArray;
+                }
+                $this->calculatedArray['handling']['0']['priceTax'] =
+                    $priceObj->getModePrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $conf['TAXmode'],
+                        $this->calculatedArray['handling']['0']['priceNoTax'],
+                        true,
+                        $shippingRow,
+                        false,
+                        true
+                    );
+                $this->calculatedArray['shipping']['priceTax'] =
+                    $priceObj->getModePrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $conf['TAXmode'],
+                        $this->calculatedArray['shipping']['priceNoTax'],
+                        true,
+                        $shippingRow,
+                        false,
+                        true
+                    );
+            }
+        } // if (count($itemArray))
+        $paymentTax = PaymentShippingHandling::getTaxPercentage($basketExtra, 'payment', '');
+        if ($paymentTax > $maxTax) {
+            $maxTax = $paymentTax;
+        } else if ($paymentTax == '') {
+            $paymentTax = $maxTax;
+        }
+        $paymentRow = ['tax' => floatval($paymentTax)];
 
-		PaymentShippingHandling::getHandlingData(
-			$basketExtra,
-			$basketRecs,
-			$conf,
-			$iso3Seller,
-			$iso3Buyer,
-			$this->calculatedArray['count'] ?? 0,
-			$this->calculatedArray['priceTax']['goodstotal']['ALL'],
-			$this->calculatedArray,
-			$itemArray
-		);
+        PaymentShippingHandling::getHandlingData(
+            $basketExtra,
+            $basketRecs,
+            $conf,
+            $iso3Seller,
+            $iso3Buyer,
+            $this->calculatedArray['count'] ?? 0,
+            $this->calculatedArray['priceTax']['goodstotal']['ALL'],
+            $this->calculatedArray,
+            $itemArray
+        );
 
-		// payment must be dealt with at the latest because the payment gateway must know about all other costs
-			// Shipping must be at the end in order to use the calculated values from before
-		PaymentShippingHandling::getPaymentShippingData(
-			$basketExtra,
-			$basketRecs,
-			$conf,
-			$iso3Seller,
-			$iso3Buyer,
-			$this->calculatedArray['count'] ?? 0,
-			$this->calculatedArray['priceTax']['goodstotal']['ALL'],
-			$shippingRow,
-			$paymentRow,
-			$itemArray,
-			$this->calculatedArray,
-			$this->calculatedArray['shipping']['priceTax'],
-			$this->calculatedArray['shipping']['priceNoTax'],
-			$this->calculatedArray['payment']['priceTax'],
-			$this->calculatedArray['payment']['priceNoTax']
-		);
+        // payment must be dealt with at the latest because the payment gateway must know about all other costs
+            // Shipping must be at the end in order to use the calculated values from before
+        PaymentShippingHandling::getPaymentShippingData(
+            $basketExtra,
+            $basketRecs,
+            $conf,
+            $iso3Seller,
+            $iso3Buyer,
+            $this->calculatedArray['count'] ?? 0,
+            $this->calculatedArray['priceTax']['goodstotal']['ALL'],
+            $shippingRow,
+            $paymentRow,
+            $itemArray,
+            $this->calculatedArray,
+            $this->calculatedArray['shipping']['priceTax'],
+            $this->calculatedArray['shipping']['priceNoTax'],
+            $this->calculatedArray['payment']['priceTax'],
+            $this->calculatedArray['payment']['priceNoTax']
+        );
 
-		if ($shippingTax) {
+        if ($shippingTax) {
             if (!isset($this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($shippingTax, 2))])) {
                 $this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($shippingTax, 2))] = 0;
             }
-			$this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($shippingTax, 2))] += $this->calculatedArray['shipping']['priceNoTax'];
-		}
+            $this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($shippingTax, 2))] += $this->calculatedArray['shipping']['priceNoTax'];
+        }
 
-		if ($paymentTax) {
+        if ($paymentTax) {
             if (!isset($this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($paymentTax, 2))])) {
                 $this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($paymentTax, 2))] = 0;
             }
-			$this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($paymentTax, 2))] += $this->calculatedArray['payment']['priceNoTax'];
-		}
-	} // calculate
+            $this->calculatedArray['priceNoTax']['sametaxtotal']['ALL'][strval(number_format($paymentTax, 2))] += $this->calculatedArray['payment']['priceNoTax'];
+        }
+    } // calculate
 
 
-	// This calculates the total for everything in the basket
-	public function calculateSums (
-		$roundFormat,
-		$pricefactor,
-		$creditpoints,
-		$getShopCountryCode
-	) {
-		$creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
+    // This calculates the total for everything in the basket
+    public function calculateSums (
+        $roundFormat,
+        $pricefactor,
+        $creditpoints,
+        $getShopCountryCode
+    ) {
+        $creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
 
-	// Todo: consider the $roundFormat parameter .XXXXXXXXXX
-		$calculatedArray = $this->getCalculatedArray();
-		$baseCountryArray =
-			[
-				'ALL'
-			];
-		if ($getShopCountryCode != '') {
-			$baseCountryArray[] = $getShopCountryCode;
-		}
+    // Todo: consider the $roundFormat parameter .XXXXXXXXXX
+        $calculatedArray = $this->getCalculatedArray();
+        $baseCountryArray =
+            [
+                'ALL'
+            ];
+        if ($getShopCountryCode != '') {
+            $baseCountryArray[] = $getShopCountryCode;
+        }
 
-		$calculatedArray['priceTax']['creditpoints'] = $calculatedArray['priceNoTax']['creditpoints'] = $creditpointsObj->getBasketTotal() * $pricefactor;
+        $calculatedArray['priceTax']['creditpoints'] = $calculatedArray['priceNoTax']['creditpoints'] = $creditpointsObj->getBasketTotal() * $pricefactor;
 
-		foreach ($calculatedArray['priceNoTax']['goodstotal'] as $countryCode => $value) {
-			$calculatedArray['priceNoTax']['total'][$countryCode] = round($value, 2);
-		}
-		foreach ($calculatedArray['priceTax']['goodstotal'] as $countryCode => $value) {
-			$calculatedArray['priceTax']['total'][$countryCode] = round($value, 2);
-		}
+        foreach ($calculatedArray['priceNoTax']['goodstotal'] as $countryCode => $value) {
+            $calculatedArray['priceNoTax']['total'][$countryCode] = round($value, 2);
+        }
+        foreach ($calculatedArray['priceTax']['goodstotal'] as $countryCode => $value) {
+            $calculatedArray['priceTax']['total'][$countryCode] = round($value, 2);
+        }
 
-		if (
-			isset($calculatedArray['handling']) &&
-			is_array($calculatedArray['handling'])
-		) {
-			foreach ($calculatedArray['handling'] as $subkey => $handlingConf) {
-				foreach ($baseCountryArray as $baseCountry) {
-					$calculatedArray['priceNoTax']['total'][$baseCountry] += $handlingConf['priceNoTax'];
-					$calculatedArray['priceTax']['total'][$baseCountry] += $handlingConf['priceTax'];
-				}
-			}
-		}
+        if (
+            isset($calculatedArray['handling']) &&
+            is_array($calculatedArray['handling'])
+        ) {
+            foreach ($calculatedArray['handling'] as $subkey => $handlingConf) {
+                foreach ($baseCountryArray as $baseCountry) {
+                    $calculatedArray['priceNoTax']['total'][$baseCountry] += $handlingConf['priceNoTax'];
+                    $calculatedArray['priceTax']['total'][$baseCountry] += $handlingConf['priceTax'];
+                }
+            }
+        }
 
-		foreach ($baseCountryArray as $baseCountry) {
-			$calculatedArray['priceNoTax']['total'][$baseCountry] +=
-				round($calculatedArray['payment']['priceNoTax'], 2);
-			$calculatedArray['priceNoTax']['total'][$baseCountry] +=
-				round($calculatedArray['shipping']['priceNoTax'], 2);
+        foreach ($baseCountryArray as $baseCountry) {
+            $calculatedArray['priceNoTax']['total'][$baseCountry] +=
+                round($calculatedArray['payment']['priceNoTax'], 2);
+            $calculatedArray['priceNoTax']['total'][$baseCountry] +=
+                round($calculatedArray['shipping']['priceNoTax'], 2);
 
-			$calculatedArray['priceTax']['total'][$baseCountry] +=
-				$calculatedArray['payment']['priceTax'];
-			$calculatedArray['priceTax']['total'][$baseCountry] +=
-				$calculatedArray['shipping']['priceTax'];
-		}
+            $calculatedArray['priceTax']['total'][$baseCountry] +=
+                $calculatedArray['payment']['priceTax'];
+            $calculatedArray['priceTax']['total'][$baseCountry] +=
+                $calculatedArray['shipping']['priceTax'];
+        }
 
-		$calculatedArray['price0NoTax']['total']['ALL']  =
-			$calculatedArray['price0NoTax']['goodstotal']['ALL'];
-		$calculatedArray['price0Tax']['total']['ALL']  = $calculatedArray['price0Tax']['goodstotal']['ALL'];
+        $calculatedArray['price0NoTax']['total']['ALL']  =
+            $calculatedArray['price0NoTax']['goodstotal']['ALL'];
+        $calculatedArray['price0Tax']['total']['ALL']  = $calculatedArray['price0Tax']['goodstotal']['ALL'];
 
-		$calculatedArray['price2NoTax']['total']['ALL']  = $calculatedArray['price2NoTax']['goodstotal']['ALL'];
-		$calculatedArray['price2Tax']['total']['ALL']  = $calculatedArray['price2Tax']['goodstotal']['ALL'];
+        $calculatedArray['price2NoTax']['total']['ALL']  = $calculatedArray['price2NoTax']['goodstotal']['ALL'];
+        $calculatedArray['price2Tax']['total']['ALL']  = $calculatedArray['price2Tax']['goodstotal']['ALL'];
 
-		$this->setCalculatedArray($calculatedArray);
-	}
+        $this->setCalculatedArray($calculatedArray);
+    }
 
 
-	// This calculates the total for the voucher in the basket
-	public function addVoucherSums () {
-		$result = false;
-		$calculatedArray = $this->getCalculatedArray();
+    // This calculates the total for the voucher in the basket
+    public function addVoucherSums () {
+        $result = false;
+        $calculatedArray = $this->getCalculatedArray();
 
-		if (!isset($calculatedArray['priceNoTax']['total'])) {
-			debug ('internal ERROR in tt_products method addVoucherSums');// keep this
-		} else {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$voucherObj = $tablesObj->get('voucher');
-			$voucherAmount = 0;
+        if (!isset($calculatedArray['priceNoTax']['total'])) {
+            debug ('internal ERROR in tt_products method addVoucherSums');// keep this
+        } else {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $voucherObj = $tablesObj->get('voucher');
+            $voucherAmount = 0;
 
-			if (is_object($voucherObj) && $voucherObj->isEnabled()) {
-				$voucherAmount = $voucherObj->getRebateAmount();
-			}
+            if (is_object($voucherObj) && $voucherObj->isEnabled()) {
+                $voucherAmount = $voucherObj->getRebateAmount();
+            }
 
-			$calculatedArray['priceNoTax']['vouchertotal']['ALL'] = $calculatedArray['priceNoTax']['total']['ALL'] - $voucherAmount - $calculatedArray['priceNoTax']['creditpoints'];
+            $calculatedArray['priceNoTax']['vouchertotal']['ALL'] = $calculatedArray['priceNoTax']['total']['ALL'] - $voucherAmount - $calculatedArray['priceNoTax']['creditpoints'];
 
-			$calculatedArray['priceTax']['vouchertotal']['ALL'] = $calculatedArray['priceTax']['total']['ALL'] - $voucherAmount - $calculatedArray['priceTax']['creditpoints'];
+            $calculatedArray['priceTax']['vouchertotal']['ALL'] = $calculatedArray['priceTax']['total']['ALL'] - $voucherAmount - $calculatedArray['priceTax']['creditpoints'];
 
-			$calculatedArray['priceNoTax']['vouchergoodstotal']['ALL'] = $calculatedArray['priceNoTax']['goodstotal']['ALL'] - $voucherAmount - $calculatedArray['priceNoTax']['creditpoints'];
+            $calculatedArray['priceNoTax']['vouchergoodstotal']['ALL'] = $calculatedArray['priceNoTax']['goodstotal']['ALL'] - $voucherAmount - $calculatedArray['priceNoTax']['creditpoints'];
 
-			$calculatedArray['priceTax']['vouchergoodstotal']['ALL'] = $calculatedArray['priceTax']['goodstotal']['ALL'] - $voucherAmount - $calculatedArray['priceTax']['creditpoints'];
+            $calculatedArray['priceTax']['vouchergoodstotal']['ALL'] = $calculatedArray['priceTax']['goodstotal']['ALL'] - $voucherAmount - $calculatedArray['priceTax']['creditpoints'];
 
-			$result = true;
-		}
+            $result = true;
+        }
 
-		$this->setCalculatedArray($calculatedArray);
-		return $result;
-	}
+        $this->setCalculatedArray($calculatedArray);
+        return $result;
+    }
 }
 

--- a/model/class.tx_ttproducts_basketitem.php
+++ b/model/class.tx_ttproducts_basketitem.php
@@ -42,54 +42,54 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class tx_ttproducts_basketitem implements \TYPO3\CMS\Core\SingletonInterface {
 
-	/**
-	 * gets the quantity of an item
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		overwrite amount or 'basket'
-	 * @return	array
-	 * @access private
-	 */
-	public function getQuantity (
-		&$item,
-		$overwriteAmount = ''
-	) {
-		$result = $item['count'];
-		if (
-			$overwriteAmount != 'basket' &&
-			MathUtility::canBeInterpretedAsInteger($overwriteAmount)
-		) {
-			$result = intval($overwriteAmount);
-		}
-		return $result;
-	}
+    /**
+     * gets the quantity of an item
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		overwrite amount or 'basket'
+     * @return	array
+     * @access private
+     */
+    public function getQuantity (
+        &$item,
+        $overwriteAmount = ''
+    ) {
+        $result = $item['count'];
+        if (
+            $overwriteAmount != 'basket' &&
+            MathUtility::canBeInterpretedAsInteger($overwriteAmount)
+        ) {
+            $result = intval($overwriteAmount);
+        }
+        return $result;
+    }
 
 
-	/**
-	 * gets the minimum necessary and maximum possible quantity of an item
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		overwrite amount or 'basket'
-	 * @return	array
-	 * @access private
-	 */
-	public function getMinMaxQuantity (
-		$item,
-		&$minQuantity,
-		&$maxQuantity
-	) {
-		$row = $item['rec'];
-		$minQuantity = $row['basketminquantity'];
-		$maxQuantity = $row['basketmaxquantity'];
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$prodTable = $tablesObj->get('tt_products', false);
-		$articleRow = $prodTable->getArticleRowFromExt($row);
+    /**
+     * gets the minimum necessary and maximum possible quantity of an item
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		overwrite amount or 'basket'
+     * @return	array
+     * @access private
+     */
+    public function getMinMaxQuantity (
+        $item,
+        &$minQuantity,
+        &$maxQuantity
+    ) {
+        $row = $item['rec'];
+        $minQuantity = $row['basketminquantity'];
+        $maxQuantity = $row['basketmaxquantity'];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $prodTable = $tablesObj->get('tt_products', false);
+        $articleRow = $prodTable->getArticleRowFromExt($row);
 
-		if (is_array($articleRow) && count($articleRow)) {
-			$minQuantity = ($articleRow['basketminquantity'] != '0.00' ? $articleRow['basketminquantity'] : $minQuantity);
-			$maxQuantity = ($articleRow['basketmaxquantity'] != '0.00' ? $articleRow['basketmaxquantity'] : $maxQuantity);
-		}
-	}
+        if (is_array($articleRow) && count($articleRow)) {
+            $minQuantity = ($articleRow['basketminquantity'] != '0.00' ? $articleRow['basketminquantity'] : $minQuantity);
+            $maxQuantity = ($articleRow['basketmaxquantity'] != '0.00' ? $articleRow['basketmaxquantity'] : $maxQuantity);
+        }
+    }
 }
 
 

--- a/model/class.tx_ttproducts_card.php
+++ b/model/class.tx_ttproducts_card.php
@@ -43,134 +43,134 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_card extends tx_ttproducts_table_base {
-	var $ccArray;	// credit card data
-	var $allowedArray = []; // allowed uids of credit cards
-	var $inputFieldArray = ['cc_type', 'cc_number_1','cc_number_2','cc_number_3', 'cc_number_4', 'owner_name', 'cvv2', 'endtime_mm', 'endtime_yy'];
-	var $sizeArray = ['cc_type' => 4, 'cc_number_1' => 4,'cc_number_2' => 4,'cc_number_3' => 4, 'cc_number_4' => 4, 'owner_name' => 0, 'cvv2' => 4, 'endtime_mm' => 2, 'endtime_yy'  => 2];
-	var $asteriskArray = [2 => '**', 4 => '****'];
+    var $ccArray;	// credit card data
+    var $allowedArray = []; // allowed uids of credit cards
+    var $inputFieldArray = ['cc_type', 'cc_number_1','cc_number_2','cc_number_3', 'cc_number_4', 'owner_name', 'cvv2', 'endtime_mm', 'endtime_yy'];
+    var $sizeArray = ['cc_type' => 4, 'cc_number_1' => 4,'cc_number_2' => 4,'cc_number_3' => 4, 'cc_number_4' => 4, 'owner_name' => 0, 'cvv2' => 4, 'endtime_mm' => 2, 'endtime_yy'  => 2];
+    var $asteriskArray = [2 => '**', 4 => '****'];
 
 
-	public function init ($functablename) {
-		$result = true;
+    public function init ($functablename) {
+        $result = true;
 
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$formerBasket = $basketObj->recs;
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $formerBasket = $basketObj->recs;
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
 
-		if (isset($basketExtra) && is_array($basketExtra) && isset($basketExtra['payment.'])) {
-			$allowedUids = $basketExtra['payment.']['creditcards'] ?? '';
-		}
+        if (isset($basketExtra) && is_array($basketExtra) && isset($basketExtra['payment.'])) {
+            $allowedUids = $basketExtra['payment.']['creditcards'] ?? '';
+        }
 
-		$result = parent::init($functablename);
+        $result = parent::init($functablename);
 
-		$this->ccArray = $formerBasket['creditcard'] ?? [];
-		if (isset($allowedUids)) {
-			$this->allowedArray = GeneralUtility::trimExplode(',',$allowedUids);
-		}
-		$bNumberRecentlyModified = false;
+        $this->ccArray = $formerBasket['creditcard'] ?? [];
+        if (isset($allowedUids)) {
+            $this->allowedArray = GeneralUtility::trimExplode(',',$allowedUids);
+        }
+        $bNumberRecentlyModified = false;
 
-		foreach ($this->inputFieldArray as $k => $field) {
-			$size = $this->sizeArray[$field];
-			if ($size) {
-				if (isset($this->ccArray[$field]) && strcmp ($this->ccArray[$field], $this->asteriskArray[$size]) != 0) {
-					$bNumberRecentlyModified = true;
-				}
-			}
-		}
+        foreach ($this->inputFieldArray as $k => $field) {
+            $size = $this->sizeArray[$field];
+            if ($size) {
+                if (isset($this->ccArray[$field]) && strcmp ($this->ccArray[$field], $this->asteriskArray[$size]) != 0) {
+                    $bNumberRecentlyModified = true;
+                }
+            }
+        }
 
-		if ($bNumberRecentlyModified) {
+        if ($bNumberRecentlyModified) {
 
-			$ccArray = tx_ttproducts_control_session::readSession('cc');
-			if (!$ccArray) {
-				$ccArray = [];
-			}
+            $ccArray = tx_ttproducts_control_session::readSession('cc');
+            if (!$ccArray) {
+                $ccArray = [];
+            }
 
-			$allowedTags = '';
-			foreach ($ccArray as $type => $ccRow) {
-				$ccArray[$type] = strip_tags ($ccRow, $allowedTags);
-			}
+            $allowedTags = '';
+            foreach ($ccArray as $type => $ccRow) {
+                $ccArray[$type] = strip_tags ($ccRow, $allowedTags);
+            }
 
-			if ($this->ccArray) {
-				$newId = $this->create ($ccArray['cc_uid'], $this->ccArray);
+            if ($this->ccArray) {
+                $newId = $this->create ($ccArray['cc_uid'], $this->ccArray);
 
-				if ($newId) {
-					$ccArray['cc_uid'] = $newId;
-					tx_ttproducts_control_session::writeSession('cc', $ccArray);
+                if ($newId) {
+                    $ccArray['cc_uid'] = $newId;
+                    tx_ttproducts_control_session::writeSession('cc', $ccArray);
 
-					for ($i = 1; $i <= 3; ++$i) {
-						$this->ccArray['cc_number_' . $i] = ($this->ccArray['cc_number_' . $i] ? $this->asteriskArray[$this->sizeArray['cc_number_' . $i]] : '');
-					}
+                    for ($i = 1; $i <= 3; ++$i) {
+                        $this->ccArray['cc_number_' . $i] = ($this->ccArray['cc_number_' . $i] ? $this->asteriskArray[$this->sizeArray['cc_number_' . $i]] : '');
+                    }
 
-					$this->ccArray['cvv2'] = ($this->ccArray['cvv2'] ? $this->asteriskArray[$this->sizeArray['cvv2']] : '' );
-					if (!is_array($this->conf['payment.']['creditcardSelect.']['mm.'])) {
-						$this->ccArray['endtime_mm'] = ($this->ccArray['endtime_mm'] ? $this->asteriskArray[$this->sizeArray['endtime_mm']] : '');
-					}
-					if (!is_array($this->conf['payment.']['creditcardSelect.']['yy.'])) {
-						$this->ccArray['endtime_yy'] = ($this->ccArray['endtime_yy'] ? $this->asteriskArray[$this->sizeArray['endtime_yy']] : '');
-					}
-				}
-			}
-		}
+                    $this->ccArray['cvv2'] = ($this->ccArray['cvv2'] ? $this->asteriskArray[$this->sizeArray['cvv2']] : '' );
+                    if (!is_array($this->conf['payment.']['creditcardSelect.']['mm.'])) {
+                        $this->ccArray['endtime_mm'] = ($this->ccArray['endtime_mm'] ? $this->asteriskArray[$this->sizeArray['endtime_mm']] : '');
+                    }
+                    if (!is_array($this->conf['payment.']['creditcardSelect.']['yy.'])) {
+                        $this->ccArray['endtime_yy'] = ($this->ccArray['endtime_yy'] ? $this->asteriskArray[$this->sizeArray['endtime_yy']] : '');
+                    }
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	// **************************
-	// ORDER related functions
-	// **************************
+    // **************************
+    // ORDER related functions
+    // **************************
 
-	/**
-	 * Create a new credit card record
-	 *
-	 * This creates a new credit card record on the page with pid PID_sys_products_orders. That page must exist!
-	 */
-	public function create ($uid, $ccArray) {
-		$newId = 0;
-		$tablename = $this->getTablename();
-		$pid = intval($this->conf['PID_sys_products_orders']);
-		if (!$pid) {
-			$pid = intval($GLOBALS['TSFE']->id);
-		}
+    /**
+     * Create a new credit card record
+     *
+     * This creates a new credit card record on the page with pid PID_sys_products_orders. That page must exist!
+     */
+    public function create ($uid, $ccArray) {
+        $newId = 0;
+        $tablename = $this->getTablename();
+        $pid = intval($this->conf['PID_sys_products_orders']);
+        if (!$pid) {
+            $pid = intval($GLOBALS['TSFE']->id);
+        }
 
-		if ($ccArray['cc_number_1'] && $GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)) {
-			$time = time();
-			$timeArray =
-				[
-					'hour' => 0, // hour
-					'minute' => 0, // minute
-					'second' => 0, // second
-					'month' => intval($ccArray['endtime_mm']), // month
-					'day' => 28, // day
-					'year' => intval($ccArray['endtime_yy']) // year
-				];
-			$endtime = mktime ($timeArray['hour'], $timeArray['minute'], $timeArray['second'], $timeArray['month'], $timeArray['day'], $timeArray['year']);
+        if ($ccArray['cc_number_1'] && $GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)) {
+            $time = time();
+            $timeArray =
+                [
+                    'hour' => 0, // hour
+                    'minute' => 0, // minute
+                    'second' => 0, // second
+                    'month' => intval($ccArray['endtime_mm']), // month
+                    'day' => 28, // day
+                    'year' => intval($ccArray['endtime_yy']) // year
+                ];
+            $endtime = mktime ($timeArray['hour'], $timeArray['minute'], $timeArray['second'], $timeArray['month'], $timeArray['day'], $timeArray['year']);
 
-			if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-				$endtime += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-			}
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                $endtime += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+            }
 
-			for ($i = 1; $i <= 4; ++$i) {
-				$ccArray['cc_number_' . $i] = ($ccArray['cc_number_' . $i] ? $ccArray['cc_number_' . $i] : '   ');
-			}
+            for ($i = 1; $i <= 4; ++$i) {
+                $ccArray['cc_number_' . $i] = ($ccArray['cc_number_' . $i] ? $ccArray['cc_number_' . $i] : '   ');
+            }
 
-			$newFields = array (
-				'pid' => intval($pid),
-				'tstamp' => $time,
-				'crdate' => $time,
-				'endtime' => $endtime,
-				'owner_name' => $ccArray['owner_name'],
-				'cc_number' => $ccArray['cc_number_1'] . $ccArray['cc_number_2'] . $ccArray['cc_number_3'] . $ccArray['cc_number_4'],
-				'cc_type' => $ccArray['cc_type'],
-				'cvv2' => $ccArray['cvv2']
-			);
+            $newFields = array (
+                'pid' => intval($pid),
+                'tstamp' => $time,
+                'crdate' => $time,
+                'endtime' => $endtime,
+                'owner_name' => $ccArray['owner_name'],
+                'cc_number' => $ccArray['cc_number_1'] . $ccArray['cc_number_2'] . $ccArray['cc_number_3'] . $ccArray['cc_number_4'],
+                'cc_type' => $ccArray['cc_type'],
+                'cvv2' => $ccArray['cvv2']
+            );
 
-			if ($uid) {
-				$where_clause = 'uid=' . $uid;
-				$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', $tablename, $where_clause);
-				$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				for ($i = 1; $i <= 4; ++$i) {
+            if ($uid) {
+                $where_clause = 'uid=' . $uid;
+                $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', $tablename, $where_clause);
+                $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                for ($i = 1; $i <= 4; ++$i) {
                     $tmpOldPart = '';
                     if (!empty($row['cc_number'])) {
                         $tmpOldPart = substr($row['cc_number'], ($i-1) * 4, 4);
@@ -180,118 +180,118 @@ class tx_ttproducts_card extends tx_ttproducts_table_base {
                             $ccArray['cc_number_' . $i] = $tmpOldPart;
                         }
                     }
-				}
-				$fieldArray = ['cc_type', 'owner_name', 'cvv2'];
+                }
+                $fieldArray = ['cc_type', 'owner_name', 'cvv2'];
 
-				foreach ($fieldArray as $k => $field) {
-					if (isset($ccArray[$field]) && strcmp($ccArray[$field], $this->asteriskArray[$this->sizeArray[$field]]) == 0) {
-						unset($newFields[$field]); // prevent from change into asterisks
-					}
-				}
-				$newFields['cc_number'] = $ccArray['cc_number_1'] . $ccArray['cc_number_2'].$ccArray['cc_number_3'].$ccArray['cc_number_4'];
-				$oldEndtime = getdate($row['endtime']);
-				if (strcmp($ccArray['endtime_mm'], $this->asteriskArray[$this->sizeArray['endtime_mm']]) == 0) {
-					$ccArray['endtime_mm'] = $oldEndtime['mon'];
-				}
-				if (strcmp($ccArray['endtime_yy'], $this->asteriskArray[$this->sizeArray['endtime_yy']]) == 0) {
-					$ccArray['endtime_yy'] = $oldEndtime['year'];
-				}
+                foreach ($fieldArray as $k => $field) {
+                    if (isset($ccArray[$field]) && strcmp($ccArray[$field], $this->asteriskArray[$this->sizeArray[$field]]) == 0) {
+                        unset($newFields[$field]); // prevent from change into asterisks
+                    }
+                }
+                $newFields['cc_number'] = $ccArray['cc_number_1'] . $ccArray['cc_number_2'].$ccArray['cc_number_3'].$ccArray['cc_number_4'];
+                $oldEndtime = getdate($row['endtime']);
+                if (strcmp($ccArray['endtime_mm'], $this->asteriskArray[$this->sizeArray['endtime_mm']]) == 0) {
+                    $ccArray['endtime_mm'] = $oldEndtime['mon'];
+                }
+                if (strcmp($ccArray['endtime_yy'], $this->asteriskArray[$this->sizeArray['endtime_yy']]) == 0) {
+                    $ccArray['endtime_yy'] = $oldEndtime['year'];
+                }
 
-				$timeArray =
-					[
-						'hour' => 0, // hour
-						'minute' => 0, // minute
-						'second' => 0, // second
-						'month' => intval($ccArray['endtime_mm']), // month
-						'day' => 28, // day
-						'year' => intval($ccArray['endtime_yy']) // year
-					];
-				$endtime = mktime($timeArray['hour'], $timeArray['minute'], $timeArray['second'], $timeArray['month'], $timeArray['day'], $timeArray['year']);
+                $timeArray =
+                    [
+                        'hour' => 0, // hour
+                        'minute' => 0, // minute
+                        'second' => 0, // second
+                        'month' => intval($ccArray['endtime_mm']), // month
+                        'day' => 28, // day
+                        'year' => intval($ccArray['endtime_yy']) // year
+                    ];
+                $endtime = mktime($timeArray['hour'], $timeArray['minute'], $timeArray['second'], $timeArray['month'], $timeArray['day'], $timeArray['year']);
 
-				if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-					$endtime += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-				}
+                if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                    $endtime += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+                }
 
-				$newFields['endtime'] = $endtime;
+                $newFields['endtime'] = $endtime;
 
-				$GLOBALS['TYPO3_DB']->exec_UPDATEquery($tablename, $where_clause, $newFields);
-				$newId = $uid;
-			} else {
-				$GLOBALS['TYPO3_DB']->exec_INSERTquery($tablename, $newFields);
-				$newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
-			}
-		}
-		return $newId;
-	} // create
-
-
-	public function getUid () {
-		$result = 0;
-		$ccArray = tx_ttproducts_control_session::readSession('cc');
-		if (isset($ccArray['cc_uid'])) {
-			$result = $ccArray['cc_uid'];
-		}
-		return $result;
-	}
+                $GLOBALS['TYPO3_DB']->exec_UPDATEquery($tablename, $where_clause, $newFields);
+                $newId = $uid;
+            } else {
+                $GLOBALS['TYPO3_DB']->exec_INSERTquery($tablename, $newFields);
+                $newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
+            }
+        }
+        return $newId;
+    } // create
 
 
-	public function getAllowedArray () {
-		return $this->allowedArray;
-	}
+    public function getUid () {
+        $result = 0;
+        $ccArray = tx_ttproducts_control_session::readSession('cc');
+        if (isset($ccArray['cc_uid'])) {
+            $result = $ccArray['cc_uid'];
+        }
+        return $result;
+    }
 
 
-	public function getRow ($uid, $bFieldArrayAll = false) {
-		$rcArray = [];
-		if ($bFieldArrayAll) {
-			foreach ($this->inputFieldArray as $k => $field) {
-				$rcArray[$field] = '';
-			}
-		}
-
-		if ($uid) {
-			$where = 'uid = ' . intval($uid);
-
-			$fields = '*';
-			if ($bFieldArrayAll) {
-				$fields = implode(',', $this->inputFieldArray);
-			}
-			$tablename = $this->getTablename();
-			if ($tablename == '') {
-				$tablename = 'sys_products_cards';
-			}
-			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery($fields, $tablename, $where);
-			$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-			if ($row) {
-				$rcArray = $row;
-			}
-		}
-		return $rcArray;
-	}
+    public function getAllowedArray () {
+        return $this->allowedArray;
+    }
 
 
-	/**
-	 * Checks if required fields for credit cards and bank accounts are filled in
-	 */
-	public function checkRequired () {
-		$rc = '';
-		$allowedArray = $this->getAllowedArray();
+    public function getRow ($uid, $bFieldArrayAll = false) {
+        $rcArray = [];
+        if ($bFieldArrayAll) {
+            foreach ($this->inputFieldArray as $k => $field) {
+                $rcArray[$field] = '';
+            }
+        }
 
-		foreach ($this->inputFieldArray as $k => $field)	{
-			if ($field == 'cc_type' && empty($allowedArray)) {
-				continue;
-			}
+        if ($uid) {
+            $where = 'uid = ' . intval($uid);
 
-			$testVal = $this->ccArray[$field] ?? '';
-			if (
-				!MathUtility::canBeInterpretedAsInteger($testVal) &&
-				!$testVal
-			) {
-				$rc = $field;
-				break;
-			}
-		}
-		return $rc;
-	} // checkRequired
+            $fields = '*';
+            if ($bFieldArrayAll) {
+                $fields = implode(',', $this->inputFieldArray);
+            }
+            $tablename = $this->getTablename();
+            if ($tablename == '') {
+                $tablename = 'sys_products_cards';
+            }
+            $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery($fields, $tablename, $where);
+            $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+            if ($row) {
+                $rcArray = $row;
+            }
+        }
+        return $rcArray;
+    }
+
+
+    /**
+     * Checks if required fields for credit cards and bank accounts are filled in
+     */
+    public function checkRequired () {
+        $rc = '';
+        $allowedArray = $this->getAllowedArray();
+
+        foreach ($this->inputFieldArray as $k => $field)	{
+            if ($field == 'cc_type' && empty($allowedArray)) {
+                continue;
+            }
+
+            $testVal = $this->ccArray[$field] ?? '';
+            if (
+                !MathUtility::canBeInterpretedAsInteger($testVal) &&
+                !$testVal
+            ) {
+                $rc = $field;
+                break;
+            }
+        }
+        return $rc;
+    } // checkRequired
 }
 

--- a/model/class.tx_ttproducts_category.php
+++ b/model/class.tx_ttproducts_category.php
@@ -44,600 +44,600 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 use JambageCom\Div2007\Utility\ExtensionUtility;
 
 class tx_ttproducts_category extends tx_ttproducts_category_base {
-	public $tt_products_email;	// object of the type tx_table_db
-	public $tableconf;
-	protected $tableAlias = 'cat';
+    public $tt_products_email;	// object of the type tx_table_db
+    public $tableconf;
+    protected $tableAlias = 'cat';
 
-	/**
-	 * initialization with table object and language table
-	 */
-	public function init (
-		$functablename
-	) {
-		$tablename = $functablename;
+    /**
+     * initialization with table object and language table
+     */
+    public function init (
+        $functablename
+    ) {
+        $tablename = $functablename;
 
-		$result = parent::init($functablename);
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$this->tableconf = $cnf->getTableConf($functablename);
-			$tableObj = $this->getTableObj();
-			$tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
-			$tablename = $this->getTablename();
-			$tableObj->setTCAFieldArray($tablename);
+        if ($result) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $this->tableconf = $cnf->getTableConf($functablename);
+            $tableObj = $this->getTableObj();
+            $tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
+            $tablename = $this->getTablename();
+            $tableObj->setTCAFieldArray($tablename);
 
-			if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
 
-				$extensionInfo = ExtensionUtility::getExtensionInfo('mbi_products_categories');
-				if (version_compare($extensionInfo['version'], '0.5.0', '>=')) {
+                $extensionInfo = ExtensionUtility::getExtensionInfo('mbi_products_categories');
+                if (version_compare($extensionInfo['version'], '0.5.0', '>=')) {
 
-					$tableDesc = $cnf->getTableDesc($functablename);
-					$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-					$functablenameArray = GeneralUtility::trimExplode(',', $tableDesc['leafFuncTables']);
-					$prodfunctablename = $functablenameArray[0];
-					if (!$prodfunctablename) {
-						$prodfunctablename = 'tt_products';
-					}
-					$prodOb = $tablesObj->get($prodfunctablename, false);
-					$prodTableDesc = $cnf->getTableDesc($prodfunctablename);
-					$prodtablename = $prodOb->getTablename();
-					$categoryField = ($prodTableDesc['category'] ? $prodTableDesc['category'] : 'category');
-					$rcArray = \JambageCom\Div2007\Utility\TableUtility::getForeignTableInfo($prodtablename, $categoryField);
-					$this->setMMTablename($rcArray['mmtable']);
-				}
-			}
+                    $tableDesc = $cnf->getTableDesc($functablename);
+                    $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+                    $functablenameArray = GeneralUtility::trimExplode(',', $tableDesc['leafFuncTables']);
+                    $prodfunctablename = $functablenameArray[0];
+                    if (!$prodfunctablename) {
+                        $prodfunctablename = 'tt_products';
+                    }
+                    $prodOb = $tablesObj->get($prodfunctablename, false);
+                    $prodTableDesc = $cnf->getTableDesc($prodfunctablename);
+                    $prodtablename = $prodOb->getTablename();
+                    $categoryField = ($prodTableDesc['category'] ? $prodTableDesc['category'] : 'category');
+                    $rcArray = \JambageCom\Div2007\Utility\TableUtility::getForeignTableInfo($prodtablename, $categoryField);
+                    $this->setMMTablename($rcArray['mmtable']);
+                }
+            }
 
-			if ($functablename == 'tt_products_cat') {
-				$parentField = 'parent_category';
-			} else if ($functablename == 'tx_dam_cat') {
-				$parentField = 'parent_id';
-			}
+            if ($functablename == 'tt_products_cat') {
+                $parentField = 'parent_category';
+            } else if ($functablename == 'tx_dam_cat') {
+                $parentField = 'parent_id';
+            }
 
-			if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
-				$this->parentField = $parentField;
-				if ($functablename == 'tt_products_cat')	{
-					$this->referenceField = 'reference_category';
-				}
-			}
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('mbi_products_categories')) {
+                $this->parentField = $parentField;
+                if ($functablename == 'tt_products_cat')	{
+                    $this->referenceField = 'reference_category';
+                }
+            }
 
-	//		if ($GLOBALS['TSFE']->config['config']['sys_language_uid'] &&
-	//				(!$this->catconf['language.'] ||
-	//				!$this->catconf['language.']['type'])) {
+    //		if ($GLOBALS['TSFE']->config['config']['sys_language_uid'] &&
+    //				(!$this->catconf['language.'] ||
+    //				!$this->catconf['language.']['type'])) {
 
-			if ($this->bUseLanguageTable($this->tableconf) && ($functablename == 'tt_products_cat')) {
-				$this->getTableObj()->setLanguage($this->config['LLkey']);
-				$langTable = 'tt_products_cat_language'; // TODO: DAM alternative language
-				$tableObj->setLangName($langTable);
-				$tableObj->setTCAFieldArray($this->getTableObj()->langname);
-			}
+            if ($this->bUseLanguageTable($this->tableconf) && ($functablename == 'tt_products_cat')) {
+                $this->getTableObj()->setLanguage($this->config['LLkey']);
+                $langTable = 'tt_products_cat_language'; // TODO: DAM alternative language
+                $tableObj->setLangName($langTable);
+                $tableObj->setTCAFieldArray($this->getTableObj()->langname);
+            }
 
-			if (isset($this->tableconf['language.']) && isset($this->tableconf['language.']['type']) && $this->tableconf['language.']['type'] == 'csv' && isset($this->tableconf['language.']['file'])) {
-				$tableObj->initLanguageFile($this->tableconf['language.']['file']);
-			}
+            if (isset($this->tableconf['language.']) && isset($this->tableconf['language.']['type']) && $this->tableconf['language.']['type'] == 'csv' && isset($this->tableconf['language.']['file'])) {
+                $tableObj->initLanguageFile($this->tableconf['language.']['file']);
+            }
 
-			if (isset($this->tableconf['language.']) && isset($this->tableconf['language.']['marker.'])) {
-				$tableObj->initMarkerFile($this->tableconf['language.']['marker.']['file']);
-			}
-		}
+            if (isset($this->tableconf['language.']) && isset($this->tableconf['language.']['marker.'])) {
+                $tableObj->initMarkerFile($this->tableconf['language.']['marker.']['file']);
+            }
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
-	public function getRootCat () {
-		$functablename = $this->getFuncTablename ();
-		if ($functablename == 'tt_products_cat') {
-			$result = $this->conf['rootCategoryID'] ?? '';
-		} else if ($functablename == 'tx_dam_cat') {
-			$result = $this->conf['rootDAMCategoryID'] ?? '';
-		}
+    public function getRootCat () {
+        $functablename = $this->getFuncTablename ();
+        if ($functablename == 'tt_products_cat') {
+            $result = $this->conf['rootCategoryID'] ?? '';
+        } else if ($functablename == 'tx_dam_cat') {
+            $result = $this->conf['rootDAMCategoryID'] ?? '';
+        }
 
-		if ($result == '') {
-			$result = '0';
-		}
+        if ($result == '') {
+            $result = '0';
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	public function getAllChildCats (
-		$pid,
-		$orderBy,
-		$category = 0
-	) {
-		$rowArray = [];
-		if ($this->parentField != '') {
-			$where = $this->parentField . '=' . intval($category);
-			$rowArray = $this->get('', $pid, false, $where, '', $orderBy, '', 'uid');
-		}
+    public function getAllChildCats (
+        $pid,
+        $orderBy,
+        $category = 0
+    ) {
+        $rowArray = [];
+        if ($this->parentField != '') {
+            $where = $this->parentField . '=' . intval($category);
+            $rowArray = $this->get('', $pid, false, $where, '', $orderBy, '', 'uid');
+        }
 
-		$resultArray = [];
-		$result = '';
-		if (isset($rowArray) && is_array($rowArray)) {
-			foreach($rowArray as $row) {
-				$resultArray[] = $row['uid'];
-			}
-			$result = implode (',', $resultArray);
-		}
+        $resultArray = [];
+        $result = '';
+        if (isset($rowArray) && is_array($rowArray)) {
+            foreach($rowArray as $row) {
+                $resultArray[] = $row['uid'];
+            }
+            $result = implode (',', $resultArray);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getRootline (
-		$rootArray,
-		$uid,
-		$pid
-	) {
-		$bRootfound = false;
-		$rc = [];
+    public function getRootline (
+        $rootArray,
+        $uid,
+        $pid
+    ) {
+        $bRootfound = false;
+        $rc = [];
 
         if (
             $uid &&
             $this->parentField != ''
         ) {
-			$tableObj = $this->getTableObj();
-			$rc = $rowArray = $this->get($uid . ' ', $pid, false);
-			$orderBy = $this->tableconf['orderBy'];
-			$uidArray = GeneralUtility::trimExplode(',', $uid);
+            $tableObj = $this->getTableObj();
+            $rc = $rowArray = $this->get($uid . ' ', $pid, false);
+            $orderBy = $this->tableconf['orderBy'];
+            $uidArray = GeneralUtility::trimExplode(',', $uid);
 
-			foreach ($uidArray as $actUid) {
-				if (!in_array($actUid, $rootArray)) {
-					$iCount = 0;
-					$row = $rowArray[$actUid];
+            foreach ($uidArray as $actUid) {
+                if (!in_array($actUid, $rootArray)) {
+                    $iCount = 0;
+                    $row = $rowArray[$actUid];
 
-					while (
-						is_array($row) &&
-						($parent = $row[$this->parentField]) &&
-						($iCount < 500)
-					) {
-						$where = 'uid = ' . $parent;
-						$where .= ($pid ? ' AND pid IN (' . $pid . ')' : '');
-						$where .= $tableObj->enableFields();
+                    while (
+                        is_array($row) &&
+                        ($parent = $row[$this->parentField]) &&
+                        ($iCount < 500)
+                    ) {
+                        $where = 'uid = ' . $parent;
+                        $where .= ($pid ? ' AND pid IN (' . $pid . ')' : '');
+                        $where .= $tableObj->enableFields();
 
-						$res =
-							$tableObj->exec_SELECTquery(
-								'*',
-								$where,
-								'',
-								$GLOBALS['TYPO3_DB']->stripOrderBy($orderBy)
-							);
-						$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-						$GLOBALS['TYPO3_DB']->sql_free_result($res);
-						if ($row) {
-							$rc[$parent] = $row;
-						}
+                        $res =
+                            $tableObj->exec_SELECTquery(
+                                '*',
+                                $where,
+                                '',
+                                $GLOBALS['TYPO3_DB']->stripOrderBy($orderBy)
+                            );
+                        $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+                        $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                        if ($row) {
+                            $rc[$parent] = $row;
+                        }
 
-						if (in_array($parent, $rootArray)) {
-							$bRootfound = true;
-							break;
-						}
-						$iCount++;
-					}
+                        if (in_array($parent, $rootArray)) {
+                            $bRootfound = true;
+                            break;
+                        }
+                        $iCount++;
+                    }
 
 
-					if (!$parent || in_array($parent, $rootArray)) {
-						$bRootfound = true;
-						break;
-					}
-				} else {
-					$bRootfound = true;
-				}
-				if ($bRootfound) {
-					break;
-				}
-			}
-		}
+                    if (!$parent || in_array($parent, $rootArray)) {
+                        $bRootfound = true;
+                        break;
+                    }
+                } else {
+                    $bRootfound = true;
+                }
+                if ($bRootfound) {
+                    break;
+                }
+            }
+        }
 
-		if (!$bRootfound) {
-			$rc = [];
-		}
-		return $rc;
-	}
+        if (!$bRootfound) {
+            $rc = [];
+        }
+        return $rc;
+    }
 
-	public function getRelated (
-		$rootUids,
-		$currentCat,
-		$pid = 0,
-		$orderBy = ''
-	) {
-		$bUseReference = false;
-		$relatedArray = [];
-		$uidArray = $rootArray = GeneralUtility::trimExplode(',', $rootUids);
-		$tableObj = $this->getTableObj();
-		$rootLine = $this->getRootline($uidArray, $currentCat, $pid);
+    public function getRelated (
+        $rootUids,
+        $currentCat,
+        $pid = 0,
+        $orderBy = ''
+    ) {
+        $bUseReference = false;
+        $relatedArray = [];
+        $uidArray = $rootArray = GeneralUtility::trimExplode(',', $rootUids);
+        $tableObj = $this->getTableObj();
+        $rootLine = $this->getRootline($uidArray, $currentCat, $pid);
 
-		if (empty($rootLine)) {
-			$rootLine = [];
-		}
+        if (empty($rootLine)) {
+            $rootLine = [];
+        }
 
-		foreach ($rootLine as $k => $row) {
-			if (!in_array($k, $uidArray)) {
-				$uidArray[] = $k;
-			}
-		}
+        foreach ($rootLine as $k => $row) {
+            if (!in_array($k, $uidArray)) {
+                $uidArray[] = $k;
+            }
+        }
 
-		$labelFieldname = $this->getLabelFieldname();
-		foreach ($uidArray as $uid) {
-			if (
-				MathUtility::canBeInterpretedAsInteger($uid)
-			) {
-				$row = $this->get($uid, $pid, in_array($uid, $rootArray), '', '', $orderBy);
+        $labelFieldname = $this->getLabelFieldname();
+        foreach ($uidArray as $uid) {
+            if (
+                MathUtility::canBeInterpretedAsInteger($uid)
+            ) {
+                $row = $this->get($uid, $pid, in_array($uid, $rootArray), '', '', $orderBy);
 
-				if (
-					$this->referenceField != '' &&
-					!empty($row[$this->referenceField])
-				) {
-					$bUseReference = true;
-				}
+                if (
+                    $this->referenceField != '' &&
+                    !empty($row[$this->referenceField])
+                ) {
+                    $bUseReference = true;
+                }
 
-				$relatedArray[$uid] = $row;
+                $relatedArray[$uid] = $row;
 
-				if (isset($rootLine[$uid]) || $uid == 0) {
-					if ($this->parentField) {
-						$where = $this->parentField . '=' . intval($uid);
-					} else {
-						$where = '1=1';
-					}
+                if (isset($rootLine[$uid]) || $uid == 0) {
+                    if ($this->parentField) {
+                        $where = $this->parentField . '=' . intval($uid);
+                    } else {
+                        $where = '1=1';
+                    }
 // 					$where .= ($pid ? ' AND pid IN (' . $pid . ')' : '');
-					$where .= $tableObj->enableFields();
+                    $where .= $tableObj->enableFields();
 
-					$res = $tableObj->exec_SELECTquery(
-						'*',
-						$where,
-						'',
-						$GLOBALS['TYPO3_DB']->stripOrderBy($orderBy)
-					);
+                    $res = $tableObj->exec_SELECTquery(
+                        '*',
+                        $where,
+                        '',
+                        $GLOBALS['TYPO3_DB']->stripOrderBy($orderBy)
+                    );
 
-					while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-						if (
-							is_array($tableObj->langArray) &&
-							!empty($tableObj->langArray[$row[$labelFieldname]])
-						) {
-							$row[$labelFieldname] = $tableObj->langArray[$row[$labelFieldname]];
-						}
-						$this->dataArray[$row['uid']] = $row;
-						$relatedArray[$row['uid']] = $row;
+                    while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                        if (
+                            is_array($tableObj->langArray) &&
+                            !empty($tableObj->langArray[$row[$labelFieldname]])
+                        ) {
+                            $row[$labelFieldname] = $tableObj->langArray[$row[$labelFieldname]];
+                        }
+                        $this->dataArray[$row['uid']] = $row;
+                        $relatedArray[$row['uid']] = $row;
 
-						if (
-							$this->referenceField != '' &&
-							$row[$this->referenceField]
-						) {
-							$bUseReference = true;
-						}
-					}
-					$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				}
-			}
-		}
-		foreach ($rootLine as $k => $row)	{
-			$relatedArray[$k] = $row;
-		}
+                        if (
+                            $this->referenceField != '' &&
+                            $row[$this->referenceField]
+                        ) {
+                            $bUseReference = true;
+                        }
+                    }
+                    $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                }
+            }
+        }
+        foreach ($rootLine as $k => $row)	{
+            $relatedArray[$k] = $row;
+        }
 
-		if ($bUseReference && count($relatedArray)) { // remove copies of the referenced category
-			$finalUidKeyArray = [];
-			$fixedRelatedArray = [];
-			foreach ($relatedArray as $uid => $row) {
-				if ($row[$this->referenceField]) {
-					$uid = $row[$this->referenceField];
-					$row['uid'] = $uid;
-					unset($row[$this->referenceField]);
-				}
-				$finalUidKeyArray[$uid] = 1;
-				if (!isset($fixedRelatedArray[$uid])) {
-					$fixedRelatedArray[$uid] = $row;
-				}
-			}
-			$relatedArray = $fixedRelatedArray;
-		}
+        if ($bUseReference && count($relatedArray)) { // remove copies of the referenced category
+            $finalUidKeyArray = [];
+            $fixedRelatedArray = [];
+            foreach ($relatedArray as $uid => $row) {
+                if ($row[$this->referenceField]) {
+                    $uid = $row[$this->referenceField];
+                    $row['uid'] = $uid;
+                    unset($row[$this->referenceField]);
+                }
+                $finalUidKeyArray[$uid] = 1;
+                if (!isset($fixedRelatedArray[$uid])) {
+                    $fixedRelatedArray[$uid] = $row;
+                }
+            }
+            $relatedArray = $fixedRelatedArray;
+        }
 
-		return $relatedArray;
-	}
+        return $relatedArray;
+    }
 
 
-	public function getRowFromTitle ($title) {
-		$rc = $this->titleArray[$title];
-		if (is_array($rc)) {
-			$tableObj = $this->getTableObj();
+    public function getRowFromTitle ($title) {
+        $rc = $this->titleArray[$title];
+        if (is_array($rc)) {
+            $tableObj = $this->getTableObj();
 
-			$where = '1=1 ' . $tableObj->enableFields();
-			$where .= ' AND title=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($title, $tableObj->name);
-			$res = $tableObj->exec_SELECTquery('*', $where);
-			$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-			$rc = $this->titleArray[$title] = $row;
-		}
-		return $rc;
-	}
+            $where = '1=1 ' . $tableObj->enableFields();
+            $where .= ' AND title=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($title, $tableObj->name);
+            $res = $tableObj->exec_SELECTquery('*', $where);
+            $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+            $rc = $this->titleArray[$title] = $row;
+        }
+        return $rc;
+    }
 
-	public function getParent (
-		$uid = '0',
-		$pid = 0,
-		$bStore = true,
-		$where_clause = '',
-		$groupBy = '',
-		$orderBy = '',
-		$limit = '',
-		$fields = '',
-		$bCount = false,
-		$aliasPostfix = ''
-	) {
-		$result = false;
+    public function getParent (
+        $uid = '0',
+        $pid = 0,
+        $bStore = true,
+        $where_clause = '',
+        $groupBy = '',
+        $orderBy = '',
+        $limit = '',
+        $fields = '',
+        $bCount = false,
+        $aliasPostfix = ''
+    ) {
+        $result = false;
 
-		$row = $this->get(
-			$uid,
-			$pid,
-			$bStore,
-			$where_clause,
-			$groupBy,
-			$orderBy,
-			$limit,
-			$fields,
-			$bCount,
-			$aliasPostfix
-		);
-		if (
-			isset($row) &&
-			is_array($row) &&
-			isset($row[$this->parentField])
-		) {
-			$result =
-				$this->get(
-					$row[$this->parentField],
-					$pid,
-					$bStore,
-					$where_clause,
-					$groupBy,
-					$orderBy,
-					$limit,
-					$fields,
-					$bCount,
-					$aliasPostfix
-				);
-		}
-		return $result;
-	}
+        $row = $this->get(
+            $uid,
+            $pid,
+            $bStore,
+            $where_clause,
+            $groupBy,
+            $orderBy,
+            $limit,
+            $fields,
+            $bCount,
+            $aliasPostfix
+        );
+        if (
+            isset($row) &&
+            is_array($row) &&
+            isset($row[$this->parentField])
+        ) {
+            $result =
+                $this->get(
+                    $row[$this->parentField],
+                    $pid,
+                    $bStore,
+                    $where_clause,
+                    $groupBy,
+                    $orderBy,
+                    $limit,
+                    $fields,
+                    $bCount,
+                    $aliasPostfix
+                );
+        }
+        return $result;
+    }
 
-	public function getRowCategory ($row) {
-		$rc = $row['category'];
-		return $rc;
-	}
+    public function getRowCategory ($row) {
+        $rc = $row['category'];
+        return $rc;
+    }
 
-	public function getRowPid ($row) {
-		$rc = $row['pid'];
-		return $rc;
-	}
+    public function getRowPid ($row) {
+        $rc = $row['pid'];
+        return $rc;
+    }
 
-	public function getParamDefault (
-		$theCode,
-		$cat
-	) {
-		if (!$cat) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    public function getParamDefault (
+        $theCode,
+        $cat
+    ) {
+        if (!$cat) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			if ($this->getFuncTablename() == 'tt_products_cat') {
-				$cat = $cnf->conf['defaultCategoryID'] ?? '';
-				$catConfig = $cnf->config['defaultCategoryID'] ?? '';
-			}
+            if ($this->getFuncTablename() == 'tt_products_cat') {
+                $cat = $cnf->conf['defaultCategoryID'] ?? '';
+                $catConfig = $cnf->config['defaultCategoryID'] ?? '';
+            }
 
-			if ($this->getFuncTablename() == 'tx_dam_cat') {
-				$cat = $cnf->conf['defaultDAMCategoryID'] ?? '';
-				$catConfig = $cnf->config['defaultDAMCategoryID'] ?? '';
-			}
+            if ($this->getFuncTablename() == 'tx_dam_cat') {
+                $cat = $cnf->conf['defaultDAMCategoryID'] ?? '';
+                $catConfig = $cnf->config['defaultDAMCategoryID'] ?? '';
+            }
 
-			if (strlen($catConfig)) {
-				if (strlen($cat)) {
-					$cat .= ',' . $catConfig;
-				} else {
-					$cat = $catConfig;
-				}
-			}
-		}
+            if (strlen($catConfig)) {
+                if (strlen($cat)) {
+                    $cat .= ',' . $catConfig;
+                } else {
+                    $cat = $catConfig;
+                }
+            }
+        }
 
-		if ($cat) {
-			$tableConf = $this->getTableConf($theCode);
-			$catArray = GeneralUtility::intExplode(',', $cat);
-			$catArray = array_unique($catArray);
+        if ($cat) {
+            $tableConf = $this->getTableConf($theCode);
+            $catArray = GeneralUtility::intExplode(',', $cat);
+            $catArray = array_unique($catArray);
 
-			if (
-				!empty($tableConf['special.']) &&
-				isset($tableConf['special.']['all']) &&
-				(
-					MathUtility::canBeInterpretedAsInteger($tableConf['special.']['all']) &&
-					in_array($tableConf['special.']['all'], $catArray) ||
-					$tableConf['special.']['all'] == 'all'
-				)
-			) 	{
-				$cat = '';	// no filter shall be used
-			} else if (
-				!empty($tableConf['special.']) &&
-				isset($tableConf['special.']['no']) &&
-				MathUtility::canBeInterpretedAsInteger($tableConf['special.']['no']) &&
-				in_array($tableConf['special.']['no'], $catArray)
-			) {
-				$cat = '0';	// no products shall be shown
-			} else {
-				$cat = implode(',', $catArray);
-			}
-		}
+            if (
+                !empty($tableConf['special.']) &&
+                isset($tableConf['special.']['all']) &&
+                (
+                    MathUtility::canBeInterpretedAsInteger($tableConf['special.']['all']) &&
+                    in_array($tableConf['special.']['all'], $catArray) ||
+                    $tableConf['special.']['all'] == 'all'
+                )
+            ) 	{
+                $cat = '';	// no filter shall be used
+            } else if (
+                !empty($tableConf['special.']) &&
+                isset($tableConf['special.']['no']) &&
+                MathUtility::canBeInterpretedAsInteger($tableConf['special.']['no']) &&
+                in_array($tableConf['special.']['no'], $catArray)
+            ) {
+                $cat = '0';	// no products shall be shown
+            } else {
+                $cat = implode(',', $catArray);
+            }
+        }
 
-		return $cat;
-	}
+        return $cat;
+    }
 
-	public function getChildUidArray ($uid) {
-		$rcArray = [];
-		return $rcArray;
-	}
+    public function getChildUidArray ($uid) {
+        $rcArray = [];
+        return $rcArray;
+    }
 
-	/**
-	 * Getting all sub categories from internal array
-	 * This must be overwritten by other classes who support multiple categories
-	 * getPrepareCategories must have been called before
-	 *
-	 */
-	public function getSubcategories ($row) {
-		return [];
-	}
+    /**
+     * Getting all sub categories from internal array
+     * This must be overwritten by other classes who support multiple categories
+     * getPrepareCategories must have been called before
+     *
+     */
+    public function getSubcategories ($row) {
+        return [];
+    }
 
-	public function getRelationArray (
-		$dataArray,
-		$excludeCats = '',
-		$rootUids = '',
-		$allowedCats = ''
-	) {
-		$relationArray = [];
-		$rootArray = GeneralUtility::trimExplode(',', $rootUids);
-		$catArray = GeneralUtility::trimExplode(',', $allowedCats);
-		$excludeArray = GeneralUtility::trimExplode (',', $excludeCats);
-		foreach ($excludeArray as $cat) {
-			$excludeKey = array_search($cat, $catArray);
-			if ($excludeKey !== false) {
-				unset($catArray[$excludeKey]);
-			}
-		}
+    public function getRelationArray (
+        $dataArray,
+        $excludeCats = '',
+        $rootUids = '',
+        $allowedCats = ''
+    ) {
+        $relationArray = [];
+        $rootArray = GeneralUtility::trimExplode(',', $rootUids);
+        $catArray = GeneralUtility::trimExplode(',', $allowedCats);
+        $excludeArray = GeneralUtility::trimExplode (',', $excludeCats);
+        foreach ($excludeArray as $cat) {
+            $excludeKey = array_search($cat, $catArray);
+            if ($excludeKey !== false) {
+                unset($catArray[$excludeKey]);
+            }
+        }
 
-		if (is_array($dataArray) && !empty($dataArray)) {
-			foreach ($dataArray as $row) {	// separate loop to keep the sorting order
+        if (is_array($dataArray) && !empty($dataArray)) {
+            foreach ($dataArray as $row) {	// separate loop to keep the sorting order
                 if (!empty($row)) {
                     $relationArray[$row['uid']] = [];
                 }
-			}
+            }
 
-			foreach ($dataArray as $row) {
+            foreach ($dataArray as $row) {
                 $uid = 0;
                 if (!empty($row)) {
                     $uid = $row['uid'];
                 }
-				if (
-					(!$uid) ||
-					(
-						$allowedCats &&
-						!in_array($uid, $catArray)
-					) ||
-					(
-						$excludeCats &&
-						in_array($uid, $excludeArray)
-					)
-				) {
-					continue;
-				}
-				foreach ($row as $field => $value) {
-					$relationArray[$uid][$field] = $value;
-				}
+                if (
+                    (!$uid) ||
+                    (
+                        $allowedCats &&
+                        !in_array($uid, $catArray)
+                    ) ||
+                    (
+                        $excludeCats &&
+                        in_array($uid, $excludeArray)
+                    )
+                ) {
+                    continue;
+                }
+                foreach ($row as $field => $value) {
+                    $relationArray[$uid][$field] = $value;
+                }
 
-				$parentId = '';
-				if ($this->parentField != '' && isset($row[$this->parentField])) {
+                $parentId = '';
+                if ($this->parentField != '' && isset($row[$this->parentField])) {
                     $parentId = $row[$this->parentField];
-				}
+                }
 
-				if(
-					(!$parentId) ||
-					(
-						$allowedCats &&
-						!in_array($parentId, $catArray)
-					) ||
-					(
-						$excludeCats &&
-						in_array($parentId, $excludeArray)
-					)
-				) {
-					$parentId = 0;
-				}
+                if(
+                    (!$parentId) ||
+                    (
+                        $allowedCats &&
+                        !in_array($parentId, $catArray)
+                    ) ||
+                    (
+                        $excludeCats &&
+                        in_array($parentId, $excludeArray)
+                    )
+                ) {
+                    $parentId = 0;
+                }
 
-				$relationArray[$uid]['parent_category'] = $parentId;
+                $relationArray[$uid]['parent_category'] = $parentId;
 
-				if (
-					$parentId &&
-					isset($dataArray[$parentId]) &&
-					!in_array($uid, $rootArray) &&
-					!in_array($parentId, $excludeArray)
-				) {
-					if (
-						!isset($relationArray[$parentId]['child_category'])
-					) {
-						$relationArray[$parentId]['child_category'] = [];
-					}
-					$relationArray[$parentId]['child_category'][] = (int) $uid;
-				}
-			}
-		}
+                if (
+                    $parentId &&
+                    isset($dataArray[$parentId]) &&
+                    !in_array($uid, $rootArray) &&
+                    !in_array($parentId, $excludeArray)
+                ) {
+                    if (
+                        !isset($relationArray[$parentId]['child_category'])
+                    ) {
+                        $relationArray[$parentId]['child_category'] = [];
+                    }
+                    $relationArray[$parentId]['child_category'][] = (int) $uid;
+                }
+            }
+        }
 
-		return $relationArray;
-	}
-
-
-	// returns the Path of all categories above, separated by '/'
-	public function getPath ($uid) {
-		$rc = '';
-
-		return $rc;
-	}
+        return $relationArray;
+    }
 
 
-	public function getFirstDiscount (
-		$discount,
-		$bDiscountDisable,
-		$cat,
-		$pid = 0
-	) {
-		$result = 0;
+    // returns the Path of all categories above, separated by '/'
+    public function getPath ($uid) {
+        $rc = '';
 
-		if (!$bDiscountDisable) {
-			if ($discount > 0) {
-				$result = $discount;
-			} else {
-				$rootCat = $this->getRootCat();
-				$rootArray = GeneralUtility::trimExplode(',', $rootCat);
-				$rootLine = $this->getRootline($rootArray, $cat, $pid);
-
-				if (is_array($rootLine) && count($rootLine)) {
-
-					foreach ($rootLine as $catFromLine => $catRow) {
-						if ($catRow['discount_disable']) {
-							$result = 0;
-							break;
-						}
-
-						if ($catRow['discount'] > 0) {
-							$result = $catRow['discount'];
-							break;
-						}
-					}
-				}
-			}
-		}
-
-		return $result;
-	}
+        return $rc;
+    }
 
 
-	public function getMaxDiscount (
-		$discount,
-		$bDiscountDisable,
-		$catArray,
-		$pid = 0
-	) {
-		$maxDiscount = 0;
+    public function getFirstDiscount (
+        $discount,
+        $bDiscountDisable,
+        $cat,
+        $pid = 0
+    ) {
+        $result = 0;
 
-		if (!$bDiscountDisable) {
-			$maxDiscount = doubleval($discount);
-			$rootCat = $this->getRootCat();
-			$rootArray = GeneralUtility::trimExplode(',', $rootCat);
+        if (!$bDiscountDisable) {
+            if ($discount > 0) {
+                $result = $discount;
+            } else {
+                $rootCat = $this->getRootCat();
+                $rootArray = GeneralUtility::trimExplode(',', $rootCat);
+                $rootLine = $this->getRootline($rootArray, $cat, $pid);
 
-			foreach ($catArray as $cat) {
+                if (is_array($rootLine) && count($rootLine)) {
 
-				$rootLine = $this->getRootline($rootArray, $cat, $pid);
+                    foreach ($rootLine as $catFromLine => $catRow) {
+                        if ($catRow['discount_disable']) {
+                            $result = 0;
+                            break;
+                        }
 
-				if (is_array($rootLine) && count($rootLine)) {
+                        if ($catRow['discount'] > 0) {
+                            $result = $catRow['discount'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
 
-					foreach ($rootLine as $catFromLine => $catRow) {
-						if ($maxDiscount < $catRow['discount']) {
-							$maxDiscount = $catRow['discount'];
-						}
-					}
-				}
-			}
-		}
-		return $maxDiscount;
-	}
+        return $result;
+    }
+
+
+    public function getMaxDiscount (
+        $discount,
+        $bDiscountDisable,
+        $catArray,
+        $pid = 0
+    ) {
+        $maxDiscount = 0;
+
+        if (!$bDiscountDisable) {
+            $maxDiscount = doubleval($discount);
+            $rootCat = $this->getRootCat();
+            $rootArray = GeneralUtility::trimExplode(',', $rootCat);
+
+            foreach ($catArray as $cat) {
+
+                $rootLine = $this->getRootline($rootArray, $cat, $pid);
+
+                if (is_array($rootLine) && count($rootLine)) {
+
+                    foreach ($rootLine as $catFromLine => $catRow) {
+                        if ($maxDiscount < $catRow['discount']) {
+                            $maxDiscount = $catRow['discount'];
+                        }
+                    }
+                }
+            }
+        }
+        return $maxDiscount;
+    }
 }
 
 

--- a/model/class.tx_ttproducts_category_base.php
+++ b/model/class.tx_ttproducts_category_base.php
@@ -42,261 +42,261 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 abstract class tx_ttproducts_category_base extends tx_ttproducts_table_base {
-	protected $titleArray; // associative array of read in categories with title as index
-	protected $mm_table = ''; // only set if a mm table is used
-	public $parentField; // field name for parent
-	public $referenceField; // field name for reference element
-	public $categoryField = 'category';
+    protected $titleArray; // associative array of read in categories with title as index
+    protected $mm_table = ''; // only set if a mm table is used
+    public $parentField; // field name for parent
+    public $referenceField; // field name for reference element
+    public $categoryField = 'category';
 
-	public function getFromTitle ($title) {
-		$rc = [];
-		return $rc;
-	}
+    public function getFromTitle ($title) {
+        $rc = [];
+        return $rc;
+    }
 
-	public function getParent ($uid=0) {
-		$rc = [];
-		return $rc;
-	}
+    public function getParent ($uid=0) {
+        $rc = [];
+        return $rc;
+    }
 
-	public function getRootCat () {
-		$rc = 0;
-		return $rc;
-	}
+    public function getRootCat () {
+        $rc = 0;
+        return $rc;
+    }
 
-	public function getRowCategory ($row) {
-		$rc = '';
-		return $rc;
-	}
+    public function getRowCategory ($row) {
+        $rc = '';
+        return $rc;
+    }
 
-	public function setMMTablename ($mm_table) {
-		$this->mm_table = $mm_table;
-	}
+    public function setMMTablename ($mm_table) {
+        $this->mm_table = $mm_table;
+    }
 
-	public function getMMTablename () {
-		return $this->mm_table;
-	}
+    public function getMMTablename () {
+        return $this->mm_table;
+    }
 
-	public function hasSpecialConf ($cat, $theCode, $type) {
-		$rc = false;
-		$conf = $this->getTableConf($theCode);
+    public function hasSpecialConf ($cat, $theCode, $type) {
+        $rc = false;
+        $conf = $this->getTableConf($theCode);
 
-		if (is_array($conf['special.']) && isset($conf['special.'][$type])) {
-			$specialArray = GeneralUtility::trimExplode(',', $conf['special.'][$type]);
-			if (in_array($cat, $specialArray)) {
-				$rc = true;
-			}
-		}
+        if (is_array($conf['special.']) && isset($conf['special.'][$type])) {
+            $specialArray = GeneralUtility::trimExplode(',', $conf['special.'][$type]);
+            if (in_array($cat, $specialArray)) {
+                $rc = true;
+            }
+        }
 
-		return $rc;
-	}
+        return $rc;
+    }
 
-	public function getRowPid ($row) {
-		$rc = '';
-		return $rc;
-	}
+    public function getRowPid ($row) {
+        $rc = '';
+        return $rc;
+    }
 
-	public function getParamDefault ($theCode, $piVars) {
-		$rc = '';
-		return $rc;
-	}
+    public function getParamDefault ($theCode, $piVars) {
+        $rc = '';
+        return $rc;
+    }
 
-	public function getChildUidArray ($uid) {
-		$rcArray = [];
-		return $rcArray;
-	}
+    public function getChildUidArray ($uid) {
+        $rcArray = [];
+        return $rcArray;
+    }
 
-	public function getRelated ($rootUids, $currentCat, $pid = 0, $orderBy = '') {
-		$rcArray = [];
-		return $rcArray;
-	}
+    public function getRelated ($rootUids, $currentCat, $pid = 0, $orderBy = '') {
+        $rcArray = [];
+        return $rcArray;
+    }
 
-	public function getCategoryArray ($productRow, $orderBy = '') {
-		$catArray = [];
-		$uid = 0;
-		if (is_array($productRow)) {
-			$uid = $productRow['uid'];
-		}
+    public function getCategoryArray ($productRow, $orderBy = '') {
+        $catArray = [];
+        $uid = 0;
+        if (is_array($productRow)) {
+            $uid = $productRow['uid'];
+        }
 
-		if($this->getMMTablename()) {
-			$hookVar = '';
-			$functablename = $this->getFuncTablename();
-			if ($functablename == 'tt_products_cat') {
-				$hookVar = 'prodCategory';
-			} else if($functablename == 'tx_dam_cat') {
-				$hookVar = 'DAMCategory';
-			}
-				// Call all addWhere hooks for categories at the end of this method
-			if (
-				$hookVar &&
-				isset ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
-				is_array ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])
-			) {
-				foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
-					$hookObj= GeneralUtility::makeInstance($classRef);
-					if (method_exists($hookObj, 'init')) {
-						$hookObj->init($this->parentField);
-					}
-					if (method_exists($hookObj, 'getCategories')) {
-						$retArray = $hookObj->getCategories($this, $uid, $this->mm_table, $orderBy);
+        if($this->getMMTablename()) {
+            $hookVar = '';
+            $functablename = $this->getFuncTablename();
+            if ($functablename == 'tt_products_cat') {
+                $hookVar = 'prodCategory';
+            } else if($functablename == 'tx_dam_cat') {
+                $hookVar = 'DAMCategory';
+            }
+                // Call all addWhere hooks for categories at the end of this method
+            if (
+                $hookVar &&
+                isset ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
+                is_array ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])
+            ) {
+                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
+                    $hookObj= GeneralUtility::makeInstance($classRef);
+                    if (method_exists($hookObj, 'init')) {
+                        $hookObj->init($this->parentField);
+                    }
+                    if (method_exists($hookObj, 'getCategories')) {
+                        $retArray = $hookObj->getCategories($this, $uid, $this->mm_table, $orderBy);
 
-						if (isset($retArray) && is_array($retArray)) {
-							foreach ($retArray as $k => $row) {
-								$catArray[] = $row['cat'];
-							}
-						}
-					}
-				}
-			}
-		} else if ($uid && isset($productRow[$this->categoryField])) {
-			$catArray = [$productRow[$this->categoryField]];
-		}
-		return $catArray;
-	}
+                        if (isset($retArray) && is_array($retArray)) {
+                            foreach ($retArray as $k => $row) {
+                                $catArray[] = $row['cat'];
+                            }
+                        }
+                    }
+                }
+            }
+        } else if ($uid && isset($productRow[$this->categoryField])) {
+            $catArray = [$productRow[$this->categoryField]];
+        }
+        return $catArray;
+    }
 
-	public function getDepth ($theCode) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$functablename = $this->getFuncTablename();
-		$tableconf = $cnf->getTableConf($functablename, $theCode);
-		$result = $tableconf['hierarchytiers'];
-		if (!isset($result)) {
-			$result = 1;
-		}
-		return $result;
-	}
+    public function getDepth ($theCode) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $functablename = $this->getFuncTablename();
+        $tableconf = $cnf->getTableConf($functablename, $theCode);
+        $result = $tableconf['hierarchytiers'];
+        if (!isset($result)) {
+            $result = 1;
+        }
+        return $result;
+    }
 
-	public function getLineArray ($start, $endArray) {
-		$catArray = [];
-		$hookVar = '';
-		$functablename = $this->getFuncTablename ();
-		if ($functablename == 'tt_products_cat') {
-			$hookVar = 'prodCategory';
-		} else if($functablename == 'tx_dam_cat') {
-			$hookVar = 'DAMCategory';
-		}
+    public function getLineArray ($start, $endArray) {
+        $catArray = [];
+        $hookVar = '';
+        $functablename = $this->getFuncTablename ();
+        if ($functablename == 'tt_products_cat') {
+            $hookVar = 'prodCategory';
+        } else if($functablename == 'tx_dam_cat') {
+            $hookVar = 'DAMCategory';
+        }
 
-		$tmpArray = [];
-			// Call all addWhere hooks for categories at the end of this method
-		if (
+        $tmpArray = [];
+            // Call all addWhere hooks for categories at the end of this method
+        if (
             $hookVar && 
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init($this->parentField);
-				}
-				if (method_exists($hookObj, 'getLineCategories')) {
-					$catArray =
-						$hookObj->getLineCategories(
-							$this,
-							$start,
-							$endArray,
-							$this->getTableObj()->enableFields()
-						);
-				}
-			}
-		}
-		return $catArray;
-	}
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init($this->parentField);
+                }
+                if (method_exists($hookObj, 'getLineCategories')) {
+                    $catArray =
+                        $hookObj->getLineCategories(
+                            $this,
+                            $start,
+                            $endArray,
+                            $this->getTableObj()->enableFields()
+                        );
+                }
+            }
+        }
+        return $catArray;
+    }
 
-	public function getHookVar () {
-		$funcTablename = $this->getFuncTablename();
-		if ($funcTablename == 'tt_products_cat') {
-			$rc = 'prodCategory';
-		} else if ($funcTablename == 'tx_dam_cat') {
-			$rc = 'DAMCategory';
-		}
-		return $rc;
-	}
+    public function getHookVar () {
+        $funcTablename = $this->getFuncTablename();
+        if ($funcTablename == 'tt_products_cat') {
+            $rc = 'prodCategory';
+        } else if ($funcTablename == 'tx_dam_cat') {
+            $rc = 'DAMCategory';
+        }
+        return $rc;
+    }
 
-	public function getChildCategoryArray ($cat) {
+    public function getChildCategoryArray ($cat) {
 
-		$catArray = [];
-		$hookVar = $this->getHookVar();
+        $catArray = [];
+        $hookVar = $this->getHookVar();
 
-		$tmpArray = [];
-			// Call all addWhere hooks for categories at the end of this method
-		if ($hookVar && is_array ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init($this->parentField);
-				}
-				if (method_exists($hookObj, 'getChildCategories')) {
-					$tmpArray = $hookObj->getChildCategories($this, $cat);
-				}
-			}
-		}
-		if (is_array($tmpArray)) {
-			foreach ($tmpArray as $k => $row) {
-				$catArray[] = $row['cat'];
-			}
-		}
+        $tmpArray = [];
+            // Call all addWhere hooks for categories at the end of this method
+        if ($hookVar && is_array ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])) {
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init($this->parentField);
+                }
+                if (method_exists($hookObj, 'getChildCategories')) {
+                    $tmpArray = $hookObj->getChildCategories($this, $cat);
+                }
+            }
+        }
+        if (is_array($tmpArray)) {
+            foreach ($tmpArray as $k => $row) {
+                $catArray[] = $row['cat'];
+            }
+        }
 
-		return $catArray;
-	}
+        return $catArray;
+    }
 
-	public function getRootArray ($rootCat, $categoryArray, $autoRoot = true) {
-		$rootArray = [];
-		$rootCatArray = GeneralUtility::trimExplode(',', $rootCat);
-		foreach ($categoryArray as $uid => $row) {
-			if (
-				(
-					MathUtility::canBeInterpretedAsInteger($uid)
-				) &&
-				(
-					in_array($uid, $rootCatArray) ||
-					(
-					  $autoRoot &&
-					  (
-					    $this->parentField == '' ||
-					    (
-						    !$row[$this->parentField] ||
-						    !isset($categoryArray[$row[$this->parentField]]) // It is also a root if the parent is outside of the allowed pages
-					    )
-					  )
-					)
-				)
-			) {
-				$rootArray[] = $uid;
-			}
-		}
-		return $rootArray;
-	}
+    public function getRootArray ($rootCat, $categoryArray, $autoRoot = true) {
+        $rootArray = [];
+        $rootCatArray = GeneralUtility::trimExplode(',', $rootCat);
+        foreach ($categoryArray as $uid => $row) {
+            if (
+                (
+                    MathUtility::canBeInterpretedAsInteger($uid)
+                ) &&
+                (
+                    in_array($uid, $rootCatArray) ||
+                    (
+                      $autoRoot &&
+                      (
+                        $this->parentField == '' ||
+                        (
+                            !$row[$this->parentField] ||
+                            !isset($categoryArray[$row[$this->parentField]]) // It is also a root if the parent is outside of the allowed pages
+                        )
+                      )
+                    )
+                )
+            ) {
+                $rootArray[] = $uid;
+            }
+        }
+        return $rootArray;
+    }
 
-	public function getRootpathArray (&$relationArray, $rootCat, $currentCat) {
-		$rootpathArray = [];
-		$rootCatArray = GeneralUtility::trimExplode(',', $rootCat);
-		$uid = $currentCat;
-		if (!empty($uid)) {
-			$count = 0;
-			do {
-				$count++;
-				$row = $relationArray[$uid] ?? [];
-				if ($row) {
-					$rootpathArray[] = $row;
-					$lastUid = $uid;
-					$uid = $row['parent_category'] ?? '';
-				}
-			} while (
-				$row &&
-				!in_array($lastUid,$rootCatArray) &&
-				!empty($uid) &&
-				$count < 199
-			);
-		}
-		return $rootpathArray;
-	}
+    public function getRootpathArray (&$relationArray, $rootCat, $currentCat) {
+        $rootpathArray = [];
+        $rootCatArray = GeneralUtility::trimExplode(',', $rootCat);
+        $uid = $currentCat;
+        if (!empty($uid)) {
+            $count = 0;
+            do {
+                $count++;
+                $row = $relationArray[$uid] ?? [];
+                if ($row) {
+                    $rootpathArray[] = $row;
+                    $lastUid = $uid;
+                    $uid = $row['parent_category'] ?? '';
+                }
+            } while (
+                $row &&
+                !in_array($lastUid,$rootCatArray) &&
+                !empty($uid) &&
+                $count < 199
+            );
+        }
+        return $rootpathArray;
+    }
 
-	public function getRelationArray (
-		$dataArray,
-		$excludeCats = '',
-		$rootUids = '',
-		$allowedCats = ''
-	) {
-		$relationArray = [];
-		return $relationArray;
-	}
+    public function getRelationArray (
+        $dataArray,
+        $excludeCats = '',
+        $rootUids = '',
+        $allowedCats = ''
+    ) {
+        $relationArray = [];
+        return $relationArray;
+    }
 }
 

--- a/model/class.tx_ttproducts_content.php
+++ b/model/class.tx_ttproducts_content.php
@@ -41,57 +41,57 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_content extends tx_ttproducts_table_base {
-	public $dataArray = []; // array of read in contents
-	public $dataPageArray = []; // array of read in contents with page id as index
-	public $table;		 // object of the type tx_table_db
+    public $dataArray = []; // array of read in contents
+    public $dataPageArray = []; // array of read in contents with page id as index
+    public $table;		 // object of the type tx_table_db
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
 
-		$this->getTableObj()->setDefaultFieldArray(['uid'=>'uid', 'pid'=>'pid', 't3ver_oid'=>'t3ver_oid', 'tstamp'=>'tstamp', 'sorting'=> 'sorting',
-		'deleted' => 'deleted', 'hidden'=>'hidden', 'starttime' => 'starttime', 'endtime' => 'endtime', 'fe_group' => 'fe_group']);
-		$this->getTableObj()->setTCAFieldArray('tt_content');
+        $this->getTableObj()->setDefaultFieldArray(['uid'=>'uid', 'pid'=>'pid', 't3ver_oid'=>'t3ver_oid', 'tstamp'=>'tstamp', 'sorting'=> 'sorting',
+        'deleted' => 'deleted', 'hidden'=>'hidden', 'starttime' => 'starttime', 'endtime' => 'endtime', 'fe_group' => 'fe_group']);
+        $this->getTableObj()->setTCAFieldArray('tt_content');
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
-	public function getFromPid ($pid) {
-		$rcArray = $this->dataPageArray[$pid];
+    public function getFromPid ($pid) {
+        $rcArray = $this->dataPageArray[$pid];
 
-		if (!is_array($rcArray)) {
-			$sql = GeneralUtility::makeInstance('tx_table_db_access');
-			$sql->prepareFields($this->getTableObj(), 'select', '*');
-			$sql->prepareFields($this->getTableObj(), 'orderBy', 'sorting');
-			$sql->prepareWhereFields ($this->getTableObj(), 'pid', '=', intval($pid));
+        if (!is_array($rcArray)) {
+            $sql = GeneralUtility::makeInstance('tx_table_db_access');
+            $sql->prepareFields($this->getTableObj(), 'select', '*');
+            $sql->prepareFields($this->getTableObj(), 'orderBy', 'sorting');
+            $sql->prepareWhereFields ($this->getTableObj(), 'pid', '=', intval($pid));
             $api =
                 GeneralUtility::makeInstance(\JambageCom\Div2007\Api\Frontend::class);
             $sys_language_uid = $api->getLanguageId();
 
-			$sql->prepareWhereFields ($this->getTableObj(), 'sys_language_uid', '=', intval($sys_language_uid));
+            $sql->prepareWhereFields ($this->getTableObj(), 'sys_language_uid', '=', intval($sys_language_uid));
 
-			$enableFields = $this->getTableObj()->enableFields();
-			$sql->where_clause .= $enableFields;
+            $enableFields = $this->getTableObj()->enableFields();
+            $sql->where_clause .= $enableFields;
 
-			// Fetching the category
-			$res = $sql->exec_SELECTquery();
-			while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-				$this->dataPageArray[$pid][$row['uid']] = $row;
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-			$tmp = $this->dataPageArray[$pid];
-			$rcArray = (is_array($tmp) ? $tmp : []);
-		}
-		return $rcArray;
-	}
+            // Fetching the category
+            $res = $sql->exec_SELECTquery();
+            while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                $this->dataPageArray[$pid][$row['uid']] = $row;
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+            $tmp = $this->dataPageArray[$pid];
+            $rcArray = (is_array($tmp) ? $tmp : []);
+        }
+        return $rcArray;
+    }
 
-	// returns the Path of all categories above, separated by '/'
-	public function getCategoryPath ($uid) {
-		$rc = '';
+    // returns the Path of all categories above, separated by '/'
+    public function getCategoryPath ($uid) {
+        $rc = '';
 
-		return $rc;
-	}
+        return $rc;
+    }
 }
 

--- a/model/class.tx_ttproducts_country.php
+++ b/model/class.tx_ttproducts_country.php
@@ -44,85 +44,85 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_country extends tx_ttproducts_table_base {
-	public $dataArray; // array of read in contents
-	public $table;	// object of the type tx_table_db
-	public $marker = 'STATICCOUNTRIES';
+    public $dataArray; // array of read in contents
+    public $table;	// object of the type tx_table_db
+    public $marker = 'STATICCOUNTRIES';
 
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$tablename = $this->getTablename();
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$this->tableconf = $cnf->getTableConf('static_countries');
-			$this->getTableObj()->setDefaultFieldArray(['uid'=>'uid', 'pid'=>'pid']);
-			$this->getTableObj()->setTCAFieldArray('static_countries');
+        if ($result) {
+            $tablename = $this->getTablename();
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $this->tableconf = $cnf->getTableConf('static_countries');
+            $this->getTableObj()->setDefaultFieldArray(['uid'=>'uid', 'pid'=>'pid']);
+            $this->getTableObj()->setTCAFieldArray('static_countries');
 
-			$requiredFields = 'uid,pid';
-			if (!empty($this->tableconf['requiredFields'])) {
-				$tmp = $this->tableconf['requiredFields'];
-				$requiredFields = ($tmp ? $tmp : $requiredFields);
-			}
-			$requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$this->getTableObj()->setRequiredFieldArray($requiredListArray);
+            $requiredFields = 'uid,pid';
+            if (!empty($this->tableconf['requiredFields'])) {
+                $tmp = $this->tableconf['requiredFields'];
+                $requiredFields = ($tmp ? $tmp : $requiredFields);
+            }
+            $requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $this->getTableObj()->setRequiredFieldArray($requiredListArray);
 
-			if (!empty($this->tableconf['generatePath.']) &&
-				$this->tableconf['generatePath.']['type'] == 'tablefields' &&
-				!empty($this->tableconf['generatePath.']['field.'])
-				) {
-				$addRequiredFields = [];
-				foreach ($this->tableconf['generatePath.']['field.'] as $field => $value) {
-					$addRequiredFields[] = $field;
-				}
-				$this->getTableObj()->addRequiredFieldArray($addRequiredFields);
-			}
-		}
+            if (!empty($this->tableconf['generatePath.']) &&
+                $this->tableconf['generatePath.']['type'] == 'tablefields' &&
+                !empty($this->tableconf['generatePath.']['field.'])
+                ) {
+                $addRequiredFields = [];
+                foreach ($this->tableconf['generatePath.']['field.'] as $field => $value) {
+                    $addRequiredFields[] = $field;
+                }
+                $this->getTableObj()->addRequiredFieldArray($addRequiredFields);
+            }
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
 
     public function isoGet ($country_code, $where = '', $fields = '') {
 
         $rc = [];
-		if (!$fields && isset($this->dataArray[$country_code])) {
-			$rc = $this->dataArray[$country_code];
-		}
-		if (!$rc || $where) {
+        if (!$fields && isset($this->dataArray[$country_code])) {
+            $rc = $this->dataArray[$country_code];
+        }
+        if (!$rc || $where) {
             $pageRepository = \JambageCom\Div2007\Utility\CompatibilityUtility::getPageRepository();
 
-			if (!empty($country_code)) {
-				$whereString = 'cn_iso_3 = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($country_code, $this->getTableObj()->name);
-			} else {
-				$whereString = '1=1';
-			}
-			if ($where) {
-				$whereString .= ' AND ' . $where;
-			}
+            if (!empty($country_code)) {
+                $whereString = 'cn_iso_3 = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($country_code, $this->getTableObj()->name);
+            } else {
+                $whereString = '1=1';
+            }
+            if ($where) {
+                $whereString .= ' AND ' . $where;
+            }
 
-			$whereString .= ' ' . $pageRepository->enableFields($this->getTablename());
-			$fields = ($fields ? $fields : '*');
-			// Fetching the products
+            $whereString .= ' ' . $pageRepository->enableFields($this->getTablename());
+            $fields = ($fields ? $fields : '*');
+            // Fetching the products
 
-			$res = $this->getTableObj()->exec_SELECTquery($fields, $whereString);
-			if ($country_code) {
-				$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-			 	$rc = $row;
-			 	if ($row) {
-			 		$this->dataArray[$row['cn_iso_3']] = $row;
-			 	}
-			} else {
-				while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-					$rc[] = $this->dataArray[$row['uid']] = $row;
-				}
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		}
-		return $rc;
-	}
+            $res = $this->getTableObj()->exec_SELECTquery($fields, $whereString);
+            if ($country_code) {
+                $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+                $rc = $row;
+                if ($row) {
+                    $this->dataArray[$row['cn_iso_3']] = $row;
+                }
+            } else {
+                while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                    $rc[] = $this->dataArray[$row['uid']] = $row;
+                }
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        }
+        return $rc;
+    }
 }
 

--- a/model/class.tx_ttproducts_dam.php
+++ b/model/class.tx_ttproducts_dam.php
@@ -39,86 +39,86 @@
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_dam extends tx_ttproducts_article_base {
-	public $dataArray; // array of read in categories
-	public $tableArray;
+    public $dataArray; // array of read in categories
+    public $tableArray;
 
-	public $marker = 'DAM';
-	public $type = 'dam';
-	public $piVar = 'dam';
+    public $marker = 'DAM';
+    public $type = 'dam';
+    public $piVar = 'dam';
 
-	public $mm_table = 'tx_dam_mm_cat';
-	public $image;
-	public $variant; // object for the product variant attributes, must initialized in the init function
+    public $mm_table = 'tx_dam_mm_cat';
+    public $image;
+    public $variant; // object for the product variant attributes, must initialized in the init function
 
-	/**
-	 * DAM elements
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
+    /**
+     * DAM elements
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$this->tableArray = $tableArray;
-			$tableObj = $this->getTableObj();
-			$tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
+        if ($result) {
+            $this->tableArray = $tableArray;
+            $tableObj = $this->getTableObj();
+            $tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
 
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tablename = $cnf->getTableName($functablename);
-			$tableObj->setTCAFieldArray($tablename, 'dam');
-		}
-		return $result;
-	} // init
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tablename = $cnf->getTableName($functablename);
+            $tableObj->setTCAFieldArray($tablename, 'dam');
+        }
+        return $result;
+    } // init
 
-	public function getRelated (
-		&$parentFuncTablename,
-		&$parentRows,
+    public function getRelated (
+        &$parentFuncTablename,
+        &$parentRows,
         $multiOrderArray,
-		$uid,
-		$type,
-		$orderBy = ''
-	) {
-		$rcArray = [];
-		if ($type == 'products') {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$productTable = $tablesObj->get('tt_products', false);
-			$additional = $productTable->getFlexQuery('isImage', 1);
-			$rowArray =
-				$productTable->getWhere('additional REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($additional,  $productTable->getTablename)); // quotemeta
-			$rcArray = array_keys($rowArray);
-		}
-		return $rcArray;
-	}
+        $uid,
+        $type,
+        $orderBy = ''
+    ) {
+        $rcArray = [];
+        if ($type == 'products') {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $productTable = $tablesObj->get('tt_products', false);
+            $additional = $productTable->getFlexQuery('isImage', 1);
+            $rowArray =
+                $productTable->getWhere('additional REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($additional,  $productTable->getTablename)); // quotemeta
+            $rcArray = array_keys($rowArray);
+        }
+        return $rcArray;
+    }
 
-	/**
-	 * Returns true if the item has the $check value checked
-	 *
-	 */
-	public function hasAdditional (&$row, $check) {
-		$hasAdditional = false;
-		return $hasAdditional;
-	}
+    /**
+     * Returns true if the item has the $check value checked
+     *
+     */
+    public function hasAdditional (&$row, $check) {
+        $hasAdditional = false;
+        return $hasAdditional;
+    }
 
-	/**
-	 * Sets the markers for DAM specific FORM fields
-	 *
-	 */
-	public function setFormMarkerArray ($uid, &$markerArray) {
-		$markerArray['###DAM_FIELD_NAME###'] = 'ttp_basket[dam]';
-		$markerArray['###DAM_UID###'] = intval($uid);
-	}
+    /**
+     * Sets the markers for DAM specific FORM fields
+     *
+     */
+    public function setFormMarkerArray ($uid, &$markerArray) {
+        $markerArray['###DAM_FIELD_NAME###'] = 'ttp_basket[dam]';
+        $markerArray['###DAM_UID###'] = intval($uid);
+    }
 
-	/**
-	 * fills in the row fields from a DAM record
-	 *
-	 * @param	array		the row
-	 * @param	string	  variants separated by variantSeparator
-	 * @return  void
-	 * @access private
-	 * @see getVariantFromRow
-	 */
-	public function modifyItemRow (&$row, $uid) {
-		$damRow = $this->get($uid);
+    /**
+     * fills in the row fields from a DAM record
+     *
+     * @param	array		the row
+     * @param	string	  variants separated by variantSeparator
+     * @return  void
+     * @access private
+     * @see getVariantFromRow
+     */
+    public function modifyItemRow (&$row, $uid) {
+        $damRow = $this->get($uid);
 
-		if ($damRow) {
+        if ($damRow) {
 // 			$damRow['damdescription'] = $damRow['description'];
 // 			unset($damRow['description']);
 // 			foreach ($damRow as $field => $value)	{
@@ -126,135 +126,135 @@ class tx_ttproducts_dam extends tx_ttproducts_article_base {
 // 					$row[$field] = $value;
 // 				}
 // 			}
-			if ($damRow['file_mime_type'] == 'image' && !$row['image']) {
-				$row['image'] = $damRow['file_name'];
-				$row['file_mime_type'] = 'image';
-				$row['file_path'] = $damRow['file_path'];
-			}
-		}
-	}
+            if ($damRow['file_mime_type'] == 'image' && !$row['image']) {
+                $row['image'] = $damRow['file_name'];
+                $row['file_mime_type'] = 'image';
+                $row['file_path'] = $damRow['file_path'];
+            }
+        }
+    }
 
-	public function addWhereCat (
-			$catObject,
-			$theCode,
-			$cat,
-			$categoryAnd,
-			$pid_list,
-			$bLeadingOperator = true
-	) {
-		$bOpenBracket = false;
-		$where = '';
+    public function addWhereCat (
+            $catObject,
+            $theCode,
+            $cat,
+            $categoryAnd,
+            $pid_list,
+            $bLeadingOperator = true
+    ) {
+        $bOpenBracket = false;
+        $where = '';
 
-			// Call all addWhereCat hooks for DAM categories at the end of this method
-		if (
+            // Call all addWhereCat hooks for DAM categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addWhereCat')) {
-					$whereNew =
-						$hookObj->addWhereCat(
-							$this,
-							$catObject,
-							$cat,
-							$where,
-							$operator,
-							$pid_list,
-							$catObject->getDepth($theCode),
-							$categoryAnd
-						);
-					if ($bLeadingOperator) {
-						$operator = ($operator ? $operator : 'OR');
-						$where .= ($whereNew ? ' '.$operator.' '.$whereNew : '');
-					} else {
-						$where .= $whereNew;
-					}
-				}
-			}
-		} else if($cat || $cat == '0') {
-			$cat = implode(',',GeneralUtility::intExplode(',', $cat));
-			$where = 'category IN ('.$cat.')';
-			if ($bLeadingOperator) {
-				$where = ' AND ( ' . $where . ')';
-			}
-		}
-		return $where;
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addWhereCat')) {
+                    $whereNew =
+                        $hookObj->addWhereCat(
+                            $this,
+                            $catObject,
+                            $cat,
+                            $where,
+                            $operator,
+                            $pid_list,
+                            $catObject->getDepth($theCode),
+                            $categoryAnd
+                        );
+                    if ($bLeadingOperator) {
+                        $operator = ($operator ? $operator : 'OR');
+                        $where .= ($whereNew ? ' '.$operator.' '.$whereNew : '');
+                    } else {
+                        $where .= $whereNew;
+                    }
+                }
+            }
+        } else if($cat || $cat == '0') {
+            $cat = implode(',',GeneralUtility::intExplode(',', $cat));
+            $where = 'category IN ('.$cat.')';
+            if ($bLeadingOperator) {
+                $where = ' AND ( ' . $where . ')';
+            }
+        }
+        return $where;
+    }
 
-	public function addConfCat ($catObject, &$selectConf, $aliasArray) {
-		$tableNameArray = [];
+    public function addConfCat ($catObject, &$selectConf, $aliasArray) {
+        $tableNameArray = [];
 
-			// Call all addWhere hooks for DAM categories at the end of this method
-		if (
+            // Call all addWhere hooks for DAM categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'])) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addConfCatProduct')) {
-					$newTablenames = $hookObj->addConfCatProduct($this, $catObject, $selectConf, $aliasArray);
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addConfCatProduct')) {
+                    $newTablenames = $hookObj->addConfCatProduct($this, $catObject, $selectConf, $aliasArray);
 
-					if ($newTablenames != '') {
-						$tableNameArray[] = $newTablenames;
-					}
-				}
-			}
-		}
+                    if ($newTablenames != '') {
+                        $tableNameArray[] = $newTablenames;
+                    }
+                }
+            }
+        }
 
-		return implode(',', $tableNameArray);
-	}
+        return implode(',', $tableNameArray);
+    }
 
-	public function addselectConfCat ($catObject, $cat, &$selectConf) {
-		$tableNameArray = [];
+    public function addselectConfCat ($catObject, $cat, &$selectConf) {
+        $tableNameArray = [];
 
-			// Call all addWhere hooks for DAM categories at the end of this method
-		if (
+            // Call all addWhere hooks for DAM categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addselectConfCat')) {
-					$newTablenames = $hookObj->addselectConfCat($this, $catObject, $cat, $selectConf,$catObject->getDepth());
-					if ($newTablenames != '') {
-						$tableNameArray[] = $newTablenames;
-					}
-				}
-			}
-		}
-		return implode(',', $tableNameArray);
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addselectConfCat')) {
+                    $newTablenames = $hookObj->addselectConfCat($this, $catObject, $cat, $selectConf,$catObject->getDepth());
+                    if ($newTablenames != '') {
+                        $tableNameArray[] = $newTablenames;
+                    }
+                }
+            }
+        }
+        return implode(',', $tableNameArray);
+    }
 
-	public function getPageUidsCat ($cat) {
-		$uidArray = [];
+    public function getPageUidsCat ($cat) {
+        $uidArray = [];
 
-			// Call all addWhere hooks for DAM categories at the end of this method
-		if (
+            // Call all addWhere hooks for DAM categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'])) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'getPageUidsCat')) {
-					$hookObj->getPageUidsCat($this, $cat, $uidArray);
-				}
-			}
-		}
-		$uidArray = array_unique($uidArray);
-		return (implode(',', $uidArray));
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['DAMCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'getPageUidsCat')) {
+                    $hookObj->getPageUidsCat($this, $cat, $uidArray);
+                }
+            }
+        }
+        $uidArray = array_unique($uidArray);
+        return (implode(',', $uidArray));
+    }
 
-	public function getRequiredFields ($theCode = '') {
-		$tableConf = $this->getTableConf($theCode);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    public function getRequiredFields ($theCode = '') {
+        $tableConf = $this->getTableConf($theCode);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		if (!empty($tableConf['requiredFields'])) {
-			$requiredFields = $tableConf['requiredFields'];
-		} else {
-			$requiredFields = 'uid,pid,parent_id,category,file_mime_type,file_name,file_path';
-		}
+        if (!empty($tableConf['requiredFields'])) {
+            $requiredFields = $tableConf['requiredFields'];
+        } else {
+            $requiredFields = 'uid,pid,parent_id,category,file_mime_type,file_name,file_path';
+        }
 
-		$rc = $requiredFields;
-		return $rc;
-	}
+        $rc = $requiredFields;
+        return $rc;
+    }
 }
 

--- a/model/class.tx_ttproducts_damcategory.php
+++ b/model/class.tx_ttproducts_damcategory.php
@@ -39,7 +39,7 @@
 
 
 class tx_ttproducts_damcategory extends tx_ttproducts_category {
-	protected $tableAlias = 'damcat';
+    protected $tableAlias = 'damcat';
 
 }
 

--- a/model/class.tx_ttproducts_download.php
+++ b/model/class.tx_ttproducts_download.php
@@ -41,68 +41,68 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_download extends tx_ttproducts_article_base {
-	public $relatedArray = []; // array of related products
-	public $marker = 'DOWNLOAD';
-	public $type = 'download';
-	public $piVar='download';
-	public $articleArray = [];
-	protected $tableAlias = 'download';
+    public $relatedArray = []; // array of related products
+    public $marker = 'DOWNLOAD';
+    public $type = 'download';
+    public $piVar='download';
+    public $articleArray = [];
+    protected $tableAlias = 'download';
 
 
-	public function getOrderedUid(
-		$downloadUid,
-		$falUid,
-		$multiOrderArray
-	) {
-		$orderUid = 0;
+    public function getOrderedUid(
+        $downloadUid,
+        $falUid,
+        $multiOrderArray
+    ) {
+        $orderUid = 0;
 
-		if (
-			isset($multiOrderArray) &&
-			is_array($multiOrderArray) &&
-			count($multiOrderArray)
-		) {
-			foreach($multiOrderArray as $orderRow) {
-				if (
-					isset($orderRow['fal_variants']) &&
-					$orderRow['fal_variants'] != ''
-				) {
-					$position = strpos($orderRow['fal_variants'], 'dl=' . $downloadUid . tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR);
+        if (
+            isset($multiOrderArray) &&
+            is_array($multiOrderArray) &&
+            count($multiOrderArray)
+        ) {
+            foreach($multiOrderArray as $orderRow) {
+                if (
+                    isset($orderRow['fal_variants']) &&
+                    $orderRow['fal_variants'] != ''
+                ) {
+                    $position = strpos($orderRow['fal_variants'], 'dl=' . $downloadUid . tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR);
 
-					if ($position !== 0) {
-						continue;
-					}
+                    if ($position !== 0) {
+                        continue;
+                    }
 
-					$position = strpos($orderRow['fal_variants'], tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal=');
-					$orderFalUid = substr($orderRow['fal_variants'], $position + strlen(tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal='));
+                    $position = strpos($orderRow['fal_variants'], tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal=');
+                    $orderFalUid = substr($orderRow['fal_variants'], $position + strlen(tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR . 'fal='));
 
-					if (
-						$orderFalUid = $falUid
-					) {
-						$orderUid = $orderRow['uid'];
-						break;
-					}
-				}
-			}
-		}
+                    if (
+                        $orderFalUid = $falUid
+                    ) {
+                        $orderUid = $orderRow['uid'];
+                        break;
+                    }
+                }
+            }
+        }
 
-		return $orderUid;
-	}
+        return $orderUid;
+    }
 
 
-	public function getOrderedDownloadFalArray (
+    public function getOrderedDownloadFalArray (
         $orderObj,
         $downloadUid,
         $multiOrderArray
     ) {
-		$downloadUid = intval($downloadUid);
-		$orderedFalArray = [];
-		if (
-			$downloadUid &&
-			isset($multiOrderArray) &&
-			is_array($multiOrderArray) &&
-			count($multiOrderArray)
-		) {
-			foreach($multiOrderArray as $orderRow) {
+        $downloadUid = intval($downloadUid);
+        $orderedFalArray = [];
+        if (
+            $downloadUid &&
+            isset($multiOrderArray) &&
+            is_array($multiOrderArray) &&
+            count($multiOrderArray)
+        ) {
+            foreach($multiOrderArray as $orderRow) {
                 $falUid =
                     $orderObj->getFal(
                         $tmp,
@@ -112,25 +112,25 @@ class tx_ttproducts_download extends tx_ttproducts_article_base {
                 if ($falUid) {
                     $orderedFalArray[] = $falUid;
                 }
-			}
-		}
+            }
+        }
 
-		return $orderedFalArray;
-	}
+        return $orderedFalArray;
+    }
 
 
-	public function getFileArray (
+    public function getFileArray (
         $orderObj,
-		$row,
-		$multiOrderArray,
-		$checkPriceZero = false
-	) {
-		$fileArray = [];
+        $row,
+        $multiOrderArray,
+        $checkPriceZero = false
+    ) {
+        $fileArray = [];
 
-		if (
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('filelist') &&
-			$row['file_uid']
-		) {
+        if (
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('filelist') &&
+            $row['file_uid']
+        ) {
 // mm Beziehung auswerten in Datensätze von file $fileUid
 // tt_products_downloads_mm_sysfile (
 // 	uid int(11) NOT NULL auto_increment,
@@ -143,134 +143,134 @@ class tx_ttproducts_download extends tx_ttproducts_article_base {
 // 	uid_foreign int(11) DEFAULT '0' NOT NULL,
 // 	sorting int(10) DEFAULT '0' NOT NULL,
 // 	sorting_foreign
-			$orderedFalArray =
-				$this->getOrderedDownloadFalArray(
+            $orderedFalArray =
+                $this->getOrderedDownloadFalArray(
                     $orderObj,
-					$row['uid'],
-					$multiOrderArray
-				);
-			$orderedFalArray = array_unique($orderedFalArray);
+                    $row['uid'],
+                    $multiOrderArray
+                );
+            $orderedFalArray = array_unique($orderedFalArray);
 
-			if (!empty($orderedFalArray)) {
-				$orderedFalArray = $GLOBALS['TYPO3_DB']->cleanIntArray($orderedFalArray);
+            if (!empty($orderedFalArray)) {
+                $orderedFalArray = $GLOBALS['TYPO3_DB']->cleanIntArray($orderedFalArray);
 
-				$where_clause = 'uid IN (' . implode(',', $orderedFalArray) . ')';
-				$where_clause .= ' AND uid_foreign=' . intval($row['uid']) . ' AND tablenames="tt_products_downloads" AND fieldname="file_uid"' ;
-				$where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
-				$sysfileRowArray =
-					$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-						'*',
-						'sys_file_reference',
-						$where_clause,
-						'',
-						'sorting',
-						'',
-						'uid_local'
-					);
-			}
+                $where_clause = 'uid IN (' . implode(',', $orderedFalArray) . ')';
+                $where_clause .= ' AND uid_foreign=' . intval($row['uid']) . ' AND tablenames="tt_products_downloads" AND fieldname="file_uid"' ;
+                $where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
+                $sysfileRowArray =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                        '*',
+                        'sys_file_reference',
+                        $where_clause,
+                        '',
+                        'sorting',
+                        '',
+                        'uid_local'
+                    );
+            }
 
-			if (
-				is_array($sysfileRowArray)
-			) {
-				$storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
-				$storage = $storageRepository->findByUid(1);
+            if (
+                is_array($sysfileRowArray)
+            ) {
+                $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
+                $storage = $storageRepository->findByUid(1);
 
-				foreach($sysfileRowArray as $fileUid => $sysfileRow) {
-					if (
-						$checkPriceZero &&
-						$sysfileRow['tx_ttproducts_price_enable'] && // check non free downloads against the order data
-						$sysfileRow['tx_ttproducts_price'] > 0
-					) {
-						continue;
-					}
+                foreach($sysfileRowArray as $fileUid => $sysfileRow) {
+                    if (
+                        $checkPriceZero &&
+                        $sysfileRow['tx_ttproducts_price_enable'] && // check non free downloads against the order data
+                        $sysfileRow['tx_ttproducts_price'] > 0
+                    ) {
+                        continue;
+                    }
 
                     $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
-					$fileObj = $resourceFactory->getFileReferenceObject($sysfileRow['uid']);
-					$fileInfo = $storage->getFileInfo($fileObj);
+                    $fileObj = $resourceFactory->getFileReferenceObject($sysfileRow['uid']);
+                    $fileInfo = $storage->getFileInfo($fileObj);
                     $fileArray[$sysfileRow['uid']] = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/' . 'fileadmin' . $fileInfo['identifier'];
-				}
-			}
-		} else if ($row['path'] != '') {
+                }
+            }
+        } else if ($row['path'] != '') {
             $path = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/'  . $row['path'] . '/';
-			$fileArray =
-				\TYPO3\CMS\Core\Utility\GeneralUtility::getAllFilesAndFoldersInPath(
-					$fileArray,
-					$path,
-					'',
-					1,
-					1,
-					$GLOBALS['TYPO3_CONF_VARS']['EXT']['excludeForPackaging']
-				);
-			usort($fileArray, 'version_compare');
+            $fileArray =
+                \TYPO3\CMS\Core\Utility\GeneralUtility::getAllFilesAndFoldersInPath(
+                    $fileArray,
+                    $path,
+                    '',
+                    1,
+                    1,
+                    $GLOBALS['TYPO3_CONF_VARS']['EXT']['excludeForPackaging']
+                );
+            usort($fileArray, 'version_compare');
 
-			$fileArray = array_reverse($fileArray, true);
-		}
+            $fileArray = array_reverse($fileArray, true);
+        }
 
-		return $fileArray;
-	}
+        return $fileArray;
+    }
 
 
-	public function getRelatedUidArray (
-		$uids,
-		$tagMarkerArray,
-		$parenttable = 'tt_products'
-	) {
-		$resultArray = [];
-		$downloadUidArray = [];
-		$bAllowed = true;
+    public function getRelatedUidArray (
+        $uids,
+        $tagMarkerArray,
+        $parenttable = 'tt_products'
+    ) {
+        $resultArray = [];
+        $downloadUidArray = [];
+        $bAllowed = true;
 
-		if ($parenttable == 'tt_products') {
-			$uidArray = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $uids);
-			$mmTable = 'tt_products_products_mm_downloads';
+        if ($parenttable == 'tt_products') {
+            $uidArray = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $uids);
+            $mmTable = 'tt_products_products_mm_downloads';
 
-			foreach ($uidArray as $uid) {
-				if (intval($uid) == $uid) {
-					$where_clause = 'uid_local = ' . intval($uid);
-					$rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $mmTable, $where_clause);
+            foreach ($uidArray as $uid) {
+                if (intval($uid) == $uid) {
+                    $where_clause = 'uid_local = ' . intval($uid);
+                    $rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', $mmTable, $where_clause);
 
-					if (isset($rowArray) && is_array($rowArray)) {
-						foreach ($rowArray as $row) {
-							$downloadUidArray[] = $row['uid_foreign'];
-						}
-					}
-				}
-			}
+                    if (isset($rowArray) && is_array($rowArray)) {
+                        foreach ($rowArray as $row) {
+                            $downloadUidArray[] = $row['uid_foreign'];
+                        }
+                    }
+                }
+            }
 
-			if (empty($downloadUidArray)) {
-				$bAllowed = false;
-			}
-		}
+            if (empty($downloadUidArray)) {
+                $bAllowed = false;
+            }
+        }
 
-		$where_clause = '';
-		$tagWhere = '';
+        $where_clause = '';
+        $tagWhere = '';
 
-		if (is_array($tagMarkerArray) && ($tagMarkerArray)) {
-			$newTagMarkerArray = [];
-			foreach ($tagMarkerArray as $tagMarker) {
-				if (strpos($tagMarker, '_') === false) {
-					$newTagMarkerArray[] = $tagMarker;
-				}
-			}
+        if (is_array($tagMarkerArray) && ($tagMarkerArray)) {
+            $newTagMarkerArray = [];
+            foreach ($tagMarkerArray as $tagMarker) {
+                if (strpos($tagMarker, '_') === false) {
+                    $newTagMarkerArray[] = $tagMarker;
+                }
+            }
 
-			$tagMarkerArray = $newTagMarkerArray;
-			$tagMarkerArray = $GLOBALS['TYPO3_DB']->fullQuoteArray(
-				$tagMarkerArray,
-				$this->getTableObj()->getName()
-			);
-			$tags = implode(',', $tagMarkerArray);
-			$tagWhere = ' AND marker IN (' . $tags . ')';
-		}
+            $tagMarkerArray = $newTagMarkerArray;
+            $tagMarkerArray = $GLOBALS['TYPO3_DB']->fullQuoteArray(
+                $tagMarkerArray,
+                $this->getTableObj()->getName()
+            );
+            $tags = implode(',', $tagMarkerArray);
+            $tagWhere = ' AND marker IN (' . $tags . ')';
+        }
 
-		if (is_array($downloadUidArray) && count($downloadUidArray)) {
-			$where_clause = 'uid IN (' . implode(',', $downloadUidArray) . ')' .
-				$tagWhere;
-		}
+        if (is_array($downloadUidArray) && count($downloadUidArray)) {
+            $where_clause = 'uid IN (' . implode(',', $downloadUidArray) . ')' .
+                $tagWhere;
+        }
 
-		if ($bAllowed) {
-			$resultArray = $this->get('', '', false, $where_clause);
-		}
+        if ($bAllowed) {
+            $resultArray = $this->get('', '', false, $where_clause);
+        }
 
-		return $resultArray;
-	}
+        return $resultArray;
+    }
 }
 

--- a/model/class.tx_ttproducts_edit_variant.php
+++ b/model/class.tx_ttproducts_edit_variant.php
@@ -37,15 +37,15 @@
  */
 
 /*
-	editVariant {
-		default {
-			params = onchange = "submit();"
-		}
-		10 {
-			sql.where = uid = 1
-			suffix = height
-		}
-	}
+    editVariant {
+        default {
+            params = onchange = "submit();"
+        }
+        10 {
+            sql.where = uid = 1
+            suffix = height
+        }
+    }
 
 note: the price calculation shall not been implemented because it does not make sense to make calculation only on a height. If you have a 3D object, then the surface must be calculated to determine a price. This will be a multiplication of many edit fields.
 
@@ -56,250 +56,250 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_edit_variant implements \TYPO3\CMS\Core\SingletonInterface {
-	protected $itemTable;
+    protected $itemTable;
 
-	/**
-	 * setting the local variables
-	 */
-	public function init (&$itemTable) {
-		$this->itemTable = $itemTable;
-	}
+    /**
+     * setting the local variables
+     */
+    public function init (&$itemTable) {
+        $this->itemTable = $itemTable;
+    }
 
-	public function getFieldArray () {
+    public function getFieldArray () {
 
-		$result = [];
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->conf;
+        $result = [];
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->conf;
 
-		if (
-			isset($conf['editVariant.']) &&
-			is_array($conf['editVariant.'])
-		) {
-			$editVariantConfig = $conf['editVariant.'];
-			$count = 0;
+        if (
+            isset($conf['editVariant.']) &&
+            is_array($conf['editVariant.'])
+        ) {
+            $editVariantConfig = $conf['editVariant.'];
+            $count = 0;
 
-			foreach ($editVariantConfig as $k => $config) {
-				if ($k != 'default.' && (strpos($k, '.') == strlen($k) - 1)) {
-					$count++;
-					if (isset($config['suffix'])) {
-						$suffix = $config['suffix'];
-					} else {
-						$suffix = $count;
-					}
-					$field = 'edit_' . $suffix;
-					$result[] = $field;
-				}
-			}
-		}
+            foreach ($editVariantConfig as $k => $config) {
+                if ($k != 'default.' && (strpos($k, '.') == strlen($k) - 1)) {
+                    $count++;
+                    if (isset($config['suffix'])) {
+                        $suffix = $config['suffix'];
+                    } else {
+                        $suffix = $count;
+                    }
+                    $field = 'edit_' . $suffix;
+                    $result[] = $field;
+                }
+            }
+        }
 
         $result = array_unique($result);
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getVariantFromRawRow ($row) {
-		$fieldArray = $this->getFieldArray();
-		$variantArray = [];
+    public function getVariantFromRawRow ($row) {
+        $fieldArray = $this->getFieldArray();
+        $variantArray = [];
 
-		foreach ($row as $field => $value) {
-			if (in_array($field, $fieldArray)) {
-				$variantArray[] = $field . '=>' . $value;
-			}
-		}
-		$result = implode(tx_ttproducts_variant_int::INTERNAL_VARIANT_SEPARATOR, $variantArray);
+        foreach ($row as $field => $value) {
+            if (in_array($field, $fieldArray)) {
+                $variantArray[] = $field . '=>' . $value;
+            }
+        }
+        $result = implode(tx_ttproducts_variant_int::INTERNAL_VARIANT_SEPARATOR, $variantArray);
 
-		return $result;
-	}
+        return $result;
+    }
 
-	/**
-	 * Returns the variant extVar number from the incoming product row and the index in the variant array
-	 *
-	 * @param	array	the basket raw row
-	 * @return  string	  variants separated by variantSeparator
-	 * @access private
-	 * @see modifyRowFromVariant
-	 */
-	public function getVariantRowFromProductRow ($row) {
-		$variantRow = false;
+    /**
+     * Returns the variant extVar number from the incoming product row and the index in the variant array
+     *
+     * @param	array	the basket raw row
+     * @return  string	  variants separated by variantSeparator
+     * @access private
+     * @see modifyRowFromVariant
+     */
+    public function getVariantRowFromProductRow ($row) {
+        $variantRow = false;
 
-		if (
-			isset($row) &&
-			count($row)
-		) {
-			foreach ($row as $field => $value) {
-				if (strpos($field, 'edit_') === 0) {
-					$variantRow[$field] = $value;
-				}
-			}
-		}
-		return $variantRow;
-	}
+        if (
+            isset($row) &&
+            count($row)
+        ) {
+            foreach ($row as $field => $value) {
+                if (strpos($field, 'edit_') === 0) {
+                    $variantRow[$field] = $value;
+                }
+            }
+        }
+        return $variantRow;
+    }
 
-	public function evalValues ($dataValue, $config) {
+    public function evalValues ($dataValue, $config) {
 
-		$result = true;
-		$listOfCommands = GeneralUtility::trimExplode(',', $config, 1);
+        $result = true;
+        $listOfCommands = GeneralUtility::trimExplode(',', $config, 1);
 
-		foreach($listOfCommands as $cmd) {
-			$cmdParts = preg_split('/\[|\]/', $cmd); // Point is to enable parameters after each command enclosed in brackets [..]. These will be in position 1 in the array.
-			$theCmd = trim($cmdParts[0]);
+        foreach($listOfCommands as $cmd) {
+            $cmdParts = preg_split('/\[|\]/', $cmd); // Point is to enable parameters after each command enclosed in brackets [..]. These will be in position 1 in the array.
+            $theCmd = trim($cmdParts[0]);
 
-			switch($theCmd) {
+            switch($theCmd) {
 
-				case 'required':
-					if (empty($dataValue) && $dataValue !== '0') {
-						$result = false;
-						break;
-					}
-				break;
+                case 'required':
+                    if (empty($dataValue) && $dataValue !== '0') {
+                        $result = false;
+                        break;
+                    }
+                break;
 
-				case 'wwwURL':
-					if ($dataValue) {
-						$url = 'http://' . $dataValue;
-						$report = [];
+                case 'wwwURL':
+                    if ($dataValue) {
+                        $url = 'http://' . $dataValue;
+                        $report = [];
 
-						if (
-							!GeneralUtility::isValidUrl($url) ||
-							!GeneralUtility::getUrl($url, 0, false, $report) && $report['error'] != 22 /* CURLE_HTTP_RETURNED_ERROR */
-						) {
-							$result = false;
-							break;
-						}
-					}
-				break;
+                        if (
+                            !GeneralUtility::isValidUrl($url) ||
+                            !GeneralUtility::getUrl($url, 0, false, $report) && $report['error'] != 22 /* CURLE_HTTP_RETURNED_ERROR */
+                        ) {
+                            $result = false;
+                            break;
+                        }
+                    }
+                break;
 
-			}
-		}
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function checkValid (array $config, array $row) {
+    public function checkValid (array $config, array $row) {
 
-		$result = true;
-		$checkedArray = [];
-		$rowConfig = [];
-		$resultArray = [];
+        $result = true;
+        $checkedArray = [];
+        $rowConfig = [];
+        $resultArray = [];
 
-		foreach ($config as $k => $rowConfig) {
+        foreach ($config as $k => $rowConfig) {
 
-			if ($rowConfig['suffix']) {
-				$evalArray = '';
-				$rangeArray = '';
+            if ($rowConfig['suffix']) {
+                $evalArray = '';
+                $rangeArray = '';
 
-				$theField = 'edit_' . $rowConfig['suffix'];
+                $theField = 'edit_' . $rowConfig['suffix'];
 
-				if (isset($rowConfig['range.'])) {
-					$rangeArray = $rowConfig['range.'];
-				}
-				if (isset($rowConfig['evalValues.'])) {
-					$evalArray = $rowConfig['evalValues.'];
-				}
-				$bValidData = true;
+                if (isset($rowConfig['range.'])) {
+                    $rangeArray = $rowConfig['range.'];
+                }
+                if (isset($rowConfig['evalValues.'])) {
+                    $evalArray = $rowConfig['evalValues.'];
+                }
+                $bValidData = true;
 
-				if (
-					!$checkedArray[$theField] &&
-					isset($row[$theField])
-				) {
-					$value = $row[$theField];
+                if (
+                    !$checkedArray[$theField] &&
+                    isset($row[$theField])
+                ) {
+                    $value = $row[$theField];
 
-					if (
-						isset($rangeArray) &&
-						is_array($rangeArray) &&
-						count($rangeArray)
-					) {
-						$bValidData = false;
+                    if (
+                        isset($rangeArray) &&
+                        is_array($rangeArray) &&
+                        count($rangeArray)
+                    ) {
+                        $bValidData = false;
 
-						foreach ($rangeArray as $range) {
-							$rangeValueArray = GeneralUtility::trimExplode('-', $range);
+                        foreach ($rangeArray as $range) {
+                            $rangeValueArray = GeneralUtility::trimExplode('-', $range);
 
-							if (
-								$rangeValueArray['0'] <= $value &&
-								$value <= $rangeValueArray['1']
-							) {
-								$bValidData = true;
-								$checkedArray[$theField] = true;
-								break;
-							}
-						}
-					} else if (
-						isset($evalArray) &&
-						is_array($evalArray) &&
-						count($evalArray)
-					) {
-						foreach ($evalArray as $evalValues) {
-							$bValidData = $this->evalValues($value, $evalValues);
-							if ($bValidData) {
-								$checkedArray[$theField] = true;
-								break;
-							}
-						}
-					}
-				}
+                            if (
+                                $rangeValueArray['0'] <= $value &&
+                                $value <= $rangeValueArray['1']
+                            ) {
+                                $bValidData = true;
+                                $checkedArray[$theField] = true;
+                                break;
+                            }
+                        }
+                    } else if (
+                        isset($evalArray) &&
+                        is_array($evalArray) &&
+                        count($evalArray)
+                    ) {
+                        foreach ($evalArray as $evalValues) {
+                            $bValidData = $this->evalValues($value, $evalValues);
+                            if ($bValidData) {
+                                $checkedArray[$theField] = true;
+                                break;
+                            }
+                        }
+                    }
+                }
 
-				if (!$bValidData) {
-					if (isset($rowConfig['error'])) {
-						$resultArray[$theField] = $rowConfig['error'];
-					} else {
-						$resultArray[$theField] = 'Invalid value: ' . $theField;
-					}
-				}
-			}
-		}
+                if (!$bValidData) {
+                    if (isset($rowConfig['error'])) {
+                        $resultArray[$theField] = $rowConfig['error'];
+                    } else {
+                        $resultArray[$theField] = 'Invalid value: ' . $theField;
+                    }
+                }
+            }
+        }
 
 
-		if (is_array($resultArray) && ($resultArray)) {
-			$result = $resultArray;
-		}
+        if (is_array($resultArray) && ($resultArray)) {
+            $result = $resultArray;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getValidConfig ($row) {
+    public function getValidConfig ($row) {
 
-		$result = false;
+        $result = false;
 
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		if (isset($conf['editVariant.'])) {
-			$editVariantConfig = $conf['editVariant.'];
-			$defaultConfig = $editVariantConfig['default.'];
-			$count = 0;
+        if (isset($conf['editVariant.'])) {
+            $editVariantConfig = $conf['editVariant.'];
+            $defaultConfig = $editVariantConfig['default.'];
+            $count = 0;
 
-			foreach ($editVariantConfig as $k => $config) {
-				if ($k == 'default.') {
-					// nothing
-				} else if (strpos($k, '.') == strlen($k) - 1) {
-					$count++;
-					$bIsValid = true;
-					if (isset($config['sql.']) && isset($config['sql.'])) {
-						$bIsValid = tx_ttproducts_sql::isValid($row, $config['sql.']['where']);
-					}
+            foreach ($editVariantConfig as $k => $config) {
+                if ($k == 'default.') {
+                    // nothing
+                } else if (strpos($k, '.') == strlen($k) - 1) {
+                    $count++;
+                    $bIsValid = true;
+                    if (isset($config['sql.']) && isset($config['sql.'])) {
+                        $bIsValid = tx_ttproducts_sql::isValid($row, $config['sql.']['where']);
+                    }
 
-					if ($bIsValid) {
-						$mergeKeyArray = ['params'];
-						if (isset($defaultConfig) && is_array($defaultConfig)) {
-							foreach ($defaultConfig as $k2 => $config2) {
-								if (in_array($k2, $mergeKeyArray)) {
-									// merge the configuration with the defaults
-									if (isset($config2) && is_array($config2)) {
-										if (isset($config[$k2]) && is_array($config[$k2])) {
-											$config[$k2] = array_merge($config2, $config[$k2]);
-										}
-									} else {
-										$config[$k2] = $config2 . ' ' . $config[$k2];
-									}
-								}
-							}
-						}
-						$config['index'] = $count;
-						$result[$k] = $config;
-					}
-				}
-			}
-		}
+                    if ($bIsValid) {
+                        $mergeKeyArray = ['params'];
+                        if (isset($defaultConfig) && is_array($defaultConfig)) {
+                            foreach ($defaultConfig as $k2 => $config2) {
+                                if (in_array($k2, $mergeKeyArray)) {
+                                    // merge the configuration with the defaults
+                                    if (isset($config2) && is_array($config2)) {
+                                        if (isset($config[$k2]) && is_array($config[$k2])) {
+                                            $config[$k2] = array_merge($config2, $config[$k2]);
+                                        }
+                                    } else {
+                                        $config[$k2] = $config2 . ' ' . $config[$k2];
+                                    }
+                                }
+                            }
+                        }
+                        $config['index'] = $count;
+                        $result[$k] = $config;
+                    }
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/model/class.tx_ttproducts_edit_variant_dummy.php
+++ b/model/class.tx_ttproducts_edit_variant_dummy.php
@@ -39,20 +39,20 @@
 
 class tx_ttproducts_edit_variant_dummy implements tx_ttproducts_edit_variant_int, \TYPO3\CMS\Core\SingletonInterface {
 
-	public function init ($itemTable) {
-		return true;
-	}
+    public function init ($itemTable) {
+        return true;
+    }
 
-	public function getFieldArray () {
-	}
+    public function getFieldArray () {
+    }
 
-	public function getVariantFromRawRow ($row) {
-	}
+    public function getVariantFromRawRow ($row) {
+    }
 
-	public function getVariantRowFromProductRow ($row) {
-	}
+    public function getVariantRowFromProductRow ($row) {
+    }
 
-	public function getValidConfig ($row) {
-	}
+    public function getValidConfig ($row) {
+    }
 }
 

--- a/model/class.tx_ttproducts_email.php
+++ b/model/class.tx_ttproducts_email.php
@@ -42,39 +42,39 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_email extends tx_ttproducts_table_base {
-	var $emailArray;	// array of read in emails
-	var $table;		 // object of the type tx_table_db
+    var $emailArray;	// array of read in emails
+    var $table;		 // object of the type tx_table_db
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	function init($functablename)  {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    function init($functablename)  {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$tablename = $this->getTablename();
-			$this->getTableObj()->addDefaultFieldArray(array('sorting' => 'sorting'));
-			$this->getTableObj()->setTCAFieldArray('tt_products_emails');
-		}
+        if ($result) {
+            $tablename = $this->getTablename();
+            $this->getTableObj()->addDefaultFieldArray(array('sorting' => 'sorting'));
+            $this->getTableObj()->setTCAFieldArray('tt_products_emails');
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
 
-	function getEmail ($uid) {
-		$rc = $this->emailArray[$uid] ?? '';
-		if ($uid && !$rc) {
-			$sql = GeneralUtility::makeInstance('tx_table_db_access');
-			$sql->prepareFields($this->getTableObj(), 'select', '*');
-			$sql->prepareWhereFields ($this->getTableObj(), 'uid', '=', intval($uid));
-			$sql->prepareEnableFields ($this->getTableObj());
-			//$this->getTableObj()->enableFields();
-			// Fetching the email
-			$res = $sql->exec_SELECTquery();
-			$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-			$rc = $this->emailArray[$row['uid']] = $row;
-		}
-		return $rc;
-	}
+    function getEmail ($uid) {
+        $rc = $this->emailArray[$uid] ?? '';
+        if ($uid && !$rc) {
+            $sql = GeneralUtility::makeInstance('tx_table_db_access');
+            $sql->prepareFields($this->getTableObj(), 'select', '*');
+            $sql->prepareWhereFields ($this->getTableObj(), 'uid', '=', intval($uid));
+            $sql->prepareEnableFields ($this->getTableObj());
+            //$this->getTableObj()->enableFields();
+            // Fetching the email
+            $res = $sql->exec_SELECTquery();
+            $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+            $rc = $this->emailArray[$row['uid']] = $row;
+        }
+        return $rc;
+    }
 }
 

--- a/model/class.tx_ttproducts_fal.php
+++ b/model/class.tx_ttproducts_fal.php
@@ -38,21 +38,21 @@
 
 
 class tx_ttproducts_fal extends tx_ttproducts_article_base {
-	public $marker = 'FAL';
-	public $type = 'fal';
-	public $piVar = 'fal';
+    public $marker = 'FAL';
+    public $type = 'fal';
+    public $piVar = 'fal';
 
-	static public $copyFieldArray = [
-		'title',
-		'link',
-		'description',
-		'alternative',
-		'tx_ttproducts_author',
-		'tx_ttproducts_startpoint',
-		'tx_ttproducts_endpoint',
-		'tx_ttproducts_price_enable',
-		'tx_ttproducts_price'
-	];
+    static public $copyFieldArray = [
+        'title',
+        'link',
+        'description',
+        'alternative',
+        'tx_ttproducts_author',
+        'tx_ttproducts_startpoint',
+        'tx_ttproducts_endpoint',
+        'tx_ttproducts_price_enable',
+        'tx_ttproducts_price'
+    ];
 
 }
 

--- a/model/class.tx_ttproducts_fpdf.php
+++ b/model/class.tx_ttproducts_fpdf.php
@@ -41,215 +41,215 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_fpdf extends FPDF {
-	private $header;
-	private $footer;
-	private $body;
-	protected $family;
-	protected $style;
-	protected $size;
+    private $header;
+    private $footer;
+    private $body;
+    protected $family;
+    protected $style;
+    protected $size;
 
 
-	public function init ($family, $style, $size) {
-		$this->family = $family;
-		$this->style = $style;
-		$this->size = $size;
+    public function init ($family, $style, $size) {
+        $this->family = $family;
+        $this->style = $style;
+        $this->size = $size;
 
-		$this->SetFont($family, $style, $size);
+        $this->SetFont($family, $style, $size);
 
-		return true;
-	}
+        return true;
+    }
 
-	public function setHeader ($header) {
-		$this->header = $header;
-	}
+    public function setHeader ($header) {
+        $this->header = $header;
+    }
 
-	public function setFooter ($footer) {
-		$this->footer = $footer;
-	}
+    public function setFooter ($footer) {
+        $this->footer = $footer;
+    }
 
-	public function setBody ($body) {
-		$this->body = $body;
-	}
+    public function setBody ($body) {
+        $this->body = $body;
+    }
 
-	public function Header () {
-		//Police Arial gras 15
-		$this->SetFont('Arial', 'B', 15);
-		$this->MultiCell(0, 6, $this->header, 1);
-	}
+    public function Header () {
+        //Police Arial gras 15
+        $this->SetFont('Arial', 'B', 15);
+        $this->MultiCell(0, 6, $this->header, 1);
+    }
 
-	public function Footer () {
-		//Positionnement à 1,5 cm du bas
-		$this->SetY(-15);
-		//Police Arial gras 15
-		$this->SetFont('Arial', 'I', 8);
-		$this->MultiCell(0, 6, $this->footer, 1);
-	}
+    public function Footer () {
+        //Positionnement à 1,5 cm du bas
+        $this->SetY(-15);
+        //Police Arial gras 15
+        $this->SetFont('Arial', 'I', 8);
+        $this->MultiCell(0, 6, $this->footer, 1);
+    }
 
-	private function addEmptyColumns ($bLastLine) {
+    private function addEmptyColumns ($bLastLine) {
 
-		$row = [];
-		$row['1'] = '';
-		$row['2'] = '';
-		$row['3'] = '';
+        $row = [];
+        $row['1'] = '';
+        $row['2'] = '';
+        $row['3'] = '';
 
-		$this->getDimensions($widthArray);
+        $this->getDimensions($widthArray);
 
-		foreach ($row as $k => $v) {
-			if ($k2 < 2) {
-				$this->Cell($widthArray[$k], 6, $v, 'LR', 0);
-			} else {
-				$this->Cell($widthArray[$k], 6, $v, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
-			}
-		}
-	}
+        foreach ($row as $k => $v) {
+            if ($k2 < 2) {
+                $this->Cell($widthArray[$k], 6, $v, 'LR', 0);
+            } else {
+                $this->Cell($widthArray[$k], 6, $v, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
+            }
+        }
+    }
 
-	private function getDimensions (&$widthArray) {
-		//Column widths
-		$widthArray = [80, 25, 40, 45];
-	}
+    private function getDimensions (&$widthArray) {
+        //Column widths
+        $widthArray = [80, 25, 40, 45];
+    }
 
-	//Better table
-	public function ImprovedTable ($header, array $data) {
-		$this->getDimensions($widthArray);
+    //Better table
+    public function ImprovedTable ($header, array $data) {
+        $this->getDimensions($widthArray);
 
-		$totalWidth = 0;
-		foreach ($widthArray as $width) {
-			$totalWidth += $width;
-		}
+        $totalWidth = 0;
+        foreach ($widthArray as $width) {
+            $totalWidth += $width;
+        }
 
-		if (is_array($header)) {
+        if (is_array($header)) {
             //Header
             for($i = 0; $i < count($header); $i++) {
                 $this->Cell($widthArray[$i], 7, $header[$i], 1, 0, 'C');
             }
         }
-		$this->Ln();
+        $this->Ln();
 
-		$dataCount = count($data);
-		$rowCount = 4;
-		$columnNo = 1;
+        $dataCount = count($data);
+        $rowCount = 4;
+        $columnNo = 1;
 
-		//Data. The keys must start with 1
-		foreach($data as $k1 => $row) {
-			$bLastLine = ($k1 == $dataCount);
-			if ($bLastLine) {
-				$this->SetFont($this->family, 'B', $this->size);
-			}
-			$oldRowCount = $rowCount;
-			$rowCount = count($row);
+        //Data. The keys must start with 1
+        foreach($data as $k1 => $row) {
+            $bLastLine = ($k1 == $dataCount);
+            if ($bLastLine) {
+                $this->SetFont($this->family, 'B', $this->size);
+            }
+            $oldRowCount = $rowCount;
+            $rowCount = count($row);
 
-			foreach ($row as $k2 => $v2) {
+            foreach ($row as $k2 => $v2) {
 
-				if ($columnNo > 4) {
-					$columnNo = 1;
-				}
+                if ($columnNo > 4) {
+                    $columnNo = 1;
+                }
 
-				if ($k2 == 0 && trim($v2) == '' && $rowCount == 4 && $oldRowCount == 1 && $columnNo == 2) {
-					// skip first column which has been filled in from former row
-					continue;
-				}
-				$l2 = intval($this->GetStringWidth($v2));
-				unset($value);
+                if ($k2 == 0 && trim($v2) == '' && $rowCount == 4 && $oldRowCount == 1 && $columnNo == 2) {
+                    // skip first column which has been filled in from former row
+                    continue;
+                }
+                $l2 = intval($this->GetStringWidth($v2));
+                unset($value);
 
-				if ($l2 > $widthArray[$k2] - 5) {
-					$subStringCount = intval ($l2 / ($widthArray[$k2] - 10)) + 1;
-					$averageStringLength = strlen($v2) / $subStringCount;
-					if (!isset($additonalRow)) {
-						$additonalRow = [];
-					}
+                if ($l2 > $widthArray[$k2] - 5) {
+                    $subStringCount = intval ($l2 / ($widthArray[$k2] - 10)) + 1;
+                    $averageStringLength = strlen($v2) / $subStringCount;
+                    if (!isset($additonalRow)) {
+                        $additonalRow = [];
+                    }
 
-					$startPosition = 0;
-					for ($i = 0; $i < $subStringCount; $i++) {
-						$subValue = substr($v2, $startPosition, $averageStringLength);
-						$lastSpacePosition = strrpos($subValue, ' ');
-						$subValue = substr($subValue, 0, $lastSpacePosition);
-						$startPosition += strlen($subValue) + 1;
+                    $startPosition = 0;
+                    for ($i = 0; $i < $subStringCount; $i++) {
+                        $subValue = substr($v2, $startPosition, $averageStringLength);
+                        $lastSpacePosition = strrpos($subValue, ' ');
+                        $subValue = substr($subValue, 0, $lastSpacePosition);
+                        $startPosition += strlen($subValue) + 1;
 
-						if ($i == 0) {
-							if ($oldRowCount > 1) {
-								$value = $subValue;
-							} else {
-								$additonalRow[] = $subValue;
-							}
-						} else {
-							$additonalRow[] = $subValue;
-						}
-					}
-				} else {
-					if ($oldRowCount > 1 || $rowCount > 1) {
-						$value = $v2;
-					} else {
-						$additonalRow[] = $v2;
-					}
-				}
+                        if ($i == 0) {
+                            if ($oldRowCount > 1) {
+                                $value = $subValue;
+                            } else {
+                                $additonalRow[] = $subValue;
+                            }
+                        } else {
+                            $additonalRow[] = $subValue;
+                        }
+                    }
+                } else {
+                    if ($oldRowCount > 1 || $rowCount > 1) {
+                        $value = $v2;
+                    } else {
+                        $additonalRow[] = $v2;
+                    }
+                }
 
-				if (isset($value)) {
-					if ($k2 < 2) {
-						$this->Cell($widthArray[$k2], 6, $value, 'LR', 0);
-					} else {
-						$this->Cell($widthArray[$k2], 6, $value, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
-					}
-					$columnNo++;
+                if (isset($value)) {
+                    if ($k2 < 2) {
+                        $this->Cell($widthArray[$k2], 6, $value, 'LR', 0);
+                    } else {
+                        $this->Cell($widthArray[$k2], 6, $value, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
+                    }
+                    $columnNo++;
 
-					if ($columnNo <= 4) {
-						continue;
-					}
-					$this->Ln();
-				} else {
-					continue;
-				}
+                    if ($columnNo <= 4) {
+                        continue;
+                    }
+                    $this->Ln();
+                } else {
+                    continue;
+                }
 
-				if (isset($additonalRow) && is_array($additonalRow)) {
-			//		$this->Ln();
+                if (isset($additonalRow) && is_array($additonalRow)) {
+            //		$this->Ln();
 
-					foreach ($additonalRow as $k3 => $subValue) {
-						$bLastSubRow = ($k3 == ($subRowCount - 1));
+                    foreach ($additonalRow as $k3 => $subValue) {
+                        $bLastSubRow = ($k3 == ($subRowCount - 1));
 
-						$this->Cell($widthArray['0'], 6, $subValue, 'LR', ($subRowCount > 1 && !$bLastSubRow ? 1 : 0));
-						$this->addEmptyColumns($bLastLine);
-						$this->Ln();
-					}
-					$columnNo = 1;
-					unset($additonalRow);
-				}
-			}
-		}
+                        $this->Cell($widthArray['0'], 6, $subValue, 'LR', ($subRowCount > 1 && !$bLastSubRow ? 1 : 0));
+                        $this->addEmptyColumns($bLastLine);
+                        $this->Ln();
+                    }
+                    $columnNo = 1;
+                    unset($additonalRow);
+                }
+            }
+        }
 
-		$this->SetFont($this->family, $this->style, $this->size);
+        $this->SetFont($this->family, $this->style, $this->size);
 
-		//Closure line
-		$this->Cell(array_sum($w), 0, '', 'T');
-		$this->Ln();
-	}
+        //Closure line
+        $this->Cell(array_sum($w), 0, '', 'T');
+        $this->Ln();
+    }
 
-	public function Body () {
+    public function Body () {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		// $xPos = $this->GetX();
-		$tempContent = $templateService->getSubpart($this->body, '###PDF_TABLE_1###');
-		if (empty($tempContent)) {
+        // $xPos = $this->GetX();
+        $tempContent = $templateService->getSubpart($this->body, '###PDF_TABLE_1###');
+        if (empty($tempContent)) {
             return false;
-		}
-		$tempContentArray = preg_split('/[\n]+/', $tempContent);
-		$dataArray = [];
-		foreach ($tempContentArray as $tmpContent) {
-			if (isset($tmpContent) && trim($tmpContent) != '') {
-				$dataArray[] = preg_split('/\|/', $tmpContent, -1, PREG_SPLIT_NO_EMPTY);
-			}
-		}
-		$header = $dataArray['0'];
-		unset($dataArray['0']);
-		$this->ImprovedTable($header, $dataArray);
+        }
+        $tempContentArray = preg_split('/[\n]+/', $tempContent);
+        $dataArray = [];
+        foreach ($tempContentArray as $tmpContent) {
+            if (isset($tmpContent) && trim($tmpContent) != '') {
+                $dataArray[] = preg_split('/\|/', $tmpContent, -1, PREG_SPLIT_NO_EMPTY);
+            }
+        }
+        $header = $dataArray['0'];
+        unset($dataArray['0']);
+        $this->ImprovedTable($header, $dataArray);
 
-		$restBody = $templateService->substituteMarkerArrayCached(
-				$this->body,
-				[],
-				['###PDF_TABLE_1###' => ''],
-				[]
-			);
+        $restBody = $templateService->substituteMarkerArrayCached(
+                $this->body,
+                [],
+                ['###PDF_TABLE_1###' => ''],
+                []
+            );
 
-		// $this->SetX($xPos);
-		$this->MultiCell(0, 4, $restBody, '1L');
-	}
+        // $this->SetX($xPos);
+        $this->MultiCell(0, 4, $restBody, '1L');
+    }
 }
 
 

--- a/model/class.tx_ttproducts_mm_table.php
+++ b/model/class.tx_ttproducts_mm_table.php
@@ -40,7 +40,7 @@
 
 
 class tx_ttproducts_mm_table extends tx_ttproducts_table_base {
-	protected $tableAlias = 'mm';
+    protected $tableAlias = 'mm';
 
 }
 

--- a/model/class.tx_ttproducts_model_activity.php
+++ b/model/class.tx_ttproducts_model_activity.php
@@ -39,17 +39,17 @@
 
 
 class tx_ttproducts_model_activity {
-	static public $activityArray;
+    static public $activityArray;
 
 
-	static public function setActivityArray ($activityArray) {
-		self::$activityArray = $activityArray;
-	}
+    static public function setActivityArray ($activityArray) {
+        self::$activityArray = $activityArray;
+    }
 
 
-	static public function getActivityArray () {
-		return self::$activityArray;
-	}
+    static public function getActivityArray () {
+        return self::$activityArray;
+    }
 }
 
 

--- a/model/class.tx_ttproducts_model_control.php
+++ b/model/class.tx_ttproducts_model_control.php
@@ -41,73 +41,73 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_model_control {
-	static public $controlVar = 'ctrl';
+    static public $controlVar = 'ctrl';
 
-	static public $paramsTableArray = [
-		'a' => 'address',
-		'article' => 'tt_products_articles',
-		'cat' => 'tt_products_cat',
-		'content' => 'tt_content',
-		'dam' => 'tx_dam',
-		'damcat' => 'tx_dam_cat',
-		'dl' => 'tt_products_downloads',
-		'fal' => 'sys_file_reference',
-		'fg' => 'fegroup',
-		'o' => 'sys_products_orders',
-		'oa' => 'orderaddress',
-		'pid' => 'pages',
-		'product' => 'tt_products',
-	];
+    static public $paramsTableArray = [
+        'a' => 'address',
+        'article' => 'tt_products_articles',
+        'cat' => 'tt_products_cat',
+        'content' => 'tt_content',
+        'dam' => 'tx_dam',
+        'damcat' => 'tx_dam_cat',
+        'dl' => 'tt_products_downloads',
+        'fal' => 'sys_file_reference',
+        'fg' => 'fegroup',
+        'o' => 'sys_products_orders',
+        'oa' => 'orderaddress',
+        'pid' => 'pages',
+        'product' => 'tt_products',
+    ];
 
-	static public $pointerParamsCodeArray = [
-		'pointer' => 'CATLIST',
-		'pp' => 'LIST',
-	];
+    static public $pointerParamsCodeArray = [
+        'pointer' => 'CATLIST',
+        'pp' => 'LIST',
+    ];
 
-	static public $basketVar = 'ttp_basket';
-	static public $searchboxVar = 'searchbox';
-	static private $basketParamVar = 'basket';
-	static private $orderViewVar = 'orderview';
-	static private $prefixId = 'tt_products';
-	static private $piVars = [];
-	static private $piVarsDefault = [];
-	static private $andVars = [];
-	static private $basketIntoIdPrefix = 'basket-into-id';
-	static private $basketInputErrorIdPrefix = 'basket-input-error-id';
+    static public $basketVar = 'ttp_basket';
+    static public $searchboxVar = 'searchbox';
+    static private $basketParamVar = 'basket';
+    static private $orderViewVar = 'orderview';
+    static private $prefixId = 'tt_products';
+    static private $piVars = [];
+    static private $piVarsDefault = [];
+    static private $andVars = [];
+    static private $basketIntoIdPrefix = 'basket-into-id';
+    static private $basketInputErrorIdPrefix = 'basket-input-error-id';
 
 
-	static public function determineRegExpDelimiter ($delimiter) {
-		$regexpDelimiter = $delimiter;
-		if ($delimiter == ';') {
+    static public function determineRegExpDelimiter ($delimiter) {
+        $regexpDelimiter = $delimiter;
+        if ($delimiter == ';') {
 // 			$regexpDelimiter = '[.semicolon.]';
 // Leads to MYSQL ERROR:
 // Got error 'POSIX collating elements are not supported at offset 46' from regexp
 
- 			$regexpDelimiter = ';';
-		}
-		switch ($delimiter) {
-			case ';':
+            $regexpDelimiter = ';';
+        }
+        switch ($delimiter) {
+            case ';':
 // 				$regexpDelimiter = '[.semicolon.]';
 // Leads to MYSQL ERROR:
 // Got error 'POSIX collating elements are not supported at offset 46' from regexp
-				break;
-			case '\n':
-				$regexpDelimiter = '[\n]';
-				break;
-		}
+                break;
+            case '\n':
+                $regexpDelimiter = '[\n]';
+                break;
+        }
 
-		return $regexpDelimiter;
-	}
-
-
-	static public function getBasketIntoIdPrefix () {
-		return self::$basketIntoIdPrefix;
-	}
+        return $regexpDelimiter;
+    }
 
 
-	static public function getBasketInputErrorIdPrefix () {
-		return self::$basketInputErrorIdPrefix;
-	}
+    static public function getBasketIntoIdPrefix () {
+        return self::$basketIntoIdPrefix;
+    }
+
+
+    static public function getBasketInputErrorIdPrefix () {
+        return self::$basketInputErrorIdPrefix;
+    }
 
     /**
      * If internal TypoScript property "_DEFAULT_PI_VARS." is set then it will merge the current $this->piVars array onto these default values.
@@ -129,534 +129,534 @@ class tx_ttproducts_model_control {
         return self::$piVarsDefault;
     }
 
-	static public function setPrefixId ($prefixId) {
-		self::$prefixId = $prefixId;
-	}
+    static public function setPrefixId ($prefixId) {
+        self::$prefixId = $prefixId;
+    }
 
 
-	static public function getPrefixId () {
-		return self::$prefixId;
-	}
+    static public function getPrefixId () {
+        return self::$prefixId;
+    }
 
     static public function setPiVars ($value) {
         self::$piVars = $value;
     }
 
-	/* if a default value is set then it will merge the current self::$piVars array onto these default values. */
-	static public function getPiVars () {
-		$result = self::$piVars;
-		return $result;
-	}
+    /* if a default value is set then it will merge the current self::$piVars array onto these default values. */
+    static public function getPiVars () {
+        $result = self::$piVars;
+        return $result;
+    }
 
 
-	static public function getPiVar ($functablename) {
-		$paramsTableArray = self::getParamsTableArray();
-		$result = array_search($functablename, $paramsTableArray);
-		return $result;
-	}
+    static public function getPiVar ($functablename) {
+        $paramsTableArray = self::getParamsTableArray();
+        $result = array_search($functablename, $paramsTableArray);
+        return $result;
+    }
 
 
-	static public function setAndVar ($k, $v) {
-		if (isset(self::$andVars[$k])) {
-			self::$andVars[$k] .= ',' . $v;
-		} else {
-			self::$andVars[$k] = $v;
-		}
-	}
+    static public function setAndVar ($k, $v) {
+        if (isset(self::$andVars[$k])) {
+            self::$andVars[$k] .= ',' . $v;
+        } else {
+            self::$andVars[$k] = $v;
+        }
+    }
 
 
-	static public function getAndVar ($k) {
-		$result = false;
+    static public function getAndVar ($k) {
+        $result = false;
 
-		if (isset(self::$andVars[$k])) {
-			$result = self::$andVars[$k];
-		}
-		return $result;
-	}
-
-
-	static public function getPiVarValue ($functablename) {
-		$piVars = self::getPiVars();
-		$piVar = self::getPiVar($functablename);
-		$result = false;
-
-		if (
-			isset($piVars) &&
-			is_array($piVars) &&
-			isset($piVars[$piVar])
-		) {
-			$result = $piVars[$piVar];
-		}
-		return $result;
-	}
+        if (isset(self::$andVars[$k])) {
+            $result = self::$andVars[$k];
+        }
+        return $result;
+    }
 
 
-	static public function getParamsTableArray () {
-		return self::$paramsTableArray;
-	}
+    static public function getPiVarValue ($functablename) {
+        $piVars = self::getPiVars();
+        $piVar = self::getPiVar($functablename);
+        $result = false;
+
+        if (
+            isset($piVars) &&
+            is_array($piVars) &&
+            isset($piVars[$piVar])
+        ) {
+            $result = $piVars[$piVar];
+        }
+        return $result;
+    }
 
 
-	static public function getParamsTable ($piVar) {
-		$result = false;
-
-		if (isset(self::$paramsTableArray[$piVar])) {
-			$result = self::$paramsTableArray[$piVar];
-		}
-		return $result;
-	}
+    static public function getParamsTableArray () {
+        return self::$paramsTableArray;
+    }
 
 
-	static public function getPointerPiVar ($theCode) {
-		$pointerParamsTableArray = self::getPointerParamsCodeArray();
-		$rc = array_search($theCode,$pointerParamsTableArray);
-		return $rc;
-	}
+    static public function getParamsTable ($piVar) {
+        $result = false;
+
+        if (isset(self::$paramsTableArray[$piVar])) {
+            $result = self::$paramsTableArray[$piVar];
+        }
+        return $result;
+    }
 
 
-	static public function getPointerParamsCodeArray () {
-		return self::$pointerParamsCodeArray;
-	}
+    static public function getPointerPiVar ($theCode) {
+        $pointerParamsTableArray = self::getPointerParamsCodeArray();
+        $rc = array_search($theCode,$pointerParamsTableArray);
+        return $rc;
+    }
 
 
-	static public function getBasketVar () {
-		return self::$basketVar;
-	}
+    static public function getPointerParamsCodeArray () {
+        return self::$pointerParamsCodeArray;
+    }
 
 
-	static public function getBasketParamVar () {
-		return self::$basketParamVar;
-	}
+    static public function getBasketVar () {
+        return self::$basketVar;
+    }
 
 
-	static public function getSearchboxVar () {
-		return self::$searchboxVar;
-	}
+    static public function getBasketParamVar () {
+        return self::$basketParamVar;
+    }
 
 
-	static public function getControlVar () {
-		return self::$controlVar;
-	}
+    static public function getSearchboxVar () {
+        return self::$searchboxVar;
+    }
 
 
-	static public function getOrderViewVar () {
-		return self::$orderViewVar;
-	}
+    static public function getControlVar () {
+        return self::$controlVar;
+    }
 
 
-	static public function getControlArray () {
-		$piVars = self::getPiVars();
-
-		$allValueArray = [];
-		$resultArray = [];
-		$controlVar = self::getControlVar();
-
-		if (isset($piVars[$controlVar]) && is_array($piVars[$controlVar])) {
-			$resultArray = $piVars[$controlVar];
-		}
-
-		return $resultArray;
-	}
+    static public function getOrderViewVar () {
+        return self::$orderViewVar;
+    }
 
 
-	static public function getTableConfArrays (
-		$cObj,
-		array $functableArray,
-		$theCode,
-		array &$tableConfArray,
-		array &$viewConfArray
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+    static public function getControlArray () {
+        $piVars = self::getPiVars();
 
-		foreach ($functableArray as $ft) {
-			if ($ft != '') {
-				$tableObj = $tablesObj->get($ft, 0);
-				if (is_object($tableObj)) {
-					$tableConfArray[$ft] = $tableObj->getTableConf($theCode);
-					if (isset($tableConfArray[$ft]['view.'])) {
-						$viewConfArray[$ft] = $tableConfArray[$ft]['view.'];
-					}
-				}
-			}
-		}
+        $allValueArray = [];
+        $resultArray = [];
+        $controlVar = self::getControlVar();
 
-		if (isset($viewConfArray) && is_array($viewConfArray)) {
+        if (isset($piVars[$controlVar]) && is_array($piVars[$controlVar])) {
+            $resultArray = $piVars[$controlVar];
+        }
 
-			$controlArray = self::getControlArray();
-			$typeArray = ['sortSelect', 'filterSelect', 'filterInput'];
-			$typeSelectArray = ['sortSelect', 'filterSelect'];
+        return $resultArray;
+    }
 
-			foreach ($viewConfArray as $ftname => $funcViewConfArray) {
 
-				foreach ($typeArray as $type) {
-					if (isset($controlArray[$type]) && is_array($controlArray[$type])) {
-						if (in_array($type, $typeSelectArray)) {
-							$fitArray = [];
-							foreach ($controlArray[$type] as $k => $v) {
+    static public function getTableConfArrays (
+        $cObj,
+        array $functableArray,
+        $theCode,
+        array &$tableConfArray,
+        array &$viewConfArray
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-								if ($v != '') {
-									$valueArray = $funcViewConfArray[$type . '.'][$k . '.']['valueArray.'];
-									$bFitValueArray = [];
-									foreach ($valueArray as $valueConf) {
-										if (
+        foreach ($functableArray as $ft) {
+            if ($ft != '') {
+                $tableObj = $tablesObj->get($ft, 0);
+                if (is_object($tableObj)) {
+                    $tableConfArray[$ft] = $tableObj->getTableConf($theCode);
+                    if (isset($tableConfArray[$ft]['view.'])) {
+                        $viewConfArray[$ft] = $tableConfArray[$ft]['view.'];
+                    }
+                }
+            }
+        }
+
+        if (isset($viewConfArray) && is_array($viewConfArray)) {
+
+            $controlArray = self::getControlArray();
+            $typeArray = ['sortSelect', 'filterSelect', 'filterInput'];
+            $typeSelectArray = ['sortSelect', 'filterSelect'];
+
+            foreach ($viewConfArray as $ftname => $funcViewConfArray) {
+
+                foreach ($typeArray as $type) {
+                    if (isset($controlArray[$type]) && is_array($controlArray[$type])) {
+                        if (in_array($type, $typeSelectArray)) {
+                            $fitArray = [];
+                            foreach ($controlArray[$type] as $k => $v) {
+
+                                if ($v != '') {
+                                    $valueArray = $funcViewConfArray[$type . '.'][$k . '.']['valueArray.'];
+                                    $bFitValueArray = [];
+                                    foreach ($valueArray as $valueConf) {
+                                        if (
                                             isset($valueConf['field']) &&
                                             $valueConf['value'] == $v &&
                                             !$bFitValueArray[$v]
                                         ) {
-											$fitArray[] = [
-												'delimiter' => $valueConf['delimiter'],
-												'field' => $valueConf['field'],
-												'key' => $valueConf['key'],
-												'key.' => $valueConf['key.'],
-											];
-											$bFitValueArray[$v] = true;
-										}
-									}
-								}
-							}
+                                            $fitArray[] = [
+                                                'delimiter' => $valueConf['delimiter'],
+                                                'field' => $valueConf['field'],
+                                                'key' => $valueConf['key'],
+                                                'key.' => $valueConf['key.'],
+                                            ];
+                                            $bFitValueArray[$v] = true;
+                                        }
+                                    }
+                                }
+                            }
 
-							switch ($type) {
-								case 'sortSelect':
-									if (is_array($fitArray) && count($fitArray)) {
-										$fieldArray = [];
-										foreach ($fitArray as $fitRow) {
-											$fieldArray[] = $fitRow['field'];
-										}
-										$tableConfArray[$ftname]['orderBy'] = implode(',', $fieldArray);
-									}
-								break;
-								case 'filterSelect':
-									foreach ($fitArray as $fitRow) {
-										$field = $fitRow['field'];
-										if ($field != '' && isset($fitRow['key'])) {
-											if (isset($tableConfArray[$ftname]['filter.']['where.']['field.'][$field])) {
-												$preFilter = '(' . $tableConfArray[$ftname]['filter.']['where.']['field.'][$field] . ') AND (';
-											} else {
-												$preFilter = '';
-											}
+                            switch ($type) {
+                                case 'sortSelect':
+                                    if (is_array($fitArray) && count($fitArray)) {
+                                        $fieldArray = [];
+                                        foreach ($fitArray as $fitRow) {
+                                            $fieldArray[] = $fitRow['field'];
+                                        }
+                                        $tableConfArray[$ftname]['orderBy'] = implode(',', $fieldArray);
+                                    }
+                                break;
+                                case 'filterSelect':
+                                    foreach ($fitArray as $fitRow) {
+                                        $field = $fitRow['field'];
+                                        if ($field != '' && isset($fitRow['key'])) {
+                                            if (isset($tableConfArray[$ftname]['filter.']['where.']['field.'][$field])) {
+                                                $preFilter = '(' . $tableConfArray[$ftname]['filter.']['where.']['field.'][$field] . ') AND (';
+                                            } else {
+                                                $preFilter = '';
+                                            }
 
-											if (isset($fitRow['key.'])) {
-												$key = $cObj->stdWrap($fitRow['key'],$fitRow['key.']);
-											} else {
-												$key = $fitRow['key'];
-											}
+                                            if (isset($fitRow['key.'])) {
+                                                $key = $cObj->stdWrap($fitRow['key'],$fitRow['key.']);
+                                            } else {
+                                                $key = $fitRow['key'];
+                                            }
 
-											$tableConfArray[$ftname]['filter.']['where.']['field.'][$field] = $preFilter . $key . ($preFilter != '' ? ')' : '');
+                                            $tableConfArray[$ftname]['filter.']['where.']['field.'][$field] = $preFilter . $key . ($preFilter != '' ? ')' : '');
 
-											if (!empty($fitRow['delimiter'])) {
-												$tableConfArray[$ftname]['filter.']['delimiter.']['field.'][$field] = $fitRow['delimiter'];
-											}
-										}
-									}
-								break;
-							}
-						} else if ($type == 'filterInput') {
-							foreach ($controlArray[$type] as $k => $v) {
-								if ($v != '') {
-									$fitRow = $funcViewConfArray[$type . '.'][$k . '.'];
-									$field = $fitRow['field'];
-									$tableConfArray[$ftname]['filter.']['where.']['field.'][$field] = $v;
-									if (!empty($fitRow['delimiter'])) {
-										$tableConfArray[$ftname]['filter.']['delimiter.']['field.'][$field] = $fitRow['delimiter'];
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-
-	static public function getTableVars (
-		$searchFunctablename,
-		&$searchTablename,
-		&$searchAlias,
-		&$tableAliasArray,
-		&$bUseSearchboxArray,
-		&$enableFieldArray
-	) {
-		if ($searchFunctablename != '') {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-
-			$tableObj = $tablesObj->get($searchFunctablename, false);
-			$searchTablename = $tableObj->getTablename();
-			$searchAlias = $tableObj->getAlias();
-
-			if ($searchTablename != '' && $searchAlias != '') {
-				$tableAliasArray[$searchTablename] = $searchAlias;
-				$bUseSearchboxArray[$searchFunctablename] = true;
-			}
-			$enableFieldArray = $tableObj->getTableObj()->getEnableFieldArray();
-		}
-	}
+                                            if (!empty($fitRow['delimiter'])) {
+                                                $tableConfArray[$ftname]['filter.']['delimiter.']['field.'][$field] = $fitRow['delimiter'];
+                                            }
+                                        }
+                                    }
+                                break;
+                            }
+                        } else if ($type == 'filterInput') {
+                            foreach ($controlArray[$type] as $k => $v) {
+                                if ($v != '') {
+                                    $fitRow = $funcViewConfArray[$type . '.'][$k . '.'];
+                                    $field = $fitRow['field'];
+                                    $tableConfArray[$ftname]['filter.']['where.']['field.'][$field] = $v;
+                                    if (!empty($fitRow['delimiter'])) {
+                                        $tableConfArray[$ftname]['filter.']['delimiter.']['field.'][$field] = $fitRow['delimiter'];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
 
-	static public function getWhereByFields (
-		$tablename,
-		$alias,
-		$aliasPostfix,
-		$fields,
-		$sword,
-		$delimiter
-	) {
-		$rc = false;
-		$fieldArray = GeneralUtility::trimExplode(',', $fields);
-		if (isset($fieldArray) && is_array($fieldArray)) {
-			$rcArray = [];
-			$regexpDelimiter = self::determineRegExpDelimiter($delimiter);
+    static public function getTableVars (
+        $searchFunctablename,
+        &$searchTablename,
+        &$searchAlias,
+        &$tableAliasArray,
+        &$bUseSearchboxArray,
+        &$enableFieldArray
+    ) {
+        if ($searchFunctablename != '') {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-			foreach ($fieldArray as $field) {
-				$rcArray[] =
-					$alias . $aliasPostfix . '.' . $field . ' REGEXP ' .
-						$GLOBALS['TYPO3_DB']->fullQuoteStr(
-							'^([[:print:]]*[' . $regexpDelimiter . '])*' . '(' . $sword . ')([[:print:]]*[[:blank:]]*)*([' . $regexpDelimiter . '][[:print:]]*)*$', $tablename
-						);
-			}
-			$rc = implode(' OR ', $rcArray);
-		}
-		return $rc;
-	}
+            $tableObj = $tablesObj->get($searchFunctablename, false);
+            $searchTablename = $tableObj->getTablename();
+            $searchAlias = $tableObj->getAlias();
+
+            if ($searchTablename != '' && $searchAlias != '') {
+                $tableAliasArray[$searchTablename] = $searchAlias;
+                $bUseSearchboxArray[$searchFunctablename] = true;
+            }
+            $enableFieldArray = $tableObj->getTableObj()->getEnableFieldArray();
+        }
+    }
 
 
-	static public function getSearchInfo (
-		$cObj,
-		array $searchVars,
-		$functablename,
-		$tablename,
-		&$searchboxWhere,
-		&$bUseSearchboxArray,
-		&$sqlTableArray,
-		&$sqlTableIndex,
-		&$latest
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    static public function getWhereByFields (
+        $tablename,
+        $alias,
+        $aliasPostfix,
+        $fields,
+        $sword,
+        $delimiter
+    ) {
+        $rc = false;
+        $fieldArray = GeneralUtility::trimExplode(',', $fields);
+        if (isset($fieldArray) && is_array($fieldArray)) {
+            $rcArray = [];
+            $regexpDelimiter = self::determineRegExpDelimiter($delimiter);
 
-		$paramsTableArray = self::getParamsTableArray();
-		$searchParamArray = [];
-		$searchFieldArray = [];
-		$tableAliasArray = [];
-		$enableFieldArray = [];
-		if (isset($searchVars['latest'])) {
-			$latest = $searchVars['latest'];
-		}
+            foreach ($fieldArray as $field) {
+                $rcArray[] =
+                    $alias . $aliasPostfix . '.' . $field . ' REGEXP ' .
+                        $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                            '^([[:print:]]*[' . $regexpDelimiter . '])*' . '(' . $sword . ')([[:print:]]*[[:blank:]]*)*([' . $regexpDelimiter . '][[:print:]]*)*$', $tablename
+                        );
+            }
+            $rc = implode(' OR ', $rcArray);
+        }
+        return $rc;
+    }
 
-		$aliasPostfix = '';
-		if ($sqlTableIndex) {
-			$aliasPostfix = ($sqlTableIndex + 1);
-		}
 
-		if (isset($searchVars['uid'])) {
-			$contentObj = $tablesObj->get('tt_content',false);
-			$contentRow = $contentObj->get($searchVars['uid']);
+    static public function getSearchInfo (
+        $cObj,
+        array $searchVars,
+        $functablename,
+        $tablename,
+        &$searchboxWhere,
+        &$bUseSearchboxArray,
+        &$sqlTableArray,
+        &$sqlTableIndex,
+        &$latest
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			if(
+        $paramsTableArray = self::getParamsTableArray();
+        $searchParamArray = [];
+        $searchFieldArray = [];
+        $tableAliasArray = [];
+        $enableFieldArray = [];
+        if (isset($searchVars['latest'])) {
+            $latest = $searchVars['latest'];
+        }
+
+        $aliasPostfix = '';
+        if ($sqlTableIndex) {
+            $aliasPostfix = ($sqlTableIndex + 1);
+        }
+
+        if (isset($searchVars['uid'])) {
+            $contentObj = $tablesObj->get('tt_content',false);
+            $contentRow = $contentObj->get($searchVars['uid']);
+
+            if(
                 isset($contentRow['pi_flexform']) &&
                 $contentRow['pi_flexform'] != ''
             ) {
-				$contentRow['pi_flexform'] = GeneralUtility::xml2array($contentRow['pi_flexform']);
-				$searchObj = GeneralUtility::makeInstance('tx_ttproducts_control_search');	// fetch and store it as persistent object
-				$controlConfig = $searchObj->getControlConfig($cObj, $cnf->conf, $contentRow);
+                $contentRow['pi_flexform'] = GeneralUtility::xml2array($contentRow['pi_flexform']);
+                $searchObj = GeneralUtility::makeInstance('tx_ttproducts_control_search');	// fetch and store it as persistent object
+                $controlConfig = $searchObj->getControlConfig($cObj, $cnf->conf, $contentRow);
 
-				self::getTableVars(
-					$controlConfig['local_table'],
-					$searchTablename,
-					$searchAlias,
-					$tableAliasArray,
-					$bUseSearchboxArray,
-					$enableFieldArray
-				);
+                self::getTableVars(
+                    $controlConfig['local_table'],
+                    $searchTablename,
+                    $searchAlias,
+                    $tableAliasArray,
+                    $bUseSearchboxArray,
+                    $enableFieldArray
+                );
 
-				$delimiter = '';
-				$searchboxWhere =
-					self::getWhereByFields(
-						$searchTablename,
-						$searchAlias,
-						$aliasPostfix,
-						$controlConfig['fields'],
-						$searchVars['sword'],
-						$delimiter
-					);
-			}
-		}
+                $delimiter = '';
+                $searchboxWhere =
+                    self::getWhereByFields(
+                        $searchTablename,
+                        $searchAlias,
+                        $aliasPostfix,
+                        $controlConfig['fields'],
+                        $searchVars['sword'],
+                        $delimiter
+                    );
+            }
+        }
 
         $tmpArray = [];
-		$tmpArray[0] = (
+        $tmpArray[0] = (
                 is_array($searchVars['local']) ? 
                 key($searchVars['local']) : 
                 $searchVars['local']
             );
-		if (is_array($searchVars['local'])) {
-			$tmpArray[0] = key($searchVars['local']);
-			$localParam = current($searchVars['local']);
-			if (is_array($localParam)) {
-				$tmpArray[1] = key($localParam);
-			} else {
-				$tmpArray[1] = $localParam;
-			}
-		} else {
-			$tmpArray[0] = $searchVars['local'];
-		}
-		$searchParamArray['local'] = $tmpArray[0];
-		$searchParamArray['foreign'] = $searchVars['foreign'];
-		$searchFieldArray['local'] = $tmpArray[1];
-		$searchFieldArray['foreign'] = '';
+        if (is_array($searchVars['local'])) {
+            $tmpArray[0] = key($searchVars['local']);
+            $localParam = current($searchVars['local']);
+            if (is_array($localParam)) {
+                $tmpArray[1] = key($localParam);
+            } else {
+                $tmpArray[1] = $localParam;
+            }
+        } else {
+            $tmpArray[0] = $searchVars['local'];
+        }
+        $searchParamArray['local'] = $tmpArray[0];
+        $searchParamArray['foreign'] = $searchVars['foreign'];
+        $searchFieldArray['local'] = $tmpArray[1];
+        $searchFieldArray['foreign'] = '';
 
-		if (self::getPiVar($functablename) == $searchParamArray['local']) {
-			$sqlTableArray['from'] = [];
-			$sqlTableArray['join'] = [];
-			$sqlTableArray['local'] = [];
-			$sqlTableArray['where'] = [];
+        if (self::getPiVar($functablename) == $searchParamArray['local']) {
+            $sqlTableArray['from'] = [];
+            $sqlTableArray['join'] = [];
+            $sqlTableArray['local'] = [];
+            $sqlTableArray['where'] = [];
 
-			$loopArray = ['local', 'foreign'];
-			$bUseSearchboxCat = false;
-			$theTable = $cnf->getTableName($paramsTableArray[$searchParamArray['local']]);
+            $loopArray = ['local', 'foreign'];
+            $bUseSearchboxCat = false;
+            $theTable = $cnf->getTableName($paramsTableArray[$searchParamArray['local']]);
 
-			foreach ($loopArray as $position) {
-				$positionSearchVars = [];
-				$foundKey = 0;
+            foreach ($loopArray as $position) {
+                $positionSearchVars = [];
+                $foundKey = 0;
 
-				if ($position == 'local' && isset($keyFieldArray[$searchFieldArray['local']]) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('searchbox')) {	// Todo
+                if ($position == 'local' && isset($keyFieldArray[$searchFieldArray['local']]) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('searchbox')) {	// Todo
 
-					GeneralUtility::requireOnce(PATH_BE_searchbox . 'model/class.tx_searchbox_model.php');
-					$modelObj = GeneralUtility::makeInstance('tx_searchbox_model');
+                    GeneralUtility::requireOnce(PATH_BE_searchbox . 'model/class.tx_searchbox_model.php');
+                    $modelObj = GeneralUtility::makeInstance('tx_searchbox_model');
 
-					$fullKeyFieldArray = $modelObj->getKeyFieldArray($tablename, '', '-', $searchFieldArray['local'], '1', $tmpCount);
-				} else if (isset($fullKeyFieldArray)) {
-					unset($fullKeyFieldArray);
-				}
+                    $fullKeyFieldArray = $modelObj->getKeyFieldArray($tablename, '', '-', $searchFieldArray['local'], '1', $tmpCount);
+                } else if (isset($fullKeyFieldArray)) {
+                    unset($fullKeyFieldArray);
+                }
 
-				foreach ($searchVars as $k => $v) {
-					$searchKey = $k;
-					$searchValue = $v;
-					if (is_array($v)) {
-						$tmpK = key($v);
-						$tmpArray = current($v);
-						$searchKey .= '|' . $tmpK;
-						if (is_array($tmpArray)) {
-							$tmpK = key($tmpArray);
-							$tmpArray = current($tmpArray);
-							$searchKey .= '|' . $tmpK;
-						}
-						$searchValue = $tmpArray;
-					}
+                foreach ($searchVars as $k => $v) {
+                    $searchKey = $k;
+                    $searchValue = $v;
+                    if (is_array($v)) {
+                        $tmpK = key($v);
+                        $tmpArray = current($v);
+                        $searchKey .= '|' . $tmpK;
+                        if (is_array($tmpArray)) {
+                            $tmpK = key($tmpArray);
+                            $tmpArray = current($tmpArray);
+                            $searchKey .= '|' . $tmpK;
+                        }
+                        $searchValue = $tmpArray;
+                    }
 
-					if ($searchKey == $positionSearchVars[$position] || (is_array($searchParamArray[$position]) && key($searchParamArray[$position]) == $k || !is_array($searchParamArray[$position]) && $searchParamArray[$position] == $k)) {
+                    if ($searchKey == $positionSearchVars[$position] || (is_array($searchParamArray[$position]) && key($searchParamArray[$position]) == $k || !is_array($searchParamArray[$position]) && $searchParamArray[$position] == $k)) {
 
                         if (substr($searchValue, 0, 1) == '\'' && substr($searchValue, -1) == '\'') {
-							$searchValue = substr($searchValue,1,strlen($searchValue)-2);
-						}
-						if (isset($fullKeyFieldArray) && is_array($fullKeyFieldArray)) {
-							$tmpArray = GeneralUtility::trimExplode('|',$searchKey);
+                            $searchValue = substr($searchValue,1,strlen($searchValue)-2);
+                        }
+                        if (isset($fullKeyFieldArray) && is_array($fullKeyFieldArray)) {
+                            $tmpArray = GeneralUtility::trimExplode('|',$searchKey);
 
-							if ($tmpArray[1] == $searchFieldArray[$position] && isset($fullKeyFieldArray[$searchValue])) {
-								$searchValue = $fullKeyFieldArray[$searchValue];
-							}
-						}
-						$positionSearchVars[$searchKey] = $searchValue;
-						if (!$foundKey) {
-							$foundKey = $k;
-						}
-					}
-				}
+                            if ($tmpArray[1] == $searchFieldArray[$position] && isset($fullKeyFieldArray[$searchValue])) {
+                                $searchValue = $fullKeyFieldArray[$searchValue];
+                            }
+                        }
+                        $positionSearchVars[$searchKey] = $searchValue;
+                        if (!$foundKey) {
+                            $foundKey = $k;
+                        }
+                    }
+                }
 
-				if (isset($searchVars[$position]) && isset($positionSearchVars) && is_array($positionSearchVars) && count($positionSearchVars) && $searchVars[$foundKey] != 'all') {
+                if (isset($searchVars[$position]) && isset($positionSearchVars) && is_array($positionSearchVars) && count($positionSearchVars) && $searchVars[$foundKey] != 'all') {
 
-					$positionSearchKey = key($positionSearchVars);
-					$positionSearchValue = current($positionSearchVars);
- 					$partArray = GeneralUtility::trimExplode('|',$positionSearchKey);
- 					$delimiter = ($partArray[2] ? $partArray[2] : '');
-					$searchTablename = '';
-					$searchParam = $partArray[0];
-					$searchField = $partArray[1];
-					self::getTableVars(
-						$paramsTableArray[$searchParam],
-						$searchTablename,
-						$searchAlias,
-						$tableAliasArray,
-						$bUseSearchboxArray,
-						$enableFieldArray
-					);
+                    $positionSearchKey = key($positionSearchVars);
+                    $positionSearchValue = current($positionSearchVars);
+                    $partArray = GeneralUtility::trimExplode('|',$positionSearchKey);
+                    $delimiter = ($partArray[2] ? $partArray[2] : '');
+                    $searchTablename = '';
+                    $searchParam = $partArray[0];
+                    $searchField = $partArray[1];
+                    self::getTableVars(
+                        $paramsTableArray[$searchParam],
+                        $searchTablename,
+                        $searchAlias,
+                        $tableAliasArray,
+                        $bUseSearchboxArray,
+                        $enableFieldArray
+                    );
 
-					if ($searchTablename != '') {
+                    if ($searchTablename != '') {
 
-						$field = ($searchField!='' && isset($GLOBALS['TCA'][$searchTablename]['columns'][$searchField]) ? $searchField : 'title');
-						$configArray = $GLOBALS['TCA'][$searchTablename]['columns'][$field]['config'];
+                        $field = ($searchField!='' && isset($GLOBALS['TCA'][$searchTablename]['columns'][$searchField]) ? $searchField : 'title');
+                        $configArray = $GLOBALS['TCA'][$searchTablename]['columns'][$field]['config'];
 
-						if (isset($configArray) && is_array($configArray) || in_array($field,$enableFieldArray)) {
-							if ($configArray['eval'] == 'date') {
-								$searchboxWhere = 'YEAR(' . $searchAlias . $aliasPostfix . '.' . $field . ')=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($positionSearchValue, $searchTablename);
-							} else {
-								if ($delimiter != '') {
-									if ($searchVars['query'] == 'IN') {
-										$valueArray = [];
-										$tmpParamArray = GeneralUtility::trimExplode(',',$positionSearchValue);
-										foreach ($tmpParamArray as $param => $v) {
-											if ($v != '') {
-												$valueArray[] = $GLOBALS['TYPO3_DB']->fullQuoteStr($v, $searchTablename);;
-											}
-										}
-										$searchboxWhereArray=[];
-										foreach ($valueArray as $v) {
-											$searchboxWhereArray[] = $searchAlias.$aliasPostfix . '.' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr('.*[' . $delimiter . ']*' . $positionSearchValue . '[' . $delimiter . ']*.*', $searchTablename);
-										}
-										$searchboxWhere = implode(' OR ', $searchboxWhereArray);
-										// TODO
-									} else {
-										$searchboxWhere =
-											self::getWhereByFields(
-												$searchTablename,
-												$searchAlias,
-												$aliasPostfix,
-												$field,
-												$positionSearchValue,
-												$delimiter
-											);
-									}
-								} else {
-									if ($searchVars['query'] == 'IN') {
-										$valueArray = [];
-										$tmpParamArray = GeneralUtility::trimExplode(',',$positionSearchValue);
-										foreach ($tmpParamArray as $param => $v) {
-											if ($v != '') {
-												$valueArray[] = $v;
-											}
-										}
-										$searchboxWhereArray=[];
-										foreach ($valueArray as $v) {
-											$searchboxWhereArray[] = $searchAlias.$aliasPostfix . '.' . $field . ' LIKE ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($v . '%', $searchTablename);
-										}
-										$searchboxWhere = '(' . implode(' OR ' ,$searchboxWhereArray) . ')';
-									} else {
-										$searchboxWhere = $searchAlias . $aliasPostfix . '.' . $field . ' LIKE ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($positionSearchValue . '%', $searchTablename);
-									}
-								}
-							}
-							$newSqlTableArray = [];
-							if ($position == 'foreign') {
-								$foreignTableInfo = $tablesObj->getForeignTableInfo($theTable,$searchFieldArray['local']);
-								$foreignTableInfo['table_field'] = $searchFieldArray['local'];
-								$tablesObj->prepareSQL($foreignTableInfo,$tableAliasArray,$aliasPostfix,$newSqlTableArray);
-							}
-							$sqlTableArray[$position][$sqlTableIndex] = $cnf->getTableName($paramsTableArray[$searchParam]);
-							if (!empty($foreignTableInfo['where'])) {
-								$sqlTableArray['where'][$sqlTableIndex] = $foreignTableInfo['where'];
-							}
-							if (isset($newSqlTableArray) && is_array($newSqlTableArray)) {
-								foreach ($sqlTableArray as $k => $tmpArray) {
-									if (isset($newSqlTableArray[$k])) {
-										$sqlTableArray[$k][$sqlTableIndex] = $newSqlTableArray[$k];
-									}
-								}
-							}
-							$sqlTableIndex++;
-						}
-					}
-				}
-			}
-		}
-	}
+                        if (isset($configArray) && is_array($configArray) || in_array($field,$enableFieldArray)) {
+                            if ($configArray['eval'] == 'date') {
+                                $searchboxWhere = 'YEAR(' . $searchAlias . $aliasPostfix . '.' . $field . ')=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($positionSearchValue, $searchTablename);
+                            } else {
+                                if ($delimiter != '') {
+                                    if ($searchVars['query'] == 'IN') {
+                                        $valueArray = [];
+                                        $tmpParamArray = GeneralUtility::trimExplode(',',$positionSearchValue);
+                                        foreach ($tmpParamArray as $param => $v) {
+                                            if ($v != '') {
+                                                $valueArray[] = $GLOBALS['TYPO3_DB']->fullQuoteStr($v, $searchTablename);;
+                                            }
+                                        }
+                                        $searchboxWhereArray=[];
+                                        foreach ($valueArray as $v) {
+                                            $searchboxWhereArray[] = $searchAlias.$aliasPostfix . '.' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr('.*[' . $delimiter . ']*' . $positionSearchValue . '[' . $delimiter . ']*.*', $searchTablename);
+                                        }
+                                        $searchboxWhere = implode(' OR ', $searchboxWhereArray);
+                                        // TODO
+                                    } else {
+                                        $searchboxWhere =
+                                            self::getWhereByFields(
+                                                $searchTablename,
+                                                $searchAlias,
+                                                $aliasPostfix,
+                                                $field,
+                                                $positionSearchValue,
+                                                $delimiter
+                                            );
+                                    }
+                                } else {
+                                    if ($searchVars['query'] == 'IN') {
+                                        $valueArray = [];
+                                        $tmpParamArray = GeneralUtility::trimExplode(',',$positionSearchValue);
+                                        foreach ($tmpParamArray as $param => $v) {
+                                            if ($v != '') {
+                                                $valueArray[] = $v;
+                                            }
+                                        }
+                                        $searchboxWhereArray=[];
+                                        foreach ($valueArray as $v) {
+                                            $searchboxWhereArray[] = $searchAlias.$aliasPostfix . '.' . $field . ' LIKE ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($v . '%', $searchTablename);
+                                        }
+                                        $searchboxWhere = '(' . implode(' OR ' ,$searchboxWhereArray) . ')';
+                                    } else {
+                                        $searchboxWhere = $searchAlias . $aliasPostfix . '.' . $field . ' LIKE ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($positionSearchValue . '%', $searchTablename);
+                                    }
+                                }
+                            }
+                            $newSqlTableArray = [];
+                            if ($position == 'foreign') {
+                                $foreignTableInfo = $tablesObj->getForeignTableInfo($theTable,$searchFieldArray['local']);
+                                $foreignTableInfo['table_field'] = $searchFieldArray['local'];
+                                $tablesObj->prepareSQL($foreignTableInfo,$tableAliasArray,$aliasPostfix,$newSqlTableArray);
+                            }
+                            $sqlTableArray[$position][$sqlTableIndex] = $cnf->getTableName($paramsTableArray[$searchParam]);
+                            if (!empty($foreignTableInfo['where'])) {
+                                $sqlTableArray['where'][$sqlTableIndex] = $foreignTableInfo['where'];
+                            }
+                            if (isset($newSqlTableArray) && is_array($newSqlTableArray)) {
+                                foreach ($sqlTableArray as $k => $tmpArray) {
+                                    if (isset($newSqlTableArray[$k])) {
+                                        $sqlTableArray[$k][$sqlTableIndex] = $newSqlTableArray[$k];
+                                    }
+                                }
+                            }
+                            $sqlTableIndex++;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 

--- a/model/class.tx_ttproducts_model_creator.php
+++ b/model/class.tx_ttproducts_model_creator.php
@@ -43,7 +43,7 @@ use JambageCom\Div2007\Utility\ExtensionUtility;
 
 class tx_ttproducts_model_creator implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function init ($conf, $config, $cObj) {
+    public function init ($conf, $config, $cObj) {
 
         $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
          if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
@@ -53,66 +53,66 @@ class tx_ttproducts_model_creator implements \TYPO3\CMS\Core\SingletonInterface 
         }
 
         $useStaticInfoTables = $staticInfoApi->isActive();
-		$bUseStaticTaxes = false;
+        $bUseStaticTaxes = false;
 
-		if (
-			!empty($conf['useStaticTaxes']) &&
-			$useStaticInfoTables
-		) {
-			if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')) {
-				$eInfo2 = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
+        if (
+            !empty($conf['useStaticTaxes']) &&
+            $useStaticInfoTables
+        ) {
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')) {
+                $eInfo2 = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
 
-				if (is_array($eInfo2)) {
-					$sittVersion = $eInfo2['version'];
-					if (version_compare($sittVersion, '0.3.0', '>=')) {
-						$bUseStaticTaxes = true;
-					}
-				}
-			}
-		}
+                if (is_array($eInfo2)) {
+                    $sittVersion = $eInfo2['version'];
+                    if (version_compare($sittVersion, '0.3.0', '>=')) {
+                        $bUseStaticTaxes = true;
+                    }
+                }
+            }
+        }
 
-		$UIDstore = 0;
+        $UIDstore = 0;
 
-		if (isset($conf['UIDstore'])) {
-			$tmpArray = GeneralUtility::trimExplode(',', $conf['UIDstore']);
-			$UIDstore = intval($tmpArray['0']);
-			if ($UIDstore) {
-				$where_clause = 'uid = ' . $UIDstore . \JambageCom\Div2007\Utility\TableUtility::enableFields('fe_users');
-				$storeRecord =
-					$GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow(
-						'*',
-						'fe_users',
-						$where_clause
-					);
-				if ($storeRecord) {
-					\JambageCom\TtProducts\Api\PaymentApi::setStoreRecord($storeRecord);
-				}
-			}
-		}
-		$infoArray = tx_ttproducts_control_basket::getInfoArray();
+        if (isset($conf['UIDstore'])) {
+            $tmpArray = GeneralUtility::trimExplode(',', $conf['UIDstore']);
+            $UIDstore = intval($tmpArray['0']);
+            if ($UIDstore) {
+                $where_clause = 'uid = ' . $UIDstore . \JambageCom\Div2007\Utility\TableUtility::enableFields('fe_users');
+                $storeRecord =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow(
+                        '*',
+                        'fe_users',
+                        $where_clause
+                    );
+                if ($storeRecord) {
+                    \JambageCom\TtProducts\Api\PaymentApi::setStoreRecord($storeRecord);
+                }
+            }
+        }
+        $infoArray = tx_ttproducts_control_basket::getInfoArray();
 
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$taxObj->preInit(
-			$bUseStaticTaxes,
-			$UIDstore,
-			$infoArray,
-			$conf
-		);
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $taxObj->preInit(
+            $bUseStaticTaxes,
+            $UIDstore,
+            $infoArray,
+            $conf
+        );
 
-			// price
-		$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-		$priceObj->preInit(
-			$conf
-		);
+            // price
+        $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+        $priceObj->preInit(
+            $conf
+        );
 
-			// paymentshipping
+            // paymentshipping
 // 		$paymentshippingObj = GeneralUtility::makeInstance('tx_ttproducts_paymentshipping');
 // 		$paymentshippingObj->init($priceObj);
-		$paymentPriceObj = clone $priceObj;
-		$voucher = GeneralUtility::makeInstance('tx_ttproducts_voucher');
-		\JambageCom\TtProducts\Api\PaymentShippingHandling::init($paymentPriceObj, $voucher);
+        $paymentPriceObj = clone $priceObj;
+        $voucher = GeneralUtility::makeInstance('tx_ttproducts_voucher');
+        \JambageCom\TtProducts\Api\PaymentShippingHandling::init($paymentPriceObj, $voucher);
 
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket'); // TODO: initialization
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket'); // TODO: initialization
 // 		$basketObj->init (
 // 			$pibaseClass,
 // 			$updateMode,
@@ -120,10 +120,10 @@ class tx_ttproducts_model_creator implements \TYPO3\CMS\Core\SingletonInterface 
 // 			$bStoreBasket
 // 		);
 
-		return true;
-	}
+        return true;
+    }
 
-	public function destruct () {
-	}
+    public function destruct () {
+    }
 }
 

--- a/model/class.tx_ttproducts_order.php
+++ b/model/class.tx_ttproducts_order.php
@@ -45,230 +45,230 @@ use JambageCom\TtProducts\Api\PaymentShippingHandling;
 
 class tx_ttproducts_order extends tx_ttproducts_table_base {
 
-	private $currentArray = [];
+    private $currentArray = [];
 
 
-	// **************************
-	// ORDER related functions
-	// **************************
-	/**
-	 * Create a new order record
-	 *
-	 * This creates a new order-record on the page with pid PID_sys_products_orders. That page must exist!
-	 * Should be called only internally by eg. $order->getBlankUid, that first checks if a blank record is already created.
-	 */
-	public function create () {
-		$newId = 0;
-		$pid = intval($this->conf['PID_sys_products_orders']);
-		if (!$pid) {
-			$pid = intval($GLOBALS['TSFE']->id);
-		}
+    // **************************
+    // ORDER related functions
+    // **************************
+    /**
+     * Create a new order record
+     *
+     * This creates a new order-record on the page with pid PID_sys_products_orders. That page must exist!
+     * Should be called only internally by eg. $order->getBlankUid, that first checks if a blank record is already created.
+     */
+    public function create () {
+        $newId = 0;
+        $pid = intval($this->conf['PID_sys_products_orders']);
+        if (!$pid) {
+            $pid = intval($GLOBALS['TSFE']->id);
+        }
 
-		if ($GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)) {
-			$advanceUid = 0;
+        if ($GLOBALS['TSFE']->sys_page->getPage_noCheck($pid)) {
+            $advanceUid = 0;
 
-			if (
-				$this->conf['advanceOrderNumberWithInteger'] ||
-				$this->conf['alwaysAdvanceOrderNumber']
-			) {
-				$res =
-					$GLOBALS['TYPO3_DB']->exec_SELECTquery(
-						'uid',
-						'sys_products_orders',
-						'',
-						'',
-						'uid DESC',
-						'1'
-					);
-				list($prevUid) = $GLOBALS['TYPO3_DB']->sql_fetch_row($res);
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
+            if (
+                $this->conf['advanceOrderNumberWithInteger'] ||
+                $this->conf['alwaysAdvanceOrderNumber']
+            ) {
+                $res =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                        'uid',
+                        'sys_products_orders',
+                        '',
+                        '',
+                        'uid DESC',
+                        '1'
+                    );
+                list($prevUid) = $GLOBALS['TYPO3_DB']->sql_fetch_row($res);
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
 
-				if ($this->conf['advanceOrderNumberWithInteger']) {
-					$rndParts = explode(',', $this->conf['advanceOrderNumberWithInteger']);
-					$randomValue = rand(intval($rndParts[0]), intval($rndParts[1]));
-					$advanceUid = $prevUid + MathUtility::forceIntegerInRange($randomValue, 1);
-				} else {
-					$advanceUid = $prevUid + 1;
-				}
-			}
+                if ($this->conf['advanceOrderNumberWithInteger']) {
+                    $rndParts = explode(',', $this->conf['advanceOrderNumberWithInteger']);
+                    $randomValue = rand(intval($rndParts[0]), intval($rndParts[1]));
+                    $advanceUid = $prevUid + MathUtility::forceIntegerInRange($randomValue, 1);
+                } else {
+                    $advanceUid = $prevUid + 1;
+                }
+            }
 
-			$time = time();
-			if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-				$time += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-			}
-			$insertFields = array (
-				'pid' => intval($pid),
-				'tstamp' => $time,
-				'crdate' => $time,
-				'deleted' => 0,
-				'hidden' => 1
-			);
-			if ($advanceUid > 0) {
-				$insertFields['uid'] = intval($advanceUid);
-			}
+            $time = time();
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                $time += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+            }
+            $insertFields = array (
+                'pid' => intval($pid),
+                'tstamp' => $time,
+                'crdate' => $time,
+                'deleted' => 0,
+                'hidden' => 1
+            );
+            if ($advanceUid > 0) {
+                $insertFields['uid'] = intval($advanceUid);
+            }
 
-			$GLOBALS['TYPO3_DB']->exec_INSERTquery('sys_products_orders', $insertFields);
-			$newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
+            $GLOBALS['TYPO3_DB']->exec_INSERTquery('sys_products_orders', $insertFields);
+            $newId = $GLOBALS['TYPO3_DB']->sql_insert_id();
 
-			if (
-				!$newId &&
-				(
-					get_class($GLOBALS['TYPO3_DB']->getDatabaseHandle()) == 'mysqli'
-				)
-			) {
-				$rowArray =
-					$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-						'uid',
-						'sys_products_orders',
-						'uid=LAST_INSERT_ID()',
-						''
-					);
-				if (
-					isset($rowArray) &&
-					is_array($rowArray) &&
-					isset($rowArray['0']) &&
-					is_array($rowArray['0'])
-				) {
-					$newId = $rowArray['0']['uid'];
-				}
-			}
-		}
+            if (
+                !$newId &&
+                (
+                    get_class($GLOBALS['TYPO3_DB']->getDatabaseHandle()) == 'mysqli'
+                )
+            ) {
+                $rowArray =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                        'uid',
+                        'sys_products_orders',
+                        'uid=LAST_INSERT_ID()',
+                        ''
+                    );
+                if (
+                    isset($rowArray) &&
+                    is_array($rowArray) &&
+                    isset($rowArray['0']) &&
+                    is_array($rowArray['0'])
+                ) {
+                    $newId = $rowArray['0']['uid'];
+                }
+            }
+        }
 
-		return $newId;
-	} // create
-
-
-	/**
-	 * Returns a blank order uid. If there was no order id already, a new one is created.
-	 *
-	 * Blank orders are marked hidden and with status=0 initialy. Blank orders are not necessarily finalized because users may abort instead of buying.
-	 * A finalized order is marked 'not hidden' and with status=1.
-	 * Returns this uid which is a blank order record uid.
-	 */
-	public function getBlankUid (&$orderArray) {
-
-		$res = false;
-	// an new orderUid has been created always because also payment systems can be used which do not accept a duplicate order id
-		$orderArray = tx_ttproducts_control_basket::getStoredOrder();
-		$orderUid = 0;
-
-		if (isset($orderArray['uid'])) {
-			$orderUid = intval($orderArray['uid']);
-		}
-
-		if (
-			$orderUid &&
-			!$this->conf['alwaysAdvanceOrderNumber']
-		) {
-			$res =
-				$GLOBALS['TYPO3_DB']->exec_SELECTquery(
-					'uid',
-					'sys_products_orders',
-					'uid=' . $orderUid . ' AND hidden AND NOT status'
-				);	// Checks if record exists, is marked hidden (all blank orders are hidden by default) and is not finished.
-		}
-
-		if (
-			!$orderUid ||
-			$this->conf['alwaysAdvanceOrderNumber'] ||
-			$res !== false && !$GLOBALS['TYPO3_DB']->sql_num_rows($res)
-		) {
-			$orderUid = $this->create();
-			$orderArray = [];
-			$orderArray['uid'] = $orderUid;
-			$orderArray['crdate'] = time();
-			if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-				$orderArray['crdate'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-			}
-			$orderArray['tracking_code'] =
-				$this->getNumber($orderUid) . '-' .
-				strtolower(substr(md5(uniqid(time())), 0, 6));
-			tx_ttproducts_control_basket::store('order', $orderArray);
-			$this->currentArray = $orderArray;
-		}
-
-		if ($res !== false) {
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		}
-
-		return $orderUid;
-	} // getBlankUid
+        return $newId;
+    } // create
 
 
-	public function setCurrentData ($key, $value) {
-		$this->currentArray[$key] = $value;
-	}
+    /**
+     * Returns a blank order uid. If there was no order id already, a new one is created.
+     *
+     * Blank orders are marked hidden and with status=0 initialy. Blank orders are not necessarily finalized because users may abort instead of buying.
+     * A finalized order is marked 'not hidden' and with status=1.
+     * Returns this uid which is a blank order record uid.
+     */
+    public function getBlankUid (&$orderArray) {
+
+        $res = false;
+    // an new orderUid has been created always because also payment systems can be used which do not accept a duplicate order id
+        $orderArray = tx_ttproducts_control_basket::getStoredOrder();
+        $orderUid = 0;
+
+        if (isset($orderArray['uid'])) {
+            $orderUid = intval($orderArray['uid']);
+        }
+
+        if (
+            $orderUid &&
+            !$this->conf['alwaysAdvanceOrderNumber']
+        ) {
+            $res =
+                $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                    'uid',
+                    'sys_products_orders',
+                    'uid=' . $orderUid . ' AND hidden AND NOT status'
+                );	// Checks if record exists, is marked hidden (all blank orders are hidden by default) and is not finished.
+        }
+
+        if (
+            !$orderUid ||
+            $this->conf['alwaysAdvanceOrderNumber'] ||
+            $res !== false && !$GLOBALS['TYPO3_DB']->sql_num_rows($res)
+        ) {
+            $orderUid = $this->create();
+            $orderArray = [];
+            $orderArray['uid'] = $orderUid;
+            $orderArray['crdate'] = time();
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                $orderArray['crdate'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+            }
+            $orderArray['tracking_code'] =
+                $this->getNumber($orderUid) . '-' .
+                strtolower(substr(md5(uniqid(time())), 0, 6));
+            tx_ttproducts_control_basket::store('order', $orderArray);
+            $this->currentArray = $orderArray;
+        }
+
+        if ($res !== false) {
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        }
+
+        return $orderUid;
+    } // getBlankUid
 
 
-	public function getCurrentArray () {
-		$result = $this->currentArray;
-		return $result;
-	}
+    public function setCurrentData ($key, $value) {
+        $this->currentArray[$key] = $value;
+    }
 
 
-	public function setUid ($uid) {
-		$this->setCurrentData('uid', $uid);
-	}
+    public function getCurrentArray () {
+        $result = $this->currentArray;
+        return $result;
+    }
 
 
-	public function getUid ($orderArray = []) {
-		if (empty($orderArray)) {
-			$orderArray = $this->getCurrentArray();
-		}
-
-		$result = $orderArray['uid'] ?? 0;
-		return $result;
-	}
+    public function setUid ($uid) {
+        $this->setCurrentData('uid', $uid);
+    }
 
 
-	public function clearUid () {
-		$this->setCurrentData('uid', '');
-		tx_ttproducts_control_basket::store('order', []);
-	}
+    public function getUid ($orderArray = []) {
+        if (empty($orderArray)) {
+            $orderArray = $this->getCurrentArray();
+        }
+
+        $result = $orderArray['uid'] ?? 0;
+        return $result;
+    }
 
 
-	public function updateRecord ($orderUid, array $fieldsArray) {
-
-			// Saving the order record
-		$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-			'sys_products_orders',
-			'uid=' . intval($orderUid),
-			$fieldsArray
-		);
-	}
+    public function clearUid () {
+        $this->setCurrentData('uid', '');
+        tx_ttproducts_control_basket::store('order', []);
+    }
 
 
-	/**
-	 * Returns the order record if $orderUid.
-	 * If $tracking is set, then the order with the tracking number is fetched instead.
-	 */
-	public function getRecord ($orderUid, $tracking = '') {
-		if (
-			empty($tracking) &&
-			!$orderUid
-		) {
-			return false;
-		}
+    public function updateRecord ($orderUid, array $fieldsArray) {
+
+            // Saving the order record
+        $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+            'sys_products_orders',
+            'uid=' . intval($orderUid),
+            $fieldsArray
+        );
+    }
+
+
+    /**
+     * Returns the order record if $orderUid.
+     * If $tracking is set, then the order with the tracking number is fetched instead.
+     */
+    public function getRecord ($orderUid, $tracking = '') {
+        if (
+            empty($tracking) &&
+            !$orderUid
+        ) {
+            return false;
+        }
 
         $where = ($tracking ? 'tracking_code=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($tracking, 'sys_products_orders') : 'uid=' . intval($orderUid));
 
         $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_products_orders');
 
-		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'*',
-			'sys_products_orders',
-			$where . $enableFields
-		);
-		$result = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-		$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		return $result;
-	} //getRecord
+        $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            '*',
+            'sys_products_orders',
+            $where . $enableFields
+        );
+        $result = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+        $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        return $result;
+    } //getRecord
 
 
-	/**
-	 * This returns the order-number (opposed to the order's uid) for display in the shop, confirmation notes and so on.
-	 * Basically this prefixes the .orderNumberPrefix, if any
-	 */
+    /**
+     * This returns the order-number (opposed to the order's uid) for display in the shop, confirmation notes and so on.
+     * Basically this prefixes the .orderNumberPrefix, if any
+     */
     public function getNumber ($orderUid)   {
         $orderNumberPrefix = substr($this->conf['orderNumberPrefix'], 0, 30);
         if (($position = strpos($orderNumberPrefix, '%')) !== false)    {
@@ -281,40 +281,40 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
     } // getNumber
 
 
-	/**
-	 * Saves the order record and returns the result
-	 *
-	 */
-	public function putRecord (
-		$orderUid,
-		$orderArray,
-		$itemArray,
-		$calculatedArray,
-		$cardUid,
-		$accountUid,
-		$email_notify,
-		$payment,
-		$shipping,
-		$amount,
-		$orderConfirmationHTML,
-		$infoViewOb,
-		\JambageCom\Div2007\Base\TranslationBase $languageObj,
-		$status,
-		$basketExtra,
-		$giftcode,
-		$giftServiceArticleArray,
-		$vouchercode,
-		$usedCreditpoints,
-		$voucherCount,
-		$bOnlyStatusChange
-	) {
-		$billingInfo = $infoViewOb->infoArray['billing'];
-		$deliveryInfo = $infoViewOb->infoArray['delivery'];
+    /**
+     * Saves the order record and returns the result
+     *
+     */
+    public function putRecord (
+        $orderUid,
+        $orderArray,
+        $itemArray,
+        $calculatedArray,
+        $cardUid,
+        $accountUid,
+        $email_notify,
+        $payment,
+        $shipping,
+        $amount,
+        $orderConfirmationHTML,
+        $infoViewOb,
+        \JambageCom\Div2007\Base\TranslationBase $languageObj,
+        $status,
+        $basketExtra,
+        $giftcode,
+        $giftServiceArticleArray,
+        $vouchercode,
+        $usedCreditpoints,
+        $voucherCount,
+        $bOnlyStatusChange
+    ) {
+        $billingInfo = $infoViewOb->infoArray['billing'];
+        $deliveryInfo = $infoViewOb->infoArray['delivery'];
         $feusers_uid = 0;
         if (is_array($billingInfo) && isset($billingInfo['feusers_uid'])) {
             $feusers_uid = $billingInfo['feusers_uid'];
-		}
-		$orderRow = [];
+        }
+        $orderRow = [];
 
         if (
             !isset($deliveryInfo) ||
@@ -323,10 +323,10 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
             $deliveryInfo = $billingInfo;
         }
 
-		$fieldsArray = [];
+        $fieldsArray = [];
 
-		$tablename = $this->getTablename();
-		$fieldsArray['hidden'] = 1;
+        $tablename = $this->getTablename();
+        $fieldsArray['hidden'] = 1;
         $excludeFieldArray = [];
 
         if (
@@ -337,83 +337,83 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
             $excludeFieldArray = $excludeArray[$tablename];
         }
 
-		if ($status > 0) {
-			$fieldsArray['hidden'] = 0;
+        if ($status > 0) {
+            $fieldsArray['hidden'] = 0;
 
-			if ($bOnlyStatusChange) {
-				$orderRow =
-					$this->get(
-						$orderUid,
-						0,
-						false,
-						'',
-						'',
-						'',
-						'',
-						'orderData,hidden,email,tracking_code',
-						false,
-						'',
-						false
-					);
+            if ($bOnlyStatusChange) {
+                $orderRow =
+                    $this->get(
+                        $orderUid,
+                        0,
+                        false,
+                        '',
+                        '',
+                        '',
+                        '',
+                        'orderData,hidden,email,tracking_code',
+                        false,
+                        '',
+                        false
+                    );
 
-				if (
-					empty($orderRow) ||
-					!is_array($orderRow) ||
-					isset($orderRow['tracking_code']) && $orderRow['tracking_code'] == '' ||
-					isset($orderRow['email']) && $orderRow['email'] == ''
-				) {
-					$bOnlyStatusChange = false;
-				}
-			}
-		} else {
-			$bOnlyStatusChange = false;
-		}
+                if (
+                    empty($orderRow) ||
+                    !is_array($orderRow) ||
+                    isset($orderRow['tracking_code']) && $orderRow['tracking_code'] == '' ||
+                    isset($orderRow['email']) && $orderRow['email'] == ''
+                ) {
+                    $bOnlyStatusChange = false;
+                }
+            }
+        } else {
+            $bOnlyStatusChange = false;
+        }
 
-		if (!$bOnlyStatusChange) {
-			if (
+        if (!$bOnlyStatusChange) {
+            if (
                 empty($deliveryInfo['name']) &&
                 isset($deliveryInfo['first_name']) &&
                 isset($deliveryInfo['last_name'])
             ) {
-				$deliveryInfo['name'] = $deliveryInfo['last_name'] . ' ' . $deliveryInfo['first_name'];
-			}
+                $deliveryInfo['name'] = $deliveryInfo['last_name'] . ' ' . $deliveryInfo['first_name'];
+            }
 
-			$dateBirth = '';
-			if (!empty($deliveryInfo['date_of_birth'])) {
-				$dateBirth = tx_ttproducts_sql::convertDate($deliveryInfo['date_of_birth']);
-			}
+            $dateBirth = '';
+            if (!empty($deliveryInfo['date_of_birth'])) {
+                $dateBirth = tx_ttproducts_sql::convertDate($deliveryInfo['date_of_birth']);
+            }
 
-			$addressFields = ['name', 'first_name', 'last_name', 'company', 'salutation', 'address', 'house_no', 'zip', 'city', 'country', 'telephone', 'fax', 'email', 'email_notify', 'business_partner', 'organisation_form'];
+            $addressFields = ['name', 'first_name', 'last_name', 'company', 'salutation', 'address', 'house_no', 'zip', 'city', 'country', 'telephone', 'fax', 'email', 'email_notify', 'business_partner', 'organisation_form'];
 
-			if (isset($billingInfo) && is_array($billingInfo)) {
-				foreach ($billingInfo as $field => $value) {
-					if (
-						$value &&
-						!in_array($field, $addressFields) &&
-						isset($GLOBALS['TCA']['sys_products_orders']['columns'][$field])
-					) {
-						$fieldsArray[$field] = $value;
-					}
-				}
+            if (isset($billingInfo) && is_array($billingInfo)) {
+                foreach ($billingInfo as $field => $value) {
+                    if (
+                        $value &&
+                        !in_array($field, $addressFields) &&
+                        isset($GLOBALS['TCA']['sys_products_orders']['columns'][$field])
+                    ) {
+                        $fieldsArray[$field] = $value;
+                    }
+                }
             }
 
             if (isset($deliveryInfo) && is_array($deliveryInfo)) {
-				foreach ($deliveryInfo as $field => $value) {
-					if (
+                foreach ($deliveryInfo as $field => $value) {
+                    if (
                         $value && 
                         isset($GLOBALS['TCA']['sys_products_orders']['columns'][$field])
                     ) {
-						$fieldsArray[$field] = $value;
-					}
-				}
-			}
+                        $fieldsArray[$field] = $value;
+                    }
+                }
+            }
 
-			$fieldsArray['email_notify'] = $email_notify;
+            $fieldsArray['email_notify'] = $email_notify;
 
-				// can be changed after order is set.
-			$fieldsArray['payment'] = $payment;
-			$fieldsArray['shipping'] = $shipping;
-			$fieldsArray['amount'] = $amount;
+                // can be changed after order is set.
+            $fieldsArray['payment'] = $payment;
+            $fieldsArray['shipping'] = $shipping;
+            $fieldsArray['amount'] = $amount;
 
             $fieldsArray['note'] = $deliveryInfo['note'] ?? null;
             $fieldsArray['date_of_birth'] = $dateBirth ?? null;
@@ -424,51 +424,51 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
                 is_array($giftServiceArticleArray) &&
                 !empty($deliveryInfo['giftservice'])
             ) {
-				$fieldsArray['giftservice'] = $deliveryInfo['giftservice'] . '||' . implode(',',$giftServiceArticleArray);
-			}
-			if (!empty($deliveryInfo['foundby'])) {
+                $fieldsArray['giftservice'] = $deliveryInfo['giftservice'] . '||' . implode(',',$giftServiceArticleArray);
+            }
+            if (!empty($deliveryInfo['foundby'])) {
                 $fieldsArray['foundby'] = $deliveryInfo['foundby'];
-			}
-			$fieldsArray['client_ip'] = GeneralUtility::getIndpEnv('REMOTE_ADDR');
-			$fieldsArray['cc_uid'] = intval($cardUid);
-			$fieldsArray['ac_uid'] = intval($accountUid);
-			$fieldsArray['giftcode'] = $giftcode;
+            }
+            $fieldsArray['client_ip'] = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+            $fieldsArray['cc_uid'] = intval($cardUid);
+            $fieldsArray['ac_uid'] = intval($accountUid);
+            $fieldsArray['giftcode'] = $giftcode;
 
             $api =
                 GeneralUtility::makeInstance(\JambageCom\Div2007\Api\Frontend::class);
             $sys_language_uid = $api->getLanguageId();
-			$fieldsArray['sys_language_uid'] = $sys_language_uid;
+            $fieldsArray['sys_language_uid'] = $sys_language_uid;
 
-			if (!empty($billingInfo['tt_products_vat'])) {
-				$fieldsArray['vat_id'] = $billingInfo['tt_products_vat'];
+            if (!empty($billingInfo['tt_products_vat'])) {
+                $fieldsArray['vat_id'] = $billingInfo['tt_products_vat'];
 
-				$taxPercentage = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
-				if (doubleval($taxPercentage) == 0) {
-					$fieldsArray['tax_mode'] = 1;
-				}
-			}
+                $taxPercentage = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
+                if (doubleval($taxPercentage) == 0) {
+                    $fieldsArray['tax_mode'] = 1;
+                }
+            }
 
-			$fieldsArrayFeUsers = [];
-			$uid_voucher = ''; // define it here
+            $fieldsArrayFeUsers = [];
+            $uid_voucher = ''; // define it here
 
-			if (!empty($dateBirth)) {
-				$fieldsArrayFeUsers['date_of_birth'] = $dateBirth;
-			}
+            if (!empty($dateBirth)) {
+                $fieldsArrayFeUsers['date_of_birth'] = $dateBirth;
+            }
 
-			if ($status == 1 && !empty($this->conf['creditpoints.']) && $usedCreditpoints) {
+            if ($status == 1 && !empty($this->conf['creditpoints.']) && $usedCreditpoints) {
 
-	/* Added Els: update fe_user with amount of creditpoints (= exisitng amount - used_creditpoints - spended_creditpoints + saved_creditpoints */
-				$fieldsArrayFeUsers['tt_products_creditpoints'] =
-					floatval($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] -
-						$usedCreditpoints
-						/*+ GeneralUtility::_GP('creditpoints_saved')*/);
-				if ($fieldsArrayFeUsers['tt_products_creditpoints'] < 0) {
-					$fieldsArrayFeUsers['tt_products_creditpoints'] = 0;
-				}
-			}
+    /* Added Els: update fe_user with amount of creditpoints (= exisitng amount - used_creditpoints - spended_creditpoints + saved_creditpoints */
+                $fieldsArrayFeUsers['tt_products_creditpoints'] =
+                    floatval($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] -
+                        $usedCreditpoints
+                        /*+ GeneralUtility::_GP('creditpoints_saved')*/);
+                if ($fieldsArrayFeUsers['tt_products_creditpoints'] < 0) {
+                    $fieldsArrayFeUsers['tt_products_creditpoints'] = 0;
+                }
+            }
 
-			if ($status == 1 &&  $vouchercode  != '') {
-				// first check if vouchercode exist and is not their own vouchercode
+            if ($status == 1 &&  $vouchercode  != '') {
+                // first check if vouchercode exist and is not their own vouchercode
                 $res =
                     $GLOBALS['TYPO3_DB']->exec_SELECTquery(
                         'uid',
@@ -477,26 +477,26 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
                             $GLOBALS['TYPO3_DB']->fullQuoteStr($vouchercode, 'fe_users')
                     );
 
-				if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-					$uid_voucher = $row['uid'];
-				}
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				if (
-					($uid_voucher != '') &&
-					!empty($deliveryInfo['feusers_uid']) &&
-					($deliveryInfo['feusers_uid'] != $uid_voucher)
-				) {
-					$fieldsArrayFeUsers['tt_products_vouchercode'] = $vouchercode;
-				}
-			}
+                if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                    $uid_voucher = $row['uid'];
+                }
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                if (
+                    ($uid_voucher != '') &&
+                    !empty($deliveryInfo['feusers_uid']) &&
+                    ($deliveryInfo['feusers_uid'] != $uid_voucher)
+                ) {
+                    $fieldsArrayFeUsers['tt_products_vouchercode'] = $vouchercode;
+                }
+            }
 
-			if ($status == 1 && !empty($deliveryInfo['feusers_uid'])) {
-		/* Added Els: update user from vouchercode with 5 credits */
-				tx_ttproducts_creditpoints_div::addCreditPoints(
-					$vouchercode,
-					$this->conf['voucher.']['price']
-				);
-			}
+            if ($status == 1 && !empty($deliveryInfo['feusers_uid'])) {
+        /* Added Els: update user from vouchercode with 5 credits */
+                tx_ttproducts_creditpoints_div::addCreditPoints(
+                    $vouchercode,
+                    $this->conf['voucher.']['price']
+                );
+            }
     
             foreach ($excludeFieldArray as $field) {
                 if (isset($fieldsArrayFeUsers[$field])) {
@@ -504,89 +504,89 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
                 }
             }
 
-			if (
+            if (
                 \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
-				$GLOBALS['TSFE']->fe_user->user['uid'] &&
-				count($fieldsArrayFeUsers)
-			) {
-				$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-					'fe_users',
-					'uid=' . intval($GLOBALS['TSFE']->fe_user->user['uid']),
-					$fieldsArrayFeUsers
-				);
-			}
+                $GLOBALS['TSFE']->fe_user->user['uid'] &&
+                count($fieldsArrayFeUsers)
+            ) {
+                $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+                    'fe_users',
+                    'uid=' . intval($GLOBALS['TSFE']->fe_user->user['uid']),
+                    $fieldsArrayFeUsers
+                );
+            }
 
-			$storeItemArray = [];
-			$storeItemArray['tt_products'] = $itemArray;
+            $storeItemArray = [];
+            $storeItemArray['tt_products'] = $itemArray;
 
-				// Order Data serialized
-			$fieldsArray['orderData'] = serialize([
-				'html_output' 	=>	$orderConfirmationHTML,
-				'delivery' 		=>	$deliveryInfo,
-				'billing' 		=>	$billingInfo,
-				'itemArray'		=>	$storeItemArray,
-				'calculatedArray'	=>	$calculatedArray,
-				'version'		=>	$this->config['version']
-			]);
+                // Order Data serialized
+            $fieldsArray['orderData'] = serialize([
+                'html_output' 	=>	$orderConfirmationHTML,
+                'delivery' 		=>	$deliveryInfo,
+                'billing' 		=>	$billingInfo,
+                'itemArray'		=>	$storeItemArray,
+                'calculatedArray'	=>	$calculatedArray,
+                'version'		=>	$this->config['version']
+            ]);
 
-				// Setting tstamp, deleted and tracking code
-			$fieldsArray['tstamp'] = time();
-			if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-				$fieldsArray['tstamp'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-			}
-			$fieldsArray['deleted'] = 0;
-			$fieldsArray['tracking_code'] = $orderArray['tracking_code'];
-			$fieldsArray['agb'] = intval($billingInfo['agb']);
-		}
+                // Setting tstamp, deleted and tracking code
+            $fieldsArray['tstamp'] = time();
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+                $fieldsArray['tstamp'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+            }
+            $fieldsArray['deleted'] = 0;
+            $fieldsArray['tracking_code'] = $orderArray['tracking_code'];
+            $fieldsArray['agb'] = intval($billingInfo['agb']);
+        }
 
-		if ($status == 1) {
-			$payMode =
-				\JambageCom\TtProducts\Api\PaymentApi::getPayMode(
-					$languageObj,
-					$basketExtra
-				);
+        if ($status == 1) {
+            $payMode =
+                \JambageCom\TtProducts\Api\PaymentApi::getPayMode(
+                    $languageObj,
+                    $basketExtra
+                );
 
-			if ($payMode) {
-				$status = 13;
-				$fieldsArray['pay_mode'] = $payMode;
-			}
+            if ($payMode) {
+                $status = 13;
+                $fieldsArray['pay_mode'] = $payMode;
+            }
 
-			if ( // save the new order HTML if present for status = 1
-				$bOnlyStatusChange &&
-				$orderConfirmationHTML != '' &&
-				!empty($orderRow)
-			) {
+            if ( // save the new order HTML if present for status = 1
+                $bOnlyStatusChange &&
+                $orderConfirmationHTML != '' &&
+                !empty($orderRow)
+            ) {
                     // Saving the order record
-				$orderData = $this->getOrderData($orderRow);
-				$orderData['html_output'] = $orderConfirmationHTML;
+                $orderData = $this->getOrderData($orderRow);
+                $orderData['html_output'] = $orderConfirmationHTML;
 
-				$fieldsArray['orderData'] = serialize($orderData);
-			}
-		}
+                $fieldsArray['orderData'] = serialize($orderData);
+            }
+        }
 
-		if ($voucherCount) {
-			$fieldsArray['gained_voucher'] = $voucherCount;
-		}
+        if ($voucherCount) {
+            $fieldsArray['gained_voucher'] = $voucherCount;
+        }
 
         if (isset($orderArray['bill_no'])) {
             $fieldsArray['bill_no'] = $orderArray['bill_no'];
         }
 
-		$fieldsArray['feusers_uid'] = intval($feusers_uid);
-		$fieldsArray['status'] = intval($status);	// If 1, then this means, "Order confirmed on website, next step: confirm from shop that order is received"
+        $fieldsArray['feusers_uid'] = intval($feusers_uid);
+        $fieldsArray['status'] = intval($status);	// If 1, then this means, "Order confirmed on website, next step: confirm from shop that order is received"
 
-			// Default status_log entry
-		$status_log = [];
-		$status_log['0'] = [
-			'time' => time(),
-			'info' => $this->conf['statusCodes.'][$status] ?? '',
-			'status' => $status,
-			'comment' => $deliveryInfo['note'] ?? ''
-		];
-		if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
-			$status_log['0']['time'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
-		}
-		$fieldsArray['status_log'] = serialize($status_log);
+            // Default status_log entry
+        $status_log = [];
+        $status_log['0'] = [
+            'time' => time(),
+            'info' => $this->conf['statusCodes.'][$status] ?? '',
+            'status' => $status,
+            'comment' => $deliveryInfo['note'] ?? ''
+        ];
+        if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
+            $status_log['0']['time'] += ($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'] * 3600);
+        }
+        $fieldsArray['status_log'] = serialize($status_log);
 
         foreach ($excludeFieldArray as $field) {
             if (isset($fieldsArray[$field])) {
@@ -594,117 +594,117 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
             }
         }
 
-			// Saving the order record
-		$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-			'sys_products_orders',
-			'uid=' . intval($orderUid),
-			$fieldsArray
-		);
-	} // putRecord
+            // Saving the order record
+        $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+            'sys_products_orders',
+            'uid=' . intval($orderUid),
+            $fieldsArray
+        );
+    } // putRecord
 
 
-	/**
-	 * Creates M-M relations for the products with tt_products and maybe also the tt_products_articles table.
-	 * Isn't really used yet, but later will be used to display stock-status by looking up how many items are
-	 * already ordered.
-	 *
-	 */
-	public function createMM (
-		$orderUid,
-		$itemArray,
-		$theCode
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$editFieldArray = [];
-		$selectableVariantFieldArray = [];
-		$orderTablename = 'sys_products_orders';
-		$falFieldname = 'fal_uid';
-		$variantSeparator = '---';
+    /**
+     * Creates M-M relations for the products with tt_products and maybe also the tt_products_articles table.
+     * Isn't really used yet, but later will be used to display stock-status by looking up how many items are
+     * already ordered.
+     *
+     */
+    public function createMM (
+        $orderUid,
+        $itemArray,
+        $theCode
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $editFieldArray = [];
+        $selectableVariantFieldArray = [];
+        $orderTablename = 'sys_products_orders';
+        $falFieldname = 'fal_uid';
+        $variantSeparator = '---';
 
-		if ($this->conf['useArticles'] != 2) {
-			$productTable = $tablesObj->get('tt_products', false);
-			$productTablename = $productTable->getTablename();
-			$editFieldArray = $productTable->editVariant->getFieldArray();
-			$selectableVariantFieldArray = $productTable->variant->getSelectableFieldArray();
-			$variantSeparator = $productTable->getVariant()->getImplodeSeparator();
+        if ($this->conf['useArticles'] != 2) {
+            $productTable = $tablesObj->get('tt_products', false);
+            $productTablename = $productTable->getTablename();
+            $editFieldArray = $productTable->editVariant->getFieldArray();
+            $selectableVariantFieldArray = $productTable->variant->getSelectableFieldArray();
+            $variantSeparator = $productTable->getVariant()->getImplodeSeparator();
 
-		} else {
-			$productTablename = '';
-		}
+        } else {
+            $productTablename = '';
+        }
 
-		if ($this->conf['useArticles'] > 0) {
-			$articleTable = $tablesObj->get('tt_products_articles', false);
-			$articleTablename = $articleTable->getTablename();
-		} else {
-			$articleTablename = '';
-		}
+        if ($this->conf['useArticles'] > 0) {
+            $articleTable = $tablesObj->get('tt_products_articles', false);
+            $articleTablename = $articleTable->getTablename();
+        } else {
+            $articleTablename = '';
+        }
 
-			// First: delete any existing. This should never be the case.
-		$where = 'uid_local=' . intval($orderUid);
-		$GLOBALS['TYPO3_DB']->exec_DELETEquery(
-			'sys_products_orders_mm_tt_products',
-			$where
-		);
+            // First: delete any existing. This should never be the case.
+        $where = 'uid_local=' . intval($orderUid);
+        $GLOBALS['TYPO3_DB']->exec_DELETEquery(
+            'sys_products_orders_mm_tt_products',
+            $where
+        );
 
-		$where = 'uid_foreign=' . intval($orderUid) . ' AND `tablenames`="sys_products_orders"';
-		$GLOBALS['TYPO3_DB']->exec_DELETEquery(
-			'sys_file_reference',
-			$where
-		);
+        $where = 'uid_foreign=' . intval($orderUid) . ' AND `tablenames`="sys_products_orders"';
+        $GLOBALS['TYPO3_DB']->exec_DELETEquery(
+            'sys_file_reference',
+            $where
+        );
 
-		$productCount = 0;
-		$falCount = 0;
+        $productCount = 0;
+        $falCount = 0;
 
-		if (isset($itemArray) && is_array($itemArray)) {
-			// loop over all items in the basket indexed by a sorting text
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					$extArray = $row['ext'];
-					$pid = intval($row['pid']);
-					$externalUidArray = [];
+        if (isset($itemArray) && is_array($itemArray)) {
+            // loop over all items in the basket indexed by a sorting text
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    $extArray = $row['ext'];
+                    $pid = intval($row['pid']);
+                    $externalUidArray = [];
 
-					if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
-						// product belongs to another basket
-						continue;
-					}
+                    if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
+                        // product belongs to another basket
+                        continue;
+                    }
 
-					$variantArray = [];
-					$editVariantArray = [];
+                    $variantArray = [];
+                    $editVariantArray = [];
 
-					// fill in the variants and edit_variants mediumtext NOT NULL,
-					foreach ($selectableVariantFieldArray as $variant) {
-						if (isset($row[$variant]) && $row[$variant] != '') {
-							$variantArray[] = $variant . ':' . $row[$variant];
-						}
-					}
-					foreach ($editFieldArray as $editVariant) {
-						if (isset($row[$editVariant]) && $row[$editVariant] != '') {
-							$editVariantArray[] = substr($editVariant, strlen('edit_')) . ':' . $row[$editVariant];
-						}
-					}
+                    // fill in the variants and edit_variants mediumtext NOT NULL,
+                    foreach ($selectableVariantFieldArray as $variant) {
+                        if (isset($row[$variant]) && $row[$variant] != '') {
+                            $variantArray[] = $variant . ':' . $row[$variant];
+                        }
+                    }
+                    foreach ($editFieldArray as $editVariant) {
+                        if (isset($row[$editVariant]) && $row[$editVariant] != '') {
+                            $editVariantArray[] = substr($editVariant, strlen('edit_')) . ':' . $row[$editVariant];
+                        }
+                    }
 
-					$variants = implode($variantSeparator, $variantArray);
-					$editVariants = implode($variantSeparator, $editVariantArray);
-					$falVariants = '';
+                    $variants = implode($variantSeparator, $variantArray);
+                    $editVariants = implode($variantSeparator, $editVariantArray);
+                    $falVariants = '';
 
-					if (
-						isset($extArray) &&
-						isset($extArray['records']) &&
-						is_array($extArray['records'])
-					) {
-						$newTitleArray = [];
-						$externalRowArray = $extArray['records'];						\JambageCom\TtProducts\Api\BasketApi::getRecordvariantAndPriceFromRows(
-							$falVariants,
-							$dummyPrice,
-							$externalUidArray,
-							$externalRowArray
-						);
+                    if (
+                        isset($extArray) &&
+                        isset($extArray['records']) &&
+                        is_array($extArray['records'])
+                    ) {
+                        $newTitleArray = [];
+                        $externalRowArray = $extArray['records'];						\JambageCom\TtProducts\Api\BasketApi::getRecordvariantAndPriceFromRows(
+                            $falVariants,
+                            $dummyPrice,
+                            $externalUidArray,
+                            $externalRowArray
+                        );
 
-						if (($position = strpos($falVariants, '|records:')) === 0) {
-							$falVariants = substr($falVariants, strlen('|records:'));
-						}
-					}
+                        if (($position = strpos($falVariants, '|records:')) === 0) {
+                            $falVariants = substr($falVariants, strlen('|records:'));
+                        }
+                    }
 
                     $time = time();
                     if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['serverTimeZone'])) {
@@ -729,121 +729,121 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
                         'tablenames' => $productTablename . ',' . $articleTablename
                     ];
 
-					if (
-						$this->conf['useArticles'] == 1 ||
-						$this->conf['useArticles'] == 3
-					) {
-						// get the article uid with these colors, sizes and gradings
-						$articleRow =
-							$productTable->getArticleRow(
-								$row,
-								$theCode
-							);
+                    if (
+                        $this->conf['useArticles'] == 1 ||
+                        $this->conf['useArticles'] == 3
+                    ) {
+                        // get the article uid with these colors, sizes and gradings
+                        $articleRow =
+                            $productTable->getArticleRow(
+                                $row,
+                                $theCode
+                            );
 
-						if ($articleRow) {
-							$insertFields['tt_products_articles_uid'] = intval($articleRow['uid']);
-						}
-					}
-					$GLOBALS['TYPO3_DB']->exec_INSERTquery(
-						'sys_products_orders_mm_tt_products',
-						$insertFields
-					);
-					$productCount++;
-				}
-			}
-		}
+                        if ($articleRow) {
+                            $insertFields['tt_products_articles_uid'] = intval($articleRow['uid']);
+                        }
+                    }
+                    $GLOBALS['TYPO3_DB']->exec_INSERTquery(
+                        'sys_products_orders_mm_tt_products',
+                        $insertFields
+                    );
+                    $productCount++;
+                }
+            }
+        }
 
-		$fieldsArray = array (
-			'product_uid' => intval($productCount),
-			'fal_uid' => intval($falCount),
-		);
+        $fieldsArray = array (
+            'product_uid' => intval($productCount),
+            'fal_uid' => intval($falCount),
+        );
 
-			// Saving the order record
-		$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
-			'sys_products_orders',
-			'uid=' . intval($orderUid),
-			$fieldsArray
-		);
-	}
+            // Saving the order record
+        $GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+            'sys_products_orders',
+            'uid=' . intval($orderUid),
+            $fieldsArray
+        );
+    }
 
-	public function getOrderData ($row) {
-			// initialize order data.
-		$orderData = unserialize($row['orderData']);
-		if ($orderData === false) {
-			$orderData =
-				\JambageCom\Div2007\Utility\SystemUtility::unserialize(
-					$row['orderData'],
-					false
-				);
-		}
+    public function getOrderData ($row) {
+            // initialize order data.
+        $orderData = unserialize($row['orderData']);
+        if ($orderData === false) {
+            $orderData =
+                \JambageCom\Div2007\Utility\SystemUtility::unserialize(
+                    $row['orderData'],
+                    false
+                );
+        }
 
-		return $orderData;
-	}
+        return $orderData;
+    }
 
 
-	/**
-	 * Fetches the basket itemArray from the order's serial data
-	 */
-	public function getItemArray (
-		$row,
-		&$calculatedArray,
-		&$infoArray
-	) {
-		$orderData = $this->getOrderData($row);
+    /**
+     * Fetches the basket itemArray from the order's serial data
+     */
+    public function getItemArray (
+        $row,
+        &$calculatedArray,
+        &$infoArray
+    ) {
+        $orderData = $this->getOrderData($row);
 
-		$tmp = $orderData['itemArray'];
-		$version = $orderData['version'];
+        $tmp = $orderData['itemArray'];
+        $version = $orderData['version'];
 
-		if (version_compare($version, '2.5.0', '>=') && is_array($tmp)) {
-			$tableName = key($tmp);
-			$itemArray = current($tmp);
-		} else {
-			$itemArray = (is_array($tmp) ? $tmp : []);
-		}
+        if (version_compare($version, '2.5.0', '>=') && is_array($tmp)) {
+            $tableName = key($tmp);
+            $itemArray = current($tmp);
+        } else {
+            $itemArray = (is_array($tmp) ? $tmp : []);
+        }
 
-		$tmp = $orderData['calculatedArray'];
-		$calculatedArray = ($tmp ? $tmp : []);
-		$infoArray = [];
-		$infoArray['billing'] = $orderData['billing'];
-		$infoArray['delivery'] = $orderData['delivery'];
+        $tmp = $orderData['calculatedArray'];
+        $calculatedArray = ($tmp ? $tmp : []);
+        $infoArray = [];
+        $infoArray['billing'] = $orderData['billing'];
+        $infoArray['delivery'] = $orderData['delivery'];
 
-		// overwrite with the most recent email address
-		$infoArray['billing']['email'] = $row['email'];
+        // overwrite with the most recent email address
+        $infoArray['billing']['email'] = $row['email'];
 
- 		return $itemArray;
-	}
+        return $itemArray;
+    }
 
-	/**
-	 * Sets the user order in dummy order record
-	 *
-	 * @param	integer		$orderID: uid of dummy record
-	 * @return	void
-	 */
-	public function putData (
-		$orderUid,
-		$orderArray,
-		$itemArray,
-		$orderHTML,
-		$status,
-		$basketExtra,
-		$calculatedArray,
-		$giftcode,
-		$giftServiceArticleArray,
-		$vouchercode,
-		$usedCreditpoints,
-		$voucherCount,
-		$bOnlyStatusChange
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$voucherObj = $tablesObj->get('voucher');
+    /**
+     * Sets the user order in dummy order record
+     *
+     * @param	integer		$orderID: uid of dummy record
+     * @return	void
+     */
+    public function putData (
+        $orderUid,
+        $orderArray,
+        $itemArray,
+        $orderHTML,
+        $status,
+        $basketExtra,
+        $calculatedArray,
+        $giftcode,
+        $giftServiceArticleArray,
+        $vouchercode,
+        $usedCreditpoints,
+        $voucherCount,
+        $bOnlyStatusChange
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $voucherObj = $tablesObj->get('voucher');
 
-		if (
-			is_object($voucherObj) &&
-			$status == 1 &&
-			$voucherObj->isEnabled()
-		) {
-			$voucherObj->delete();
-		}
+        if (
+            is_object($voucherObj) &&
+            $status == 1 &&
+            $voucherObj->isEnabled()
+        ) {
+            $voucherObj->delete();
+        }
 
         // get credit card info
         $card = $tablesObj->get('sys_products_cards');
@@ -858,57 +858,57 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
         }
 
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$infoViewOb = GeneralUtility::makeInstance('tx_ttproducts_info_view');
-		if (
-			$infoViewOb->needsInit() ||
-			$languageObj->getExtensionKey() != TT_PRODUCTS_EXT
-		) {
-			debug ('internal error in tt_products (putData)'); // keep this
-			echo 'internal error in tt_products (putData)';
-			return;
-		}
+        $infoViewOb = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+        if (
+            $infoViewOb->needsInit() ||
+            $languageObj->getExtensionKey() != TT_PRODUCTS_EXT
+        ) {
+            debug ('internal error in tt_products (putData)'); // keep this
+            echo 'internal error in tt_products (putData)';
+            return;
+        }
 
-		$usedCreditpoints = 0;
-		if (
-			isset($_REQUEST['recs']) &&
-			is_array($_REQUEST['recs']) &&
-			isset($_REQUEST['recs']['tt_products']) &&
-			is_array($_REQUEST['recs']['tt_products'])
-		) {
-			$usedCreditpoints = floatval($_REQUEST['recs']['tt_products']['creditpoints']);
-		}
-		$result = $this->putRecord(
-			$orderUid,
-			$orderArray,
-			$itemArray,
-			$calculatedArray,
-			$cardUid,
-			$accountUid,
-			$this->conf['email_notify_default'] ?? '',	// Email notification is set here. Default email address is delivery email contact
-			($basketExtra['payment'][0] ?? '') . ': ' . ($basketExtra['payment.']['title'] ?? ''),
-			($basketExtra['shipping'][0] ?? '') . ': ' . ($basketExtra['shipping.']['title'] ?? ''),
-			$calculatedArray['priceTax']['total']['ALL'],
-			$orderHTML,
-			$infoViewOb,
-			$languageObj,
-			$status,
-			$basketExtra,
-			$giftcode,
-			$giftServiceArticleArray,
-			$vouchercode,
-			$usedCreditpoints,
-			$voucherCount,
-			$bOnlyStatusChange
-		);
+        $usedCreditpoints = 0;
+        if (
+            isset($_REQUEST['recs']) &&
+            is_array($_REQUEST['recs']) &&
+            isset($_REQUEST['recs']['tt_products']) &&
+            is_array($_REQUEST['recs']['tt_products'])
+        ) {
+            $usedCreditpoints = floatval($_REQUEST['recs']['tt_products']['creditpoints']);
+        }
+        $result = $this->putRecord(
+            $orderUid,
+            $orderArray,
+            $itemArray,
+            $calculatedArray,
+            $cardUid,
+            $accountUid,
+            $this->conf['email_notify_default'] ?? '',	// Email notification is set here. Default email address is delivery email contact
+            ($basketExtra['payment'][0] ?? '') . ': ' . ($basketExtra['payment.']['title'] ?? ''),
+            ($basketExtra['shipping'][0] ?? '') . ': ' . ($basketExtra['shipping.']['title'] ?? ''),
+            $calculatedArray['priceTax']['total']['ALL'],
+            $orderHTML,
+            $infoViewOb,
+            $languageObj,
+            $status,
+            $basketExtra,
+            $giftcode,
+            $giftServiceArticleArray,
+            $vouchercode,
+            $usedCreditpoints,
+            $voucherCount,
+            $bOnlyStatusChange
+        );
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	public function getPid () {
-		$result = $this->conf['PID_sys_products_orders'];
-		return $result;
-	}
+    public function getPid () {
+        $result = $this->conf['PID_sys_products_orders'];
+        return $result;
+    }
 
 
     protected function fillVariant (&$row, $variant, $variantSplitSeparator, $prefix = '') {
@@ -935,7 +935,7 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
     }
 
 
-	static public function getFal (
+    static public function getFal (
         &$orderedDownloadUid,
         $downloadUid,
         array $orderRow
@@ -962,7 +962,7 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
         }
 
         return $result;
-	}
+    }
 
     static public function getUidFromMultiOrderArray (
         &$orderedDownloadUid,
@@ -991,29 +991,29 @@ class tx_ttproducts_order extends tx_ttproducts_table_base {
             }
         }
         return $result;
-	}
+    }
 
-	public function getOrderedProducts (
-		$from,
-		$uids,
-		$where,
-		$orderBy,
-		$whereProducts,
-		$onlyProductsWithFalOrders,
-		$pid_list,
-		&$productRowArray,
-		&$multiOrderArray
-	) {
-		$productRowArray = [];
-		$multiOrderArray = [];
+    public function getOrderedProducts (
+        $from,
+        $uids,
+        $where,
+        $orderBy,
+        $whereProducts,
+        $onlyProductsWithFalOrders,
+        $pid_list,
+        &$productRowArray,
+        &$multiOrderArray
+    ) {
+        $productRowArray = [];
+        $multiOrderArray = [];
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$productObj = $tablesObj->get('tt_products', false);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $productObj = $tablesObj->get('tt_products', false);
         $falObj = $tablesObj->get('sys_file_reference', false);
-		$variantSeparator = $productObj->variant->getSplitSeparator();
-		$local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $variantSeparator = $productObj->variant->getSplitSeparator();
+        $local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
 
-		$tablename = $this->getTablename();
+        $tablename = $this->getTablename();
 
 /*
 SELECT
@@ -1028,69 +1028,69 @@ po.uid = pa.uid_local INNER JOIN tt_products p ON
 pa.uid_foreign = p.uid
 */
 
-		$alias = $this->getTableObj()->getAlias();
-		$productAlias = $productObj->getTableObj()->getAlias();
-		$productAliasPostfix1 = '1';
-		$productAlias1 = $productAlias . $productAliasPostfix1;
+        $alias = $this->getTableObj()->getAlias();
+        $productAlias = $productObj->getTableObj()->getAlias();
+        $productAliasPostfix1 = '1';
+        $productAlias1 = $productAlias . $productAliasPostfix1;
 
-		$selectConf = [];
+        $selectConf = [];
         if ($uids != '') {
             $selectConf['uidInList'] = $uids;
         }
-		if ($pid_list != '') {
-			$selectConf['pidInList'] = $pid_list;
-		}
+        if ($pid_list != '') {
+            $selectConf['pidInList'] = $pid_list;
+        }
 
-		$selectConf['selectFields'] =
-			$alias . '.uid as uid, ' . $alias . '.email as email, ' . $alias . '.feusers_uid as feusers_uid, ' .
-			$alias . '.crdate as crdate, ' . $alias . '.tracking_code as tracking_code, ' .
-			'pa.sys_products_orders_qty AS quantity, pa.variants AS variants, ' .
-			'pa.edit_variants AS edit_variants, pa.fal_variants AS fal_variants, ' . $productAlias1 . '.uid AS product_uid';
+        $selectConf['selectFields'] =
+            $alias . '.uid as uid, ' . $alias . '.email as email, ' . $alias . '.feusers_uid as feusers_uid, ' .
+            $alias . '.crdate as crdate, ' . $alias . '.tracking_code as tracking_code, ' .
+            'pa.sys_products_orders_qty AS quantity, pa.variants AS variants, ' .
+            'pa.edit_variants AS edit_variants, pa.fal_variants AS fal_variants, ' . $productAlias1 . '.uid AS product_uid';
 
-		if ($whereProducts != '') {
-			$where .= ' AND ' .
-				$productObj->getTableObj()->transformWhere(
-					$whereProducts,
-					$productAliasPostfix1
-				);
-		}
-		$selectConf['where'] = $where;
-		$selectConf['from'] = $from;
-		$selectConf['leftjoin'] =
-			'sys_products_orders_mm_tt_products pa ON ' . $alias . '.uid = pa.uid_local INNER JOIN tt_products ' . $productAlias1 . ' ON pa.uid_foreign = ' . $productAlias1 . '.uid';
-		if ($orderBy != '') {
-			$selectConf['orderBy'] = $orderBy;
-		}
-		$queryParts = $this->getTableObj()->getQueryConf(
-			$local_cObj,
-			$tablename,
-			$selectConf,
-			true
-		);
+        if ($whereProducts != '') {
+            $where .= ' AND ' .
+                $productObj->getTableObj()->transformWhere(
+                    $whereProducts,
+                    $productAliasPostfix1
+                );
+        }
+        $selectConf['where'] = $where;
+        $selectConf['from'] = $from;
+        $selectConf['leftjoin'] =
+            'sys_products_orders_mm_tt_products pa ON ' . $alias . '.uid = pa.uid_local INNER JOIN tt_products ' . $productAlias1 . ' ON pa.uid_foreign = ' . $productAlias1 . '.uid';
+        if ($orderBy != '') {
+            $selectConf['orderBy'] = $orderBy;
+        }
+        $queryParts = $this->getTableObj()->getQueryConf(
+            $local_cObj,
+            $tablename,
+            $selectConf,
+            true
+        );
 
-		$res = $this->getTableObj()->exec_SELECT_queryArray($queryParts);
-		while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+        $res = $this->getTableObj()->exec_SELECT_queryArray($queryParts);
+        while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
 
-			$multiOrderArray[] = $row;
-			$productRow = $productObj->get($row['product_uid']);
+            $multiOrderArray[] = $row;
+            $productRow = $productObj->get($row['product_uid']);
 
-			if (!empty($row['edit_variants'])) {
-				$this->fillVariant(
-					$productRow,
-					$row['edit_variants'],
-					$variantSeparator,
-					'edit_'
-				);
-			}
+            if (!empty($row['edit_variants'])) {
+                $this->fillVariant(
+                    $productRow,
+                    $row['edit_variants'],
+                    $variantSeparator,
+                    'edit_'
+                );
+            }
 
-			if (!empty($row['variants'])) {
-				$this->fillVariant(
-					$productRow,
-					$row['variants'],
-					$variantSeparator
-				);
-			}
-			$addProduct = true;
+            if (!empty($row['variants'])) {
+                $this->fillVariant(
+                    $productRow,
+                    $row['variants'],
+                    $variantSeparator
+                );
+            }
+            $addProduct = true;
 
             if (
                 $onlyProductsWithFalOrders
@@ -1107,204 +1107,204 @@ pa.uid_foreign = p.uid
 
             if ($addProduct) {
                 $productRowArray[] = $productRow;
-			}
-		}
+            }
+        }
 
-		return $productRowArray;
-	}
+        return $productRowArray;
+    }
 
 
-	public function getGainedProducts (
-		$from,
-		$where,
-		$orderBy,
-		$whereProducts,
-		$onlyProductsWithFalOrders,
-		$pid_list,
-		&$productRowArray,
-		&$multiOrderArray
-	) {
-		$multiOrderArray = [];
-		$productRowArray = [];
+    public function getGainedProducts (
+        $from,
+        $where,
+        $orderBy,
+        $whereProducts,
+        $onlyProductsWithFalOrders,
+        $pid_list,
+        &$productRowArray,
+        &$multiOrderArray
+    ) {
+        $multiOrderArray = [];
+        $productRowArray = [];
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$productObj = $tablesObj->get('tt_products', false);
-		$local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-		$tablename = $this->getTablename();
-		$variantSeparator = $productObj->variant->getSplitSeparator();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $productObj = $tablesObj->get('tt_products', false);
+        $local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $tablename = $this->getTablename();
+        $variantSeparator = $productObj->variant->getSplitSeparator();
 
-		$alias = $this->getTableObj()->getAlias();
-		$productAlias = $productObj->getTableObj()->getAlias();
-		$productAliasPostfix1 = '1';
-		$productAlias1 = $productAlias . $productAliasPostfix1;
+        $alias = $this->getTableObj()->getAlias();
+        $productAlias = $productObj->getTableObj()->getAlias();
+        $productAliasPostfix1 = '1';
+        $productAlias1 = $productAlias . $productAliasPostfix1;
 
-		$selectConf = [];
-		if ($pid_list != '') {
-			$selectConf['pidInList'] = $pid_list;
-		}
-		$selectConf['selectFields'] =
-			$alias . '.uid as uid, ' . $alias . '.email as email, ' .
-			$alias . '.crdate as crdate, ' . $alias . '.tracking_code as tracking_code, ' .
-			'gp.quantity AS quantity, gp.variants AS variants, ' .
-			'gp.edit_variants AS edit_variants, ' . $productAlias1 . '.uid AS product_uid';
+        $selectConf = [];
+        if ($pid_list != '') {
+            $selectConf['pidInList'] = $pid_list;
+        }
+        $selectConf['selectFields'] =
+            $alias . '.uid as uid, ' . $alias . '.email as email, ' .
+            $alias . '.crdate as crdate, ' . $alias . '.tracking_code as tracking_code, ' .
+            'gp.quantity AS quantity, gp.variants AS variants, ' .
+            'gp.edit_variants AS edit_variants, ' . $productAlias1 . '.uid AS product_uid';
 
 // 		$selectConf['selectFields'] =
 // 			$alias . '.uid as order_uid, ' . $alias . '.email as email, ' . $productAlias1 . '.uid AS product_uid';
 
-		if ($whereProducts != '') {
-			$where .= ' AND ' . $productObj->getTableObj()->transformWhere($whereProducts, $productAliasPostfix1);
-		}
-		$selectConf['where'] = $where;
-		$selectConf['from'] = $from;
-		$selectConf['leftjoin'] =
-			'sys_products_orders_mm_gained_tt_products gp ON ' . $alias . '.uid = gp.uid_local INNER JOIN tt_products ' . $productAlias1 . ' ON gp.uid_foreign = ' . $productAlias1 . '.uid';
-		if ($orderBy != '') {
-			$selectConf['orderBy'] = $orderBy;
-		}
+        if ($whereProducts != '') {
+            $where .= ' AND ' . $productObj->getTableObj()->transformWhere($whereProducts, $productAliasPostfix1);
+        }
+        $selectConf['where'] = $where;
+        $selectConf['from'] = $from;
+        $selectConf['leftjoin'] =
+            'sys_products_orders_mm_gained_tt_products gp ON ' . $alias . '.uid = gp.uid_local INNER JOIN tt_products ' . $productAlias1 . ' ON gp.uid_foreign = ' . $productAlias1 . '.uid';
+        if ($orderBy != '') {
+            $selectConf['orderBy'] = $orderBy;
+        }
 
-		$queryParts = $this->getTableObj()->getQueryConf(
-			$local_cObj,
-			$tablename,
-			$selectConf,
-			true
-		);
+        $queryParts = $this->getTableObj()->getQueryConf(
+            $local_cObj,
+            $tablename,
+            $selectConf,
+            true
+        );
 
-		$res = $this->getTableObj()->exec_SELECT_queryArray($queryParts);
-		while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+        $res = $this->getTableObj()->exec_SELECT_queryArray($queryParts);
+        while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
 // 			$orderArray = [];
 // 			$orderArray['orderTrackingNo'] = $row['orderTrackingNo'];
 // 			$orderArray['orderUid'] = $row['order_uid'];
 // 			$orderArray['orderDate'] = $row['order_date'];
 // 			$multiOrderArray[] = $orderArray;
 
-			$multiOrderArray[] = $row;
+            $multiOrderArray[] = $row;
 
-			$productRow = [];
-			$productRow['uid'] = $row['product_uid'];
+            $productRow = [];
+            $productRow['uid'] = $row['product_uid'];
 
-			if (!empty($row['edit_variants'])) {
-				$this->fillVariant(
-					$productRow,
-					$row['edit_variants'],
-					$variantSeparator,
-					'edit' . tx_ttproducts_variant::$externalTableSeparator
-				);
-			}
+            if (!empty($row['edit_variants'])) {
+                $this->fillVariant(
+                    $productRow,
+                    $row['edit_variants'],
+                    $variantSeparator,
+                    'edit' . tx_ttproducts_variant::$externalTableSeparator
+                );
+            }
 
-			if (!empty($row['variants'])) {
-				$this->fillVariant(
-					$productRow,
-					$row['variants'],
-					$variantSeparator
-				);
-			}
+            if (!empty($row['variants'])) {
+                $this->fillVariant(
+                    $productRow,
+                    $row['variants'],
+                    $variantSeparator
+                );
+            }
 
-			$productRowArray[] = $productRow;
-		}
-	}
+            $productRowArray[] = $productRow;
+        }
+    }
 
 
-	public function getOrderedAndGainedProducts (
-		$from,
-		$where,
-		$orderBy,
-		$whereProducts,
+    public function getOrderedAndGainedProducts (
+        $from,
+        $where,
+        $orderBy,
+        $whereProducts,
         $onlyProductsWithFalOrders,
-		$pid_list,
-		&$productRowArray,
-		&$multiOrderArray
-	) {
-		$productRowArray = [];
-		$multiOrderArray = [];
+        $pid_list,
+        &$productRowArray,
+        &$multiOrderArray
+    ) {
+        $productRowArray = [];
+        $multiOrderArray = [];
 
-		$this->getOrderedProducts(
-			$from,
-			'',
-			$where,
-			$orderBy,
-			$whereProducts,
-			$onlyProductsWithFalOrders,
-			$pid_list,
-			$productRowArray,
-			$multiOrderArray
-		);
+        $this->getOrderedProducts(
+            $from,
+            '',
+            $where,
+            $orderBy,
+            $whereProducts,
+            $onlyProductsWithFalOrders,
+            $pid_list,
+            $productRowArray,
+            $multiOrderArray
+        );
 
-		$this->getGainedProducts(
-			$from,
-			$where,
-			$orderBy,
-			$whereProducts,
-			$onlyProductsWithFalOrders,
-			$pid_list,
-			$gainedProductRowArray,
-			$gainedMultiOrderArray
-		);
+        $this->getGainedProducts(
+            $from,
+            $where,
+            $orderBy,
+            $whereProducts,
+            $onlyProductsWithFalOrders,
+            $pid_list,
+            $gainedProductRowArray,
+            $gainedMultiOrderArray
+        );
 
-		if (
-			isset($productRowArray) &&
-			is_array($productRowArray) &&
-			isset($gainedProductRowArray) &&
-			is_array($gainedProductRowArray)
-		) {
-			$productRowArray = array_merge($productRowArray, $gainedProductRowArray);
-			$newProductRowArray = [];
-			$productArray = [];
-				// remove duplicates
-			foreach ($productRowArray as $productRow) {
-				$uid = $productRow['uid'];
-				if (!isset($productArray[$uid])) {
-					$productArray[$uid] = true;
-					$newProductRowArray[] = $productRow;
-				}
-			}
-			$productRowArray = $newProductRowArray;
-			$multiOrderArray = array_merge($multiOrderArray, $gainedMultiOrderArray);
-		}
-	}
+        if (
+            isset($productRowArray) &&
+            is_array($productRowArray) &&
+            isset($gainedProductRowArray) &&
+            is_array($gainedProductRowArray)
+        ) {
+            $productRowArray = array_merge($productRowArray, $gainedProductRowArray);
+            $newProductRowArray = [];
+            $productArray = [];
+                // remove duplicates
+            foreach ($productRowArray as $productRow) {
+                $uid = $productRow['uid'];
+                if (!isset($productArray[$uid])) {
+                    $productArray[$uid] = true;
+                    $newProductRowArray[] = $productRow;
+                }
+            }
+            $productRowArray = $newProductRowArray;
+            $multiOrderArray = array_merge($multiOrderArray, $gainedMultiOrderArray);
+        }
+    }
 
 
-	public function getDownloadWhereClauses (
-		$feusers_uid,
-		$trackingCode,
-		&$whereOrders,
-		&$whereProducts
-	) {
-		$whereOrders = '1=1';
+    public function getDownloadWhereClauses (
+        $feusers_uid,
+        $trackingCode,
+        &$whereOrders,
+        &$whereProducts
+    ) {
+        $whereOrders = '1=1';
 
-		if ($feusers_uid) {
+        if ($feusers_uid) {
 
-			$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-				'*',
-				'fe_users',
-				'uid=' . intval($feusers_uid) . ' AND deleted=0 AND disable=0',
-				'',
-				'',
-				1
-			);
+            $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                '*',
+                'fe_users',
+                'uid=' . intval($feusers_uid) . ' AND deleted=0 AND disable=0',
+                '',
+                '',
+                1
+            );
 
-			if (
-				is_array($rows) &&
-				is_array($rows['0'])
-			) {
-				$whereOrders =
-					'(' .
-						'feusers_uid=' . intval($feusers_uid) .
-						' OR email=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($rows['0']['email'], 'fe_users') .
-					')';
-			}
-		} else if ($trackingCode != '') {
-			$whereOrders =
-				'tracking_code=' .
-				$GLOBALS['TYPO3_DB']->fullQuoteStr(
-					$trackingCode,
-					$this->getFuncTablename()
-				);
-		}
+            if (
+                is_array($rows) &&
+                is_array($rows['0'])
+            ) {
+                $whereOrders =
+                    '(' .
+                        'feusers_uid=' . intval($feusers_uid) .
+                        ' OR email=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($rows['0']['email'], 'fe_users') .
+                    ')';
+            }
+        } else if ($trackingCode != '') {
+            $whereOrders =
+                'tracking_code=' .
+                $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                    $trackingCode,
+                    $this->getFuncTablename()
+                );
+        }
 
-		$whereOrders .= ' AND pay_mode > 0';
-		$whereOrders = $this->getTableObj()->transformWhere($whereOrders);
-		$whereProducts = 'download_uid > 0';
-	}
+        $whereOrders .= ' AND pay_mode > 0';
+        $whereOrders = $this->getTableObj()->transformWhere($whereOrders);
+        $whereProducts = 'download_uid > 0';
+    }
 
 }
 

--- a/model/class.tx_ttproducts_orderaddress.php
+++ b/model/class.tx_ttproducts_orderaddress.php
@@ -42,122 +42,122 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_orderaddress extends tx_ttproducts_table_base {
-	var $dataArray; // array of read in frontend users
-	var $table;		 // object of the type tx_table_db
-	var $fields = [];
-	var $tableconf;
-	var $piVar = 'fe';
+    var $dataArray; // array of read in frontend users
+    var $table;		 // object of the type tx_table_db
+    var $fields = [];
+    var $tableconf;
+    var $piVar = 'fe';
 
-	private $bCondition = false;
-	private $bConditionRecord = false;
+    private $bCondition = false;
+    private $bConditionRecord = false;
 
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        if ($result) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			$this->tableconf = $cnf->getTableConf($functablename);
-			$tablename = $this->getTablename();
+            $this->tableconf = $cnf->getTableConf($functablename);
+            $tablename = $this->getTablename();
 
-	// 			// image
-	// 		$this->image = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-	// 		$this->image->init($this->pibase);
+    // 			// image
+    // 		$this->image = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
+    // 		$this->image->init($this->pibase);
 
-			$this->getTableObj()->setTCAFieldArray($tablename);
-			$this->fieldArray['payment'] = ($this->tableconf['payment'] ?? '');
-			$requiredFields = 'uid,pid,email' . ($this->fieldArray['payment'] ? ',' . $this->fieldArray['payment'] : '');
+            $this->getTableObj()->setTCAFieldArray($tablename);
+            $this->fieldArray['payment'] = ($this->tableconf['payment'] ?? '');
+            $requiredFields = 'uid,pid,email' . ($this->fieldArray['payment'] ? ',' . $this->fieldArray['payment'] : '');
             if (
                 isset($this->tableconf['ALL.']) &&
                 is_array($this->tableconf['ALL.'])
             ) {
-				$tmp = $this->tableconf['ALL.']['requiredFields'];
-				$requiredFields = ($tmp ? $tmp : $requiredFields);
-			}
-			$requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$this->getTableObj()->setRequiredFieldArray($requiredListArray);
-		}
+                $tmp = $this->tableconf['ALL.']['requiredFields'];
+                $requiredFields = ($tmp ? $tmp : $requiredFields);
+            }
+            $requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $this->getTableObj()->setRequiredFieldArray($requiredListArray);
+        }
 
-		return $result;
-	} // init
-
-
-	public function getSelectInfoFields() {
-		$result = ['salutation', 'tt_products_business_partner', 'tt_products_organisation_form'];
-
-		return $result;
-	}
+        return $result;
+    } // init
 
 
-	public function getTCATableFromField ($field) {
-		$result = 'fe_users';
-		if ($field == 'salutation') {
-			$result = 'sys_products_orders';
-		}
-		return $result;
-	}
+    public function getSelectInfoFields() {
+        $result = ['salutation', 'tt_products_business_partner', 'tt_products_organisation_form'];
+
+        return $result;
+    }
 
 
-	public function getFieldName ($field) {
-		$rc = $field;
-		if (is_array($this->fieldArray) && $this->fieldArray[$field]) {
-			$rc = $this->fieldArray[$field];
-		}
-
-		return $rc;
-	}
-
-
-	public function isUserInGroup ($feuser, $group) {
-		$groups = explode(',', $feuser['usergroup']);
-		foreach ($groups as $singlegroup)
-			if ($singlegroup == $group)
-				return true;
-		return false;
-	} // isUserInGroup
+    public function getTCATableFromField ($field) {
+        $result = 'fe_users';
+        if ($field == 'salutation') {
+            $result = 'sys_products_orders';
+        }
+        return $result;
+    }
 
 
-	public function setCondition ($row, $funcTablename) {
+    public function getFieldName ($field) {
+        $rc = $field;
+        if (is_array($this->fieldArray) && $this->fieldArray[$field]) {
+            $rc = $this->fieldArray[$field];
+        }
 
-		$bCondition = false;
-		$this->bConditionRecord = false;
+        return $rc;
+    }
 
-		if (isset($this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['date_of_birth.']['period.']['y'])) {
-			$year = $this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['date_of_birth.']['period.']['y'];
-			$infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
 
-			if ($infoViewObj->infoArray['billing']['date_of_birth']) {
-				$timeTemp = $infoViewObj->infoArray['billing']['date_of_birth'];
-				$bAge = true;
-			} else if ($GLOBALS['TSFE']->fe_user->user) {
-				$timeTemp = date('d-m-Y', ($GLOBALS['TSFE']->fe_user->user['date_of_birth']));
-				$bAge = true;
-			} else {
-				$bAge = false;
-			}
+    public function isUserInGroup ($feuser, $group) {
+        $groups = explode(',', $feuser['usergroup']);
+        foreach ($groups as $singlegroup)
+            if ($singlegroup == $group)
+                return true;
+        return false;
+    } // isUserInGroup
 
-			if ($bAge) {
-				$feDateArray = GeneralUtility::trimExplode('-', $timeTemp);
-				$date = getdate();
-				$offset = 0;
-				if ($date['mon'] < $feDateArray[1]) {
-					$offset = 1;
-				}
-				if ($date['year'] - $feDateArray[2] - $offset >= $year) {
-					$bCondition = true;
-				}
-			}
-		} else {
-			$bCondition = true;
-		}
 
-		$whereConf = $this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['where'] ?? '';
-		
-		if (!empty($whereConf)) {
+    public function setCondition ($row, $funcTablename) {
+
+        $bCondition = false;
+        $this->bConditionRecord = false;
+
+        if (isset($this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['date_of_birth.']['period.']['y'])) {
+            $year = $this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['date_of_birth.']['period.']['y'];
+            $infoViewObj = GeneralUtility::makeInstance('tx_ttproducts_info_view');
+
+            if ($infoViewObj->infoArray['billing']['date_of_birth']) {
+                $timeTemp = $infoViewObj->infoArray['billing']['date_of_birth'];
+                $bAge = true;
+            } else if ($GLOBALS['TSFE']->fe_user->user) {
+                $timeTemp = date('d-m-Y', ($GLOBALS['TSFE']->fe_user->user['date_of_birth']));
+                $bAge = true;
+            } else {
+                $bAge = false;
+            }
+
+            if ($bAge) {
+                $feDateArray = GeneralUtility::trimExplode('-', $timeTemp);
+                $date = getdate();
+                $offset = 0;
+                if ($date['mon'] < $feDateArray[1]) {
+                    $offset = 1;
+                }
+                if ($date['year'] - $feDateArray[2] - $offset >= $year) {
+                    $bCondition = true;
+                }
+            }
+        } else {
+            $bCondition = true;
+        }
+
+        $whereConf = $this->conf['conf.'][$funcTablename.'.']['ALL.']['fe_users.']['where'] ?? '';
+        
+        if (!empty($whereConf)) {
             $whereArray = GeneralUtility::trimExplode('IN', $whereConf);
             $pos1 = strpos ($whereArray[1], '(');
             $pos2 = strpos ($whereArray[1], ')');
@@ -172,40 +172,40 @@ class tx_ttproducts_orderaddress extends tx_ttproducts_table_base {
             }
         }
 
-		if ($bCondition) {
-			$this->bCondition = true;
-		}
-	}
+        if ($bCondition) {
+            $this->bCondition = true;
+        }
+    }
 
 
-	public function getCondition () {
-		return $this->bCondition;
-	}
+    public function getCondition () {
+        return $this->bCondition;
+    }
 
 
-	public function getConditionRecord () {
-		return $this->bConditionRecord;
-	}
+    public function getConditionRecord () {
+        return $this->bConditionRecord;
+    }
 
 
-	public function getCreditpoints () {
+    public function getCreditpoints () {
 
-		$rc = false;
-		if (
+        $rc = false;
+        if (
             \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
-			isset($GLOBALS['TSFE']->fe_user->user) &&
-			is_array(($GLOBALS['TSFE']->fe_user->user)
-		)) {
-			$rc = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
-		}
-		return $rc;
-	}
+            isset($GLOBALS['TSFE']->fe_user->user) &&
+            is_array(($GLOBALS['TSFE']->fe_user->user)
+        )) {
+            $rc = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
+        }
+        return $rc;
+    }
 
 
-	public function getPid () {
-		$result = $this->conf['PIDuserFolder'];
-		return $result;
-	}
+    public function getPid () {
+        $result = $this->conf['PIDuserFolder'];
+        return $result;
+    }
 }
 
 

--- a/model/class.tx_ttproducts_page.php
+++ b/model/class.tx_ttproducts_page.php
@@ -42,142 +42,142 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_page extends tx_ttproducts_category_base {
-	var $noteArray = []; 	// array of pages with notes
-	var $piVar = 'pid';
-	var $pageAsCategory;		// > 0 if pages are used as categories
-	protected $tableAlias = 'page';
+    var $noteArray = []; 	// array of pages with notes
+    var $piVar = 'pid';
+    var $pageAsCategory;		// > 0 if pages are used as categories
+    protected $tableAlias = 'page';
 
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	function init ($tablename) {
-		$result = parent::init($tablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    function init ($tablename) {
+        $result = parent::init($tablename);
 
-		if ($result) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tablename = ($tablename ? $tablename : 'pages');
-			$this->tableconf = $cnf->getTableConf('pages');
-			$this->pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
+        if ($result) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tablename = ($tablename ? $tablename : 'pages');
+            $this->tableconf = $cnf->getTableConf('pages');
+            $this->pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
 
-			$requiredFields = 'uid,pid,title,subtitle,media,shortcut';
-			if (!empty($this->tableconf['requiredFields'])) {
-				$tmp = $this->tableconf['requiredFields'];
-				$requiredFields = ($tmp ? $tmp : $requiredFields);
-			}
-			$requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$this->getTableObj()->setRequiredFieldArray($requiredListArray);
-			if (
+            $requiredFields = 'uid,pid,title,subtitle,media,shortcut';
+            if (!empty($this->tableconf['requiredFields'])) {
+                $tmp = $this->tableconf['requiredFields'];
+                $requiredFields = ($tmp ? $tmp : $requiredFields);
+            }
+            $requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $this->getTableObj()->setRequiredFieldArray($requiredListArray);
+            if (
                 isset($this->tableconf['language.']) &&#
                 isset($this->tableconf['language.']['type']) &&
                 $this->tableconf['language.']['type'] == 'field' &&
                 isset($this->tableconf['language.']['field.'])
             ) {
-				$addRequiredFields = [];
-				$addRequiredFields = $this->tableconf['language.']['field.'];
-				$this->getTableObj()->addRequiredFieldArray ($addRequiredFields);
-			}
+                $addRequiredFields = [];
+                $addRequiredFields = $this->tableconf['language.']['field.'];
+                $this->getTableObj()->addRequiredFieldArray ($addRequiredFields);
+            }
 
-			if (!empty($this->tableconf['generatePath.']) &&
+            if (!empty($this->tableconf['generatePath.']) &&
                 isset($this->tableconf['generatePath.']['type']) &&
-				$this->tableconf['generatePath.']['type'] == 'tablefields' &&
-				!empty($this->tableconf['generatePath.']['field.'])
-				) {
-				$addRequiredFields = [];
-				foreach ($this->tableconf['generatePath.']['field.'] as $field => $value) {
-					$addRequiredFields[] = $field;
-				}
-				$this->getTableObj()->addRequiredFieldArray ($addRequiredFields);
-			}
+                $this->tableconf['generatePath.']['type'] == 'tablefields' &&
+                !empty($this->tableconf['generatePath.']['field.'])
+                ) {
+                $addRequiredFields = [];
+                foreach ($this->tableconf['generatePath.']['field.'] as $field => $value) {
+                    $addRequiredFields[] = $field;
+                }
+                $this->getTableObj()->addRequiredFieldArray ($addRequiredFields);
+            }
 
-			$this->getTableObj()->setTCAFieldArray($tablename, 'pages');
+            $this->getTableObj()->setTCAFieldArray($tablename, 'pages');
 
-			if ($this->bUseLanguageTable($this->tableconf)) {
-				$this->getTableObj()->setForeignUidArray($this->getTableObj()->langname, 'pid');
-			}
+            if ($this->bUseLanguageTable($this->tableconf)) {
+                $this->getTableObj()->setForeignUidArray($this->getTableObj()->langname, 'pid');
+            }
 
-			if (
+            if (
                 isset($this->tableconf['language.']) &&
                 isset($this->tableconf['language.']['type']) &&
                 isset($this->tableconf['language.']['file']) &&
                 $this->tableconf['language.']['type'] == 'csv'
             ) {
-				$this->getTableObj()->initLanguageFile($this->tableconf['language.']['file']);
-			}
-		}
+                $this->getTableObj()->initLanguageFile($this->tableconf['language.']['file']);
+            }
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
-	/* initalisation for code dependant configuration */
-	public function initCodeConf ($theCode,$tableConf) {
-		parent::initCodeConf ($theCode,$tableConf);
-		if ($this->bUseLanguageTable($tableConf)) {
-			$this->getTableObj()->setForeignUidArray($this->getTableObj()->langname, 'pid');
-		}
-	}
+    /* initalisation for code dependant configuration */
+    public function initCodeConf ($theCode,$tableConf) {
+        parent::initCodeConf ($theCode,$tableConf);
+        if ($this->bUseLanguageTable($tableConf)) {
+            $this->getTableObj()->setForeignUidArray($this->getTableObj()->langname, 'pid');
+        }
+    }
 
-	public function getRootCat () {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$rc = $cnf->config['rootPageID'] ?? '';
-		return $rc;
-	}
-
-
-	public function getNotes ($uid) {
-		$rowArray = $this->noteArray[$uid];
-		$rcArray = [];
-		if (!is_array($rowArray) && $uid) {
-			$rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_products_products_note_pages_mm', 'uid_local = ' . intval($uid), '', 'sorting');
-			$this->noteArray[$uid] = $rowArray;
-		}
-		foreach ($rowArray as $k => $row) {
-			$rcArray[] = $row['uid_foreign'];
-		}
-		return $rcArray;
-	}
+    public function getRootCat () {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $rc = $cnf->config['rootPageID'] ?? '';
+        return $rc;
+    }
 
 
-	public function getParent ($uid=0) {
-		$rc = [];
-		$row = $this->get ($uid);
-		if ($row['pid']) {
-			$rc = $this->get ($row['pid']);
-		}
-		return $rc;
-	}
+    public function getNotes ($uid) {
+        $rowArray = $this->noteArray[$uid];
+        $rcArray = [];
+        if (!is_array($rowArray) && $uid) {
+            $rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_products_products_note_pages_mm', 'uid_local = ' . intval($uid), '', 'sorting');
+            $this->noteArray[$uid] = $rowArray;
+        }
+        foreach ($rowArray as $k => $row) {
+            $rcArray[] = $row['uid_foreign'];
+        }
+        return $rcArray;
+    }
 
 
-	public function getRowCategory ($row) {
-		$rc = $row['pid'];
-		return $rc;
-	}
+    public function getParent ($uid=0) {
+        $rc = [];
+        $row = $this->get ($uid);
+        if ($row['pid']) {
+            $rc = $this->get ($row['pid']);
+        }
+        return $rc;
+    }
 
 
-	public function getRowPid($row) {
-		$rc = $row['uid'];
-		return $rc;
-	}
+    public function getRowCategory ($row) {
+        $rc = $row['pid'];
+        return $rc;
+    }
 
 
-	public function getParamDefault ($theCode, $pid) {
-		$pid = ($pid ?? $this->conf['defaultPageID'] ?? '');
-		if ($pid) {
-			$pid = implode(',',GeneralUtility::intExplode(',', $pid));
-		}
-		return $pid;
-	}
+    public function getRowPid($row) {
+        $rc = $row['uid'];
+        return $rc;
+    }
 
-	public function getRelationArray ($dataArray, $excludeCats = '',$rootUids = '',$allowedCats = '') {
 
-		$relationArray = [];
-		$pageArray = $dataArray;
-		$excludeArray = GeneralUtility::trimExplode (',', $excludeCats);
-		foreach ($excludeArray as $k => $cat) {
-			$excludeKey = array_search($cat, $pageArray);
-			unset($pageArray[$excludeKey]);
-		}
-		$tablename = $this->getTableObj()->name;
+    public function getParamDefault ($theCode, $pid) {
+        $pid = ($pid ?? $this->conf['defaultPageID'] ?? '');
+        if ($pid) {
+            $pid = implode(',',GeneralUtility::intExplode(',', $pid));
+        }
+        return $pid;
+    }
+
+    public function getRelationArray ($dataArray, $excludeCats = '',$rootUids = '',$allowedCats = '') {
+
+        $relationArray = [];
+        $pageArray = $dataArray;
+        $excludeArray = GeneralUtility::trimExplode (',', $excludeCats);
+        foreach ($excludeArray as $k => $cat) {
+            $excludeKey = array_search($cat, $pageArray);
+            unset($pageArray[$excludeKey]);
+        }
+        $tablename = $this->getTableObj()->name;
         if (
             isset($this->config['LLkey']) &&
             isset($this->tableconf['language.']) &&
@@ -187,96 +187,96 @@ class tx_ttproducts_page extends tx_ttproducts_category_base {
             $tablename = $this->tableconf['language.']['table'];
         }
 
-		foreach ($pageArray as $k => $uid) {
-			$row = $this->get ($uid);
-			if ($row) {
-				if (in_array($row['shortcut'],$excludeArray)) {	// do not show shortcuts to the excluded page
-					$excludeKey = array_search($row['uid'], $pageArray);
-					unset($pageArray[$excludeKey]);
-					continue;
-				}
-				$relationArray[$uid][$this->getLabel()] = $row['title'];
-				if ($tablename == $this->getTableObj()->name) { // default language and using language overlay table
-					$relationArray[$uid]['pid'] = $row['uid'];
-				} else {
-					$relationArray[$uid]['pid'] = $row['pid'];
-				}
-				$pid = $row['pid'];
-				$parentKey = array_search($pid, $pageArray);
-				if ($parentKey === false || $parentKey == 0 && $pageArray[0] != $pid) {
-					$pid = 0;
-				}
-				$relationArray[$uid]['parent_category'] = $pid;
-				$parentId = $pid;
-				if ($parentId) {
-					$count = 0;
-					if (!is_array($relationArray[$parentId]['child_category'])) {
-						$relationArray[$parentId]['child_category'] = [];
-					}
-					$relationArray[$parentId]['child_category'][] = (int) $uid;
-				}
-			}
-		}
+        foreach ($pageArray as $k => $uid) {
+            $row = $this->get ($uid);
+            if ($row) {
+                if (in_array($row['shortcut'],$excludeArray)) {	// do not show shortcuts to the excluded page
+                    $excludeKey = array_search($row['uid'], $pageArray);
+                    unset($pageArray[$excludeKey]);
+                    continue;
+                }
+                $relationArray[$uid][$this->getLabel()] = $row['title'];
+                if ($tablename == $this->getTableObj()->name) { // default language and using language overlay table
+                    $relationArray[$uid]['pid'] = $row['uid'];
+                } else {
+                    $relationArray[$uid]['pid'] = $row['pid'];
+                }
+                $pid = $row['pid'];
+                $parentKey = array_search($pid, $pageArray);
+                if ($parentKey === false || $parentKey == 0 && $pageArray[0] != $pid) {
+                    $pid = 0;
+                }
+                $relationArray[$uid]['parent_category'] = $pid;
+                $parentId = $pid;
+                if ($parentId) {
+                    $count = 0;
+                    if (!is_array($relationArray[$parentId]['child_category'])) {
+                        $relationArray[$parentId]['child_category'] = [];
+                    }
+                    $relationArray[$parentId]['child_category'][] = (int) $uid;
+                }
+            }
+        }
 
-		return $relationArray;
-	}
+        return $relationArray;
+    }
 
-	/**
-	 * Returning the pid out from the row using the where clause
-	 */
-	public function getPID ($conf, $confExt, $row, $rootRow = [])
-	{
-		$result = 0;
-		if ($confExt) {
-			foreach ($confExt as $k1 => $param) {
-				$type  = $param['type'];
-				$where = $param['where'];
-				$isValid = false;
-				if ($where) {
-					$wherelist = GeneralUtility::trimExplode('AND', $where);
-					$isValid = true;
-					foreach ($wherelist as $k2 => $condition) {
-						$args = GeneralUtility::trimExplode('=', $condition);
-						if ($row[$args[0]] != $args[1]) {
-							$isValid = false;
-						}
-					}
-				} else {
-					$isValid = true;
-				}
+    /**
+     * Returning the pid out from the row using the where clause
+     */
+    public function getPID ($conf, $confExt, $row, $rootRow = [])
+    {
+        $result = 0;
+        if ($confExt) {
+            foreach ($confExt as $k1 => $param) {
+                $type  = $param['type'];
+                $where = $param['where'];
+                $isValid = false;
+                if ($where) {
+                    $wherelist = GeneralUtility::trimExplode('AND', $where);
+                    $isValid = true;
+                    foreach ($wherelist as $k2 => $condition) {
+                        $args = GeneralUtility::trimExplode('=', $condition);
+                        if ($row[$args[0]] != $args[1]) {
+                            $isValid = false;
+                        }
+                    }
+                } else {
+                    $isValid = true;
+                }
 
-				if ($isValid == true) {
-					switch ($type) {
-						case 'sql':
-							$result = $param['pid'];
-							break;
-						case 'pid':
-							$result = intval($row['pid']);
-							break;
-						case 'page.pid':
+                if ($isValid == true) {
+                    switch ($type) {
+                        case 'sql':
+                            $result = $param['pid'];
+                            break;
+                        case 'pid':
+                            $result = intval($row['pid']);
+                            break;
+                        case 'page.pid':
                             $pid = intval($row['pid']);
                             $pageRow = $this->get($pid);
                             if ($pageRow) {
                                 $result = intval($pageRow['pid']);
                             }
-							break;
-					}
-					break;  //ready with the foreach loop
-				}
-			}
-		}
+                            break;
+                    }
+                    break;  //ready with the foreach loop
+                }
+            }
+        }
 
-		if (!$result) {
+        if (!$result) {
             if (MathUtility::canBeInterpretedAsInteger($conf) && $conf > 0) {
-				$result = $conf;
-			} else {
-				$result = (!empty($rootRow['uid']) ? $rootRow['uid'] : $GLOBALS['TSFE']->id);
-				$result = intval($result);
-			}
-		}
+                $result = $conf;
+            } else {
+                $result = (!empty($rootRow['uid']) ? $rootRow['uid'] : $GLOBALS['TSFE']->id);
+                $result = intval($result);
+            }
+        }
 
-		return $result;
-	} // getPID
+        return $result;
+    } // getPID
 }
 
 

--- a/model/class.tx_ttproducts_pdf.php
+++ b/model/class.tx_ttproducts_pdf.php
@@ -40,214 +40,214 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_pdf implements \TYPO3\CMS\Core\SingletonInterface {
-	private $header;
-	private $footer;
-	private $body;
-	public $cObj;
-	protected $family;
-	protected $style;
-	protected $size;
+    private $header;
+    private $footer;
+    private $body;
+    public $cObj;
+    protected $family;
+    protected $style;
+    protected $size;
 
 
-	public function init ($family, $style, $size) {
-		$this->family = $family;
-		$this->style = $style;
-		$this->size = $size;
+    public function init ($family, $style, $size) {
+        $this->family = $family;
+        $this->style = $style;
+        $this->size = $size;
 
-		$this->SetFont($family, $style, $size);
+        $this->SetFont($family, $style, $size);
 
-		return true;
-	}
+        return true;
+    }
 
-	public function setHeader ($header) {
-		$this->header = $header;
-	}
+    public function setHeader ($header) {
+        $this->header = $header;
+    }
 
-	public function setFooter ($footer) {
-		$this->footer = $footer;
-	}
+    public function setFooter ($footer) {
+        $this->footer = $footer;
+    }
 
-	public function setBody ($body) {
-		$this->body = $body;
-	}
+    public function setBody ($body) {
+        $this->body = $body;
+    }
 
-	public function Header () {
-		//Police Arial gras 15
-		$this->SetFont('Arial', 'B', 15);
-		$this->MultiCell(0, 6, $this->header, 1);
-	}
+    public function Header () {
+        //Police Arial gras 15
+        $this->SetFont('Arial', 'B', 15);
+        $this->MultiCell(0, 6, $this->header, 1);
+    }
 
-	public function Footer () {
-		//Positionnement à 1,5 cm du bas
-		$this->SetY(-15);
-		//Police Arial gras 15
-		$this->SetFont('Arial', 'I', 8);
-		$this->MultiCell(0, 6, $this->footer, 1);
-	}
+    public function Footer () {
+        //Positionnement à 1,5 cm du bas
+        $this->SetY(-15);
+        //Police Arial gras 15
+        $this->SetFont('Arial', 'I', 8);
+        $this->MultiCell(0, 6, $this->footer, 1);
+    }
 
-	private function addEmptyColumns($bLastLine) {
+    private function addEmptyColumns($bLastLine) {
 
-		$row = [];
-		$row['1'] = '';
-		$row['2'] = '';
-		$row['3'] = '';
+        $row = [];
+        $row['1'] = '';
+        $row['2'] = '';
+        $row['3'] = '';
 
-		$this->getDimensions($widthArray);
+        $this->getDimensions($widthArray);
 
-		foreach ($row as $k => $v) {
-			if ($k2 < 2) {
-				$this->Cell($widthArray[$k], 6, $v, 'LR', 0);
-			} else {
-				$this->Cell($widthArray[$k], 6, $v, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
-			}
-		}
-	}
+        foreach ($row as $k => $v) {
+            if ($k2 < 2) {
+                $this->Cell($widthArray[$k], 6, $v, 'LR', 0);
+            } else {
+                $this->Cell($widthArray[$k], 6, $v, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
+            }
+        }
+    }
 
-	private function getDimensions (&$widthArray) {
-		//Column widths
-		$widthArray = [80, 25, 40, 45];
-	}
+    private function getDimensions (&$widthArray) {
+        //Column widths
+        $widthArray = [80, 25, 40, 45];
+    }
 
-	//Better table
-	public function ImprovedTable ($header, array $data) {
-		$this->getDimensions($widthArray);
+    //Better table
+    public function ImprovedTable ($header, array $data) {
+        $this->getDimensions($widthArray);
 
-		$totalWidth = 0;
-		foreach ($widthArray as $width) {
-			$totalWidth += $width;
-		}
+        $totalWidth = 0;
+        foreach ($widthArray as $width) {
+            $totalWidth += $width;
+        }
 
-		//Header
-		if (is_array($header)) {
+        //Header
+        if (is_array($header)) {
             for($i = 0; $i < count($header); $i++) {
                 $this->Cell($widthArray[$i], 7, $header[$i], 1, 0, 'C');
             }
-		}
-		$this->Ln();
+        }
+        $this->Ln();
 
-		$dataCount = count($data);
-		$rowCount = 4;
-		$columnNo = 1;
+        $dataCount = count($data);
+        $rowCount = 4;
+        $columnNo = 1;
 
-		//Data. The keys must start with 1
-		foreach($data as $k1 => $row) {
-			$bLastLine = ($k1 == $dataCount);
-			if ($bLastLine) {
-				$this->SetFont($this->family, 'B', $this->size);
-			}
-			$oldRowCount = $rowCount;
-			$rowCount = count($row);
+        //Data. The keys must start with 1
+        foreach($data as $k1 => $row) {
+            $bLastLine = ($k1 == $dataCount);
+            if ($bLastLine) {
+                $this->SetFont($this->family, 'B', $this->size);
+            }
+            $oldRowCount = $rowCount;
+            $rowCount = count($row);
 
-			foreach ($row as $k2 => $v2) {
+            foreach ($row as $k2 => $v2) {
 
-				if ($columnNo > 4) {
-					$columnNo = 1;
-				}
+                if ($columnNo > 4) {
+                    $columnNo = 1;
+                }
 
-				if ($k2 == 0 && trim($v2) == '' && $rowCount == 4 && $oldRowCount == 1 && $columnNo == 2) {
-					// skip first column which has been filled in from former row
-					continue;
-				}
-				$l2 = intval($this->GetStringWidth($v2));
-				unset($value);
+                if ($k2 == 0 && trim($v2) == '' && $rowCount == 4 && $oldRowCount == 1 && $columnNo == 2) {
+                    // skip first column which has been filled in from former row
+                    continue;
+                }
+                $l2 = intval($this->GetStringWidth($v2));
+                unset($value);
 
-				if ($l2 > $widthArray[$k2] - 5) {
-					$subStringCount = intval ($l2 / ($widthArray[$k2] - 10)) + 1;
-					$averageStringLength = strlen($v2) / $subStringCount;
-					if (!isset($additonalRow)) {
-						$additonalRow = [];
-					}
+                if ($l2 > $widthArray[$k2] - 5) {
+                    $subStringCount = intval ($l2 / ($widthArray[$k2] - 10)) + 1;
+                    $averageStringLength = strlen($v2) / $subStringCount;
+                    if (!isset($additonalRow)) {
+                        $additonalRow = [];
+                    }
 
-					$startPosition = 0;
-					for ($i = 0; $i < $subStringCount; $i++) {
-						$subValue = substr($v2, $startPosition, $averageStringLength);
-						$lastSpacePosition = strrpos($subValue, ' ');
-						$subValue = substr($subValue, 0, $lastSpacePosition);
-						$startPosition += strlen($subValue) + 1;
+                    $startPosition = 0;
+                    for ($i = 0; $i < $subStringCount; $i++) {
+                        $subValue = substr($v2, $startPosition, $averageStringLength);
+                        $lastSpacePosition = strrpos($subValue, ' ');
+                        $subValue = substr($subValue, 0, $lastSpacePosition);
+                        $startPosition += strlen($subValue) + 1;
 
-						if ($i == 0) {
-							if ($oldRowCount > 1) {
-								$value = $subValue;
-							} else {
-								$additonalRow[] = $subValue;
-							}
-						} else {
-							$additonalRow[] = $subValue;
-						}
-					}
-				} else {
-					if ($oldRowCount > 1 || $rowCount > 1) {
-						$value = $v2;
-					} else {
-						$additonalRow[] = $v2;
-					}
-				}
+                        if ($i == 0) {
+                            if ($oldRowCount > 1) {
+                                $value = $subValue;
+                            } else {
+                                $additonalRow[] = $subValue;
+                            }
+                        } else {
+                            $additonalRow[] = $subValue;
+                        }
+                    }
+                } else {
+                    if ($oldRowCount > 1 || $rowCount > 1) {
+                        $value = $v2;
+                    } else {
+                        $additonalRow[] = $v2;
+                    }
+                }
 
-				if (isset($value)) {
-					if ($k2 < 2) {
-						$this->Cell($widthArray[$k2], 6, $value, 'LR', 0);
-					} else {
-						$this->Cell($widthArray[$k2], 6, $value, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
-					}
-					$columnNo++;
+                if (isset($value)) {
+                    if ($k2 < 2) {
+                        $this->Cell($widthArray[$k2], 6, $value, 'LR', 0);
+                    } else {
+                        $this->Cell($widthArray[$k2], 6, $value, 'LR' . ($bLastLine ? 'T' : ''), 0, 'R');
+                    }
+                    $columnNo++;
 
-					if ($columnNo <= 4) {
-						continue;
-					}
-					$this->Ln();
-				} else {
-					continue;
-				}
+                    if ($columnNo <= 4) {
+                        continue;
+                    }
+                    $this->Ln();
+                } else {
+                    continue;
+                }
 
-				if (isset($additonalRow) && is_array($additonalRow)) {
-			//		$this->Ln();
+                if (isset($additonalRow) && is_array($additonalRow)) {
+            //		$this->Ln();
 
-					foreach ($additonalRow as $k3 => $subValue) {
-						$bLastSubRow = ($k3 == ($subRowCount - 1));
+                    foreach ($additonalRow as $k3 => $subValue) {
+                        $bLastSubRow = ($k3 == ($subRowCount - 1));
 
-						$this->Cell($widthArray['0'], 6, $subValue, 'LR', ($subRowCount > 1 && !$bLastSubRow ? 1 : 0));
-						$this->addEmptyColumns($bLastLine);
-						$this->Ln();
-					}
-					$columnNo = 1;
-					unset($additonalRow);
-				}
-			}
-		}
+                        $this->Cell($widthArray['0'], 6, $subValue, 'LR', ($subRowCount > 1 && !$bLastSubRow ? 1 : 0));
+                        $this->addEmptyColumns($bLastLine);
+                        $this->Ln();
+                    }
+                    $columnNo = 1;
+                    unset($additonalRow);
+                }
+            }
+        }
 
-		$this->SetFont($this->family, $this->style, $this->size);
+        $this->SetFont($this->family, $this->style, $this->size);
 
-		//Closure line
-		$this->Cell(array_sum($w), 0, '', 'T');
-		$this->Ln();
-	}
+        //Closure line
+        $this->Cell(array_sum($w), 0, '', 'T');
+        $this->Ln();
+    }
 
-	public function Body () {
+    public function Body () {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
 
-		// $xPos = $this->GetX();
-		$tempContent = $templateService->getSubpart($this->body, '###PDF_TABLE_1###');
-		$tempContentArray = preg_split('/[\n]+/', $tempContent);
-		$dataArray = [];
-		foreach ($tempContentArray as $tmpContent) {
-			if (isset($tmpContent) && trim($tmpContent) != '') {
-				$dataArray[] = preg_split('/\|/', $tmpContent, -1, PREG_SPLIT_NO_EMPTY);
-			}
-		}
-		$header = $dataArray['0'];
-		unset($dataArray['0']);
-		$this->ImprovedTable($header, $dataArray);
+        // $xPos = $this->GetX();
+        $tempContent = $templateService->getSubpart($this->body, '###PDF_TABLE_1###');
+        $tempContentArray = preg_split('/[\n]+/', $tempContent);
+        $dataArray = [];
+        foreach ($tempContentArray as $tmpContent) {
+            if (isset($tmpContent) && trim($tmpContent) != '') {
+                $dataArray[] = preg_split('/\|/', $tmpContent, -1, PREG_SPLIT_NO_EMPTY);
+            }
+        }
+        $header = $dataArray['0'];
+        unset($dataArray['0']);
+        $this->ImprovedTable($header, $dataArray);
 
-		$restBody = $templateService->substituteMarkerArrayCached(
-				$this->body,
-				[],
-				['###PDF_TABLE_1###' => ''],
-				[]
-			);
+        $restBody = $templateService->substituteMarkerArrayCached(
+                $this->body,
+                [],
+                ['###PDF_TABLE_1###' => ''],
+                []
+            );
 
-		// $this->SetX($xPos);
-		$this->MultiCell(0, 4, $restBody, '1L');
-	}
+        // $this->SetX($xPos);
+        $this->MultiCell(0, 4, $restBody, '1L');
+    }
 }
 
 

--- a/model/class.tx_ttproducts_pid_list.php
+++ b/model/class.tx_ttproducts_pid_list.php
@@ -43,78 +43,78 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_pid_list {
-	protected $pid_list;				// list of page ids
-	protected $recursive;
-	protected $pageArray = [];		// pid_list as array
-	protected $allPages = false;
+    protected $pid_list;				// list of page ids
+    protected $recursive;
+    protected $pageArray = [];		// pid_list as array
+    protected $allPages = false;
 
 
-	/**
-	 * Sets the pid_list internal var
-	 */
-	public function setPidlist ($pid_list) {
-		if ($pid_list == -1) {
-			$this->allPages = true;
-			$this->recursive = 0;
-		}
-		$this->pid_list = $pid_list;
-	}
+    /**
+     * Sets the pid_list internal var
+     */
+    public function setPidlist ($pid_list) {
+        if ($pid_list == -1) {
+            $this->allPages = true;
+            $this->recursive = 0;
+        }
+        $this->pid_list = $pid_list;
+    }
 
 
-	/**
-	 * gets the latest applied recursive
-	 */
-	public function getRecursive () {
-		return $this->recursive;
-	}
+    /**
+     * gets the latest applied recursive
+     */
+    public function getRecursive () {
+        return $this->recursive;
+    }
 
 
-	/**
-	 * Gets the pid_list internal var or the child pid_list of the page id as parameter
-	 */
-	public function getPidlist ($pid = '') {
-		$rc = '';
-		if ($pid) {
-			$this->applyRecursive(1, $pid, false);
-			$rc = $pid;
-		} else {
-			$rc = $this->pid_list;
-		}
-		return $rc;
-	}
+    /**
+     * Gets the pid_list internal var or the child pid_list of the page id as parameter
+     */
+    public function getPidlist ($pid = '') {
+        $rc = '';
+        if ($pid) {
+            $this->applyRecursive(1, $pid, false);
+            $rc = $pid;
+        } else {
+            $rc = $this->pid_list;
+        }
+        return $rc;
+    }
 
 
-	/**
-	 * Sets the pid_list internal var
-	 */
-	public function setPageArray () {
-		$this->pageArray = GeneralUtility::trimExplode (',', $this->pid_list);
-		$this->pageArray = array_flip($this->pageArray);
-	}
+    /**
+     * Sets the pid_list internal var
+     */
+    public function setPageArray () {
+        $this->pageArray = GeneralUtility::trimExplode (',', $this->pid_list);
+        $this->pageArray = array_flip($this->pageArray);
+    }
 
 
-	public function getPageArray ($pid = 0) {
-		if (
+    public function getPageArray ($pid = 0) {
+        if (
             $pid
         )	{
-			$rc = isset($this->pageArray[$pid]) || $this->allPages;
-		} else {
-			$rc = $this->pageArray;
-		}
+            $rc = isset($this->pageArray[$pid]) || $this->allPages;
+        } else {
+            $rc = $this->pageArray;
+        }
 
-		return $rc;
-	}
+        return $rc;
+    }
 
 
-	/**
-	 * Extends the internal pid_list by the levels given by $recursive
-	 *
-	 * @param	[type]		$recursive: ...
-	 * @param	[type]		$pids: ...
-	 * @param	[type]		$bStore: ...
-	 * @return	[type]		...
-	 */
-	public function applyRecursive ($recursive, &$pids, $bStore = false) {
+    /**
+     * Extends the internal pid_list by the levels given by $recursive
+     *
+     * @param	[type]		$recursive: ...
+     * @param	[type]		$pids: ...
+     * @param	[type]		$bStore: ...
+     * @return	[type]		...
+     */
+    public function applyRecursive ($recursive, &$pids, $bStore = false) {
         if (
             defined ('TYPO3_MODE') &&
             TYPO3_MODE == 'BE'
@@ -122,50 +122,50 @@ class tx_ttproducts_pid_list {
             return;
         }
  
-		$cObj = FrontendUtility::getContentObjectRenderer();
+        $cObj = FrontendUtility::getContentObjectRenderer();
 
-		if ($pids == -1) {
-			$this->allPages = true;
-		}
+        if ($pids == -1) {
+            $this->allPages = true;
+        }
 
-		if ($pids != '') {
-			$pid_list = &$pids;
-		} else {
-			$pid_list = $this->pid_list;
-		}
+        if ($pids != '') {
+            $pid_list = &$pids;
+        } else {
+            $pid_list = $this->pid_list;
+        }
 
-		if (!$pid_list && !$this->allPages) {
-			$pid_list = $GLOBALS['TSFE']->id ?? 0;
-		}
+        if (!$pid_list && !$this->allPages) {
+            $pid_list = $GLOBALS['TSFE']->id ?? 0;
+        }
 
-		if ($recursive && !$this->allPages) {
-			// get pid-list if recursivity is enabled
-			$recursive = intval($recursive);
-			$this->recursive = $recursive;
-			$pidSubArray = [];
+        if ($recursive && !$this->allPages) {
+            // get pid-list if recursivity is enabled
+            $recursive = intval($recursive);
+            $this->recursive = $recursive;
+            $pidSubArray = [];
 
-			$pid_list_arr = explode(',', $pid_list);
-			foreach ($pid_list_arr as $val) {
+            $pid_list_arr = explode(',', $pid_list);
+            foreach ($pid_list_arr as $val) {
                 $pidSub = $cObj->getTreeList($val, $recursive);
 
-				if ($pidSub != '') {
-					$pidSubArray[] = $pidSub;
-				}
-			}
+                if ($pidSub != '') {
+                    $pidSubArray[] = $pidSub;
+                }
+            }
 
-			$pid_list .= ',' . implode(',', $pidSubArray);
-			$pid_list_arr = explode(',', $pid_list);
-			$flippedArray = array_flip($pid_list_arr);
-			$pid_list_arr = array_keys($flippedArray);
-			sort($pid_list_arr, SORT_NUMERIC);
-			$pid_list = implode(',', $pid_list_arr);
-			$pid_list = preg_replace('/^,/', '', $pid_list);
-		}
+            $pid_list .= ',' . implode(',', $pidSubArray);
+            $pid_list_arr = explode(',', $pid_list);
+            $flippedArray = array_flip($pid_list_arr);
+            $pid_list_arr = array_keys($flippedArray);
+            sort($pid_list_arr, SORT_NUMERIC);
+            $pid_list = implode(',', $pid_list_arr);
+            $pid_list = preg_replace('/^,/', '', $pid_list);
+        }
 
-		if ($bStore) {
-			$this->pid_list = $pid_list;
-		}
-	}
+        if ($bStore) {
+            $this->pid_list = $pid_list;
+        }
+    }
 }
 
 

--- a/model/class.tx_ttproducts_product.php
+++ b/model/class.tx_ttproducts_product.php
@@ -45,174 +45,174 @@ use JambageCom\Div2007\Utility\SystemCategoryUtility;
 
 
 class tx_ttproducts_product extends tx_ttproducts_article_base {
-	public $marker = 'PRODUCT';
-	public $type = 'product';
-	public $piVar='product';
-	public $articleArray = [];
-	protected $tableAlias = 'product';
-	protected $allowedTypeArray =
-			[
-				'accessories',
-				'articles',
+    public $marker = 'PRODUCT';
+    public $type = 'product';
+    public $piVar='product';
+    public $articleArray = [];
+    protected $tableAlias = 'product';
+    protected $allowedTypeArray =
+            [
+                'accessories',
+                'articles',
                 'all_downloads',
-				'complete_downloads',
-				'partial_downloads',
-				'products',
-				'productsbysystemcategory'
-			];
+                'complete_downloads',
+                'partial_downloads',
+                'products',
+                'productsbysystemcategory'
+            ];
 
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init (
-		$functablename = 'tt_products'
-	) {
-		$result = parent::init($functablename);
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init (
+        $functablename = 'tt_products'
+    ) {
+        $result = parent::init($functablename);
 
-		if ($result) {
-			$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableConfig = [];
-			$tableConfig['orderBy'] = $cnfObj->conf['orderBy'] ?? '';
+        if ($result) {
+            $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableConfig = [];
+            $tableConfig['orderBy'] = $cnfObj->conf['orderBy'] ?? '';
 
-			if (!$tableConfig['orderBy']) {
-				$tableConfig['orderBy'] = $this->getOrderBy();
-			}
+            if (!$tableConfig['orderBy']) {
+                $tableConfig['orderBy'] = $this->getOrderBy();
+            }
 
-			$tableObj = $this->getTableObj();
-			$tableObj->setConfig($tableConfig);
-			$tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
-		}
+            $tableObj = $this->getTableObj();
+            $tableObj->setConfig($tableConfig);
+            $tableObj->addDefaultFieldArray(['sorting' => 'sorting']);
+        }
 
-		return $result;
-	} // init
-
-
-	public function fixTableConf (
-		&$tableConf
-	) {
-		if (
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')
-		) {
-			$eInfo = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
-
-			if (is_array($eInfo)) {
-				$sittVersion = $eInfo['version'];
-				if (version_compare($sittVersion, '0.3.0', '>=') && !empty($tableConf['requiredFields'])) {
-					$tableConf['requiredFields'] = str_replace(',tax,', ',tax_id,taxcat_id,', $tableConf['requiredFields']);
-				}
-			}
-		}
-	}
+        return $result;
+    } // init
 
 
-	public function getArticleRows (
-		$uid,
-		$whereArticle = '',
-		$orderBy = ''
-	) {
+    public function fixTableConf (
+        &$tableConf
+    ) {
+        if (
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')
+        ) {
+            $eInfo = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
+
+            if (is_array($eInfo)) {
+                $sittVersion = $eInfo['version'];
+                if (version_compare($sittVersion, '0.3.0', '>=') && !empty($tableConf['requiredFields'])) {
+                    $tableConf['requiredFields'] = str_replace(',tax,', ',tax_id,taxcat_id,', $tableConf['requiredFields']);
+                }
+            }
+        }
+    }
+
+
+    public function getArticleRows (
+        $uid,
+        $whereArticle = '',
+        $orderBy = ''
+    ) {
         $rowArray = [];
         if (isset($this->articleArray[$uid])) {
             $rowArray = $this->articleArray[$uid];
         }
 
-		if (
-			!$rowArray && $uid
-				||
-			$whereArticle != ''
-		) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$articleObj = $tablesObj->get('tt_products_articles');
-			$rowArray = $articleObj->getWhereArray($uid, $whereArticle, $orderBy);
+        if (
+            !$rowArray && $uid
+                ||
+            $whereArticle != ''
+        ) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $articleObj = $tablesObj->get('tt_products_articles');
+            $rowArray = $articleObj->getWhereArray($uid, $whereArticle, $orderBy);
 
-			if (!$whereArticle && empty($orderBy)) {
-				$this->articleArray[$uid] = $rowArray;
-			}
-		}
-		return $rowArray;
-	}
-
-
-	public function fillVariantsFromArticles (
-		&$row
-	) {
-		$articleRowArray = $this->getArticleRows($row['uid']);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$articleObj = $tablesObj->get('tt_products_articles');
-
-		if (is_array($articleRowArray) && count($articleRowArray)) {
-			// $articleObj->sortArticleRowsByUidArray($row['uid'],$articleRowArray);
-			$variantRow =
-				$this->variant->getVariantValuesByArticle(
-					$articleRowArray,
-					$row,
-					true
-				);
-			$selectableFieldArray =
-				$this->variant->getSelectableFieldArray();
-
-			foreach ($selectableFieldArray as $field) {
-				if (
-					$row[$field] == '' &&
-					!empty($variantRow[$field])
-				) {
-					$row[$field] = $variantRow[$field];
-				}
-			}
-		}
-	}
+            if (!$whereArticle && empty($orderBy)) {
+                $this->articleArray[$uid] = $rowArray;
+            }
+        }
+        return $rowArray;
+    }
 
 
-	public function getArticleRowsFromVariant (
-		$row,
-		$theCode,
-		$variant
-	) {
-		$articleRowArray = $this->getArticleRows(intval($row['uid']));
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$articleObj = $tablesObj->get('tt_products_articles');
+    public function fillVariantsFromArticles (
+        &$row
+    ) {
+        $articleRowArray = $this->getArticleRows($row['uid']);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $articleObj = $tablesObj->get('tt_products_articles');
 
-		$result = $this->variant->filterArticleRowsByVariant($row, $variant, $articleRowArray, true);
+        if (is_array($articleRowArray) && count($articleRowArray)) {
+            // $articleObj->sortArticleRowsByUidArray($row['uid'],$articleRowArray);
+            $variantRow =
+                $this->variant->getVariantValuesByArticle(
+                    $articleRowArray,
+                    $row,
+                    true
+                );
+            $selectableFieldArray =
+                $this->variant->getSelectableFieldArray();
 
-		return $result;
-	}
+            foreach ($selectableFieldArray as $field) {
+                if (
+                    $row[$field] == '' &&
+                    !empty($variantRow[$field])
+                ) {
+                    $row[$field] = $variantRow[$field];
+                }
+            }
+        }
+    }
 
 
-	public function getMatchingArticleRows (
-		$productRow,
-		$articleRows
-	) {
-		$fieldArray = [];
+    public function getArticleRowsFromVariant (
+        $row,
+        $theCode,
+        $variant
+    ) {
+        $articleRowArray = $this->getArticleRows(intval($row['uid']));
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $articleObj = $tablesObj->get('tt_products_articles');
 
-		$variant = $this->getVariant();
-		$variantSeparator = $variant->getSplitSeparator();
+        $result = $this->variant->filterArticleRowsByVariant($row, $variant, $articleRowArray, true);
 
-		foreach ($variant->conf as $k => $field) {
-			if (
+        return $result;
+    }
+
+
+    public function getMatchingArticleRows (
+        $productRow,
+        $articleRows
+    ) {
+        $fieldArray = [];
+
+        $variant = $this->getVariant();
+        $variantSeparator = $variant->getSplitSeparator();
+
+        foreach ($variant->conf as $k => $field) {
+            if (
                 isset($productRow[$field]) &&
                 strlen($productRow[$field]) &&
                 $field != $variant->additionalField
             ) {
 
 // 			[\h]+
-				$fieldArray[$field] =
-					preg_split(
-						'/[\h]*' . $variantSeparator . '[\h]*/',
-						$productRow[$field],
-						-1,
-						PREG_SPLIT_NO_EMPTY
-					);
-			}
-		}
+                $fieldArray[$field] =
+                    preg_split(
+                        '/[\h]*' . $variantSeparator . '[\h]*/',
+                        $productRow[$field],
+                        -1,
+                        PREG_SPLIT_NO_EMPTY
+                    );
+            }
+        }
 
-		$articleRow = [];
+        $articleRow = [];
 
-		if (count($fieldArray)) {
+        if (count($fieldArray)) {
 
-			$bFitArticleRowArray = [];
-			foreach ($articleRows as $k => $row) {
-				$bFits = true;
-				foreach ($fieldArray as $field => $valueArray) {
+            $bFitArticleRowArray = [];
+            foreach ($articleRows as $k => $row) {
+                $bFits = true;
+                foreach ($fieldArray as $field => $valueArray) {
                     $rowFieldArray = [];
                     if (isset($row[$field]) && strlen($row[$field])) {
                         $rowFieldArray =
@@ -224,207 +224,207 @@ class tx_ttproducts_product extends tx_ttproducts_article_base {
                             );
                         }
 
-					$intersectArray = array_intersect($valueArray, $rowFieldArray);
-					if (
-						isset($row[$field]) &&
-						strlen($row[$field]) &&
-						!count($intersectArray) &&
-						$field != 'additional'
-					) {
-						$bFits = false;
-						break;
-					}
-				}
-				if ($bFits) {
-					$bFitArticleRowArray[] = $row;
-				}
-			}
-			$articleCount = count($bFitArticleRowArray);
-			$articleRow = $bFitArticleRowArray[0];
+                    $intersectArray = array_intersect($valueArray, $rowFieldArray);
+                    if (
+                        isset($row[$field]) &&
+                        strlen($row[$field]) &&
+                        !count($intersectArray) &&
+                        $field != 'additional'
+                    ) {
+                        $bFits = false;
+                        break;
+                    }
+                }
+                if ($bFits) {
+                    $bFitArticleRowArray[] = $row;
+                }
+            }
+            $articleCount = count($bFitArticleRowArray);
+            $articleRow = $bFitArticleRowArray[0];
 
-			if ($articleCount > 1) {
-				// many articles fit here. So lets generated a merged article.
-				for ($i = 1; $i < $articleCount; $i++) {
-					$this->mergeAttributeFields(
-						$articleRow,
-						$bFitArticleRowArray[$i],
-						false,
-						true,
-						true,
-						'',
-						true
-					);
-				}
+            if ($articleCount > 1) {
+                // many articles fit here. So lets generated a merged article.
+                for ($i = 1; $i < $articleCount; $i++) {
+                    $this->mergeAttributeFields(
+                        $articleRow,
+                        $bFitArticleRowArray[$i],
+                        false,
+                        true,
+                        true,
+                        '',
+                        true
+                    );
+                }
 
-				if (isset($articleRow['ext'])) {
-					unset($articleRow['ext']);
-				}
-			}
-		}
+                if (isset($articleRow['ext'])) {
+                    unset($articleRow['ext']);
+                }
+            }
+        }
 
-		return $articleRow;
-	}
+        return $articleRow;
+    }
 
 
-	public function getArticleRow (
-		$row,
-		$theCode,
-		$bUsePreset = true
-	) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$fieldArray = $this->variant->getSelectableFieldArray();
-		$useArticles = $cnfObj->getUseArticles();
+    public function getArticleRow (
+        $row,
+        $theCode,
+        $bUsePreset = true
+    ) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $fieldArray = $this->variant->getSelectableFieldArray();
+        $useArticles = $cnfObj->getUseArticles();
 
-		$articleNo = false;
-		$articleRow = [];
-		$variantSeparator = $this->getVariant()->getSeparator();
-		$regexpDelimiter = tx_ttproducts_model_control::determineRegExpDelimiter($variantSeparator);
+        $articleNo = false;
+        $articleRow = [];
+        $variantSeparator = $this->getVariant()->getSeparator();
+        $regexpDelimiter = tx_ttproducts_model_control::determineRegExpDelimiter($variantSeparator);
 
-		if ($bUsePreset) {
-			$presetVariantArray =
-				tx_ttproducts_control_product::getPresetVariantArray(
-					$this,
-					$row,
-					$useArticles
-				);
+        if ($bUsePreset) {
+            $presetVariantArray =
+                tx_ttproducts_control_product::getPresetVariantArray(
+                    $this,
+                    $row,
+                    $useArticles
+                );
 
             if (empty($presetVariantArray)) {
-				$articleNo = tx_ttproducts_control_product::getActiveArticleNo();
-			}
-		} else {
-			$presetVariantArray = [];
-		}
+                $articleNo = tx_ttproducts_control_product::getActiveArticleNo();
+            }
+        } else {
+            $presetVariantArray = [];
+        }
 
-		if ($articleNo === false) {
-			if (empty($presetVariantArray)) {
-				$currentRow = $this->getVariant()->getVariantRow($row);
-			} else {
-				$currentRow = $this->getVariant()->getVariantRow($row, $presetVariantArray);
-			}
-		} else {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$articleObj = $tablesObj->get('tt_products_articles');
+        if ($articleNo === false) {
+            if (empty($presetVariantArray)) {
+                $currentRow = $this->getVariant()->getVariantRow($row);
+            } else {
+                $currentRow = $this->getVariant()->getVariantRow($row, $presetVariantArray);
+            }
+        } else {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $articleObj = $tablesObj->get('tt_products_articles');
 
-			$articleRow = $articleObj->get($articleNo);
-			$variantRow =
-				$this->getVariant()->getVariantValuesByArticle(
-					[$articleRow],
-					$row,
-					true
-				);
-			$currentRow = array_merge($row, $variantRow);
-		}
+            $articleRow = $articleObj->get($articleNo);
+            $variantRow =
+                $this->getVariant()->getVariantValuesByArticle(
+                    [$articleRow],
+                    $row,
+                    true
+                );
+            $currentRow = array_merge($row, $variantRow);
+        }
 
-		$whereArray = [];
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$articleObj = $tablesObj->get('tt_products_articles');
+        $whereArray = [];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $articleObj = $tablesObj->get('tt_products_articles');
 
-		foreach ($fieldArray as $k => $field) {
-			$value = trim($currentRow[$field]);
+        foreach ($fieldArray as $k => $field) {
+            $value = trim($currentRow[$field]);
 
-			$regexpValue =
-				$GLOBALS['TYPO3_DB']->quoteStr(
-					preg_quote($value),
-					$articleObj->getTablename()
-				);
+            $regexpValue =
+                $GLOBALS['TYPO3_DB']->quoteStr(
+                    preg_quote($value),
+                    $articleObj->getTablename()
+                );
 
-			$regexpValue = preg_replace('/' . preg_quote($variantSeparator) . '/', '|', $regexpValue);
+            $regexpValue = preg_replace('/' . preg_quote($variantSeparator) . '/', '|', $regexpValue);
 
-			if ($regexpValue != '') {
-				$whereClause =
-					$field . ' REGEXP \'^[[:blank:]]*(' . $regexpValue . ')[[:blank:]]*$\'' .
-					' OR ' . $field . ' REGEXP \'^[[:blank:]]*(' . $regexpValue . ')[[:blank:]]*[' . $regexpDelimiter . ']\'' .
-					' OR ' . $field . ' REGEXP \'[' . $regexpDelimiter . '][[:blank:]]*(' . $regexpValue . ')[[:blank:]]*$\'';
-				$whereArray[] = $whereClause;
-			} else if ($useArticles == 1) {
-				$whereClause = $field . '=\'\'';
-				$whereArray[] = $whereClause;
-			}
-		}
+            if ($regexpValue != '') {
+                $whereClause =
+                    $field . ' REGEXP \'^[[:blank:]]*(' . $regexpValue . ')[[:blank:]]*$\'' .
+                    ' OR ' . $field . ' REGEXP \'^[[:blank:]]*(' . $regexpValue . ')[[:blank:]]*[' . $regexpDelimiter . ']\'' .
+                    ' OR ' . $field . ' REGEXP \'[' . $regexpDelimiter . '][[:blank:]]*(' . $regexpValue . ')[[:blank:]]*$\'';
+                $whereArray[] = $whereClause;
+            } else if ($useArticles == 1) {
+                $whereClause = $field . '=\'\'';
+                $whereArray[] = $whereClause;
+            }
+        }
 
-		if (count($whereArray)) {
-			$where = '(' . implode (($useArticles == '3' ? ' OR ' : ' AND '), $whereArray) . ')';
-		} else {
-			$where = '';
-		}
-		$articleRows = $this->getArticleRows(intval($row['uid']), $where);
+        if (count($whereArray)) {
+            $where = '(' . implode (($useArticles == '3' ? ' OR ' : ' AND '), $whereArray) . ')';
+        } else {
+            $where = '';
+        }
+        $articleRows = $this->getArticleRows(intval($row['uid']), $where);
 
-		if (is_array($articleRows) && count($articleRows)) {
-			$articleRow = $this->getMatchingArticleRows($currentRow, $articleRows);
-			$articleConf = $cnfObj->getTableConf('tt_products_articles', $theCode);
+        if (is_array($articleRows) && count($articleRows)) {
+            $articleRow = $this->getMatchingArticleRows($currentRow, $articleRows);
+            $articleConf = $cnfObj->getTableConf('tt_products_articles', $theCode);
 
-			if (
-				$theCode &&
-				isset($articleConf['fieldIndex.']) &&
-				is_array($articleConf['fieldIndex.']) &&
-				isset($articleConf['fieldIndex.']['image.']) &&
-				is_array($articleConf['fieldIndex.']['image.'])
-			) {
-				$prodImageArray = GeneralUtility::trimExplode(',', $row['image']);
-				$artImageArray = GeneralUtility::trimExplode(',', $articleRow['image']);
-				$tmpDestArray = $prodImageArray;
-				foreach ($articleConf['fieldIndex.']['image.'] as $kImage => $vImage) {
-					$tmpDestArray[$vImage-1] = $artImageArray[$kImage - 1];
-				}
-				$articleRow['image'] = implode(',', $tmpDestArray);
-			}
-		}
-		return $articleRow;
-	}
+            if (
+                $theCode &&
+                isset($articleConf['fieldIndex.']) &&
+                is_array($articleConf['fieldIndex.']) &&
+                isset($articleConf['fieldIndex.']['image.']) &&
+                is_array($articleConf['fieldIndex.']['image.'])
+            ) {
+                $prodImageArray = GeneralUtility::trimExplode(',', $row['image']);
+                $artImageArray = GeneralUtility::trimExplode(',', $articleRow['image']);
+                $tmpDestArray = $prodImageArray;
+                foreach ($articleConf['fieldIndex.']['image.'] as $kImage => $vImage) {
+                    $tmpDestArray[$vImage-1] = $artImageArray[$kImage - 1];
+                }
+                $articleRow['image'] = implode(',', $tmpDestArray);
+            }
+        }
+        return $articleRow;
+    }
 
 
-	public function getRowFromExt (
-		$funcTablename,
-		$row,
-		$useArticles
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$priceRow = $row;
+    public function getRowFromExt (
+        $funcTablename,
+        $row,
+        $useArticles
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $priceRow = $row;
 
-		if (
-			in_array($useArticles, [1, 3]) &&
-			$funcTablename == 'tt_products' &&
-			isset($row['ext']['tt_products_articles']) &&
-			is_array($row['ext']['tt_products_articles'])
-		) {
-			$articleObj = $tablesObj->get('tt_products_articles');
-			reset($row['ext']['tt_products_articles']);
-			$articleInfo = current($row['ext']['tt_products_articles']);
-			$articleRowArray = [];
+        if (
+            in_array($useArticles, [1, 3]) &&
+            $funcTablename == 'tt_products' &&
+            isset($row['ext']['tt_products_articles']) &&
+            is_array($row['ext']['tt_products_articles'])
+        ) {
+            $articleObj = $tablesObj->get('tt_products_articles');
+            reset($row['ext']['tt_products_articles']);
+            $articleInfo = current($row['ext']['tt_products_articles']);
+            $articleRowArray = [];
 
-			foreach ($row['ext']['tt_products_articles'] as $extRow) {
+            foreach ($row['ext']['tt_products_articles'] as $extRow) {
 
-				if (!isset($extRow['uid'])) {
-					throw new RuntimeException('Invalid article row for product uid=' . $row['uid']  . ' .', 50006);
-				}
-				$articleRow = false;
-				$articleUid = $extRow['uid'];
+                if (!isset($extRow['uid'])) {
+                    throw new RuntimeException('Invalid article row for product uid=' . $row['uid']  . ' .', 50006);
+                }
+                $articleRow = false;
+                $articleUid = $extRow['uid'];
 
-				if (isset($articleUid)) {
-					$articleRow = $articleObj->get($articleUid);
+                if (isset($articleUid)) {
+                    $articleRow = $articleObj->get($articleUid);
 
-					$this->mergeAttributeFields(
-						$priceRow,
-						$articleRow,
-						false,
-						true,
-						true,
-						'',
-						false
-					);
-				}
+                    $this->mergeAttributeFields(
+                        $priceRow,
+                        $articleRow,
+                        false,
+                        true,
+                        true,
+                        '',
+                        false
+                    );
+                }
 
-				if ($articleRow) {
-					$priceRow['weight'] = (round($articleRow['weight'], 16) ? $articleRow['weight'] : $row['weight']);
-					$priceRow['inStock'] = $articleRow['inStock'];
-					$articleRowArray[] = $articleRow;
-				}
-			}
-			$priceRow['ext']['tt_products_articles'] = $articleRowArray;
-		}
+                if ($articleRow) {
+                    $priceRow['weight'] = (round($articleRow['weight'], 16) ? $articleRow['weight'] : $row['weight']);
+                    $priceRow['inStock'] = $articleRow['inStock'];
+                    $articleRowArray[] = $articleRow;
+                }
+            }
+            $priceRow['ext']['tt_products_articles'] = $articleRowArray;
+        }
 
-		return $priceRow;
-	}
+        return $priceRow;
+    }
 
 
     public function getArticleRowFromExt (
@@ -452,95 +452,95 @@ class tx_ttproducts_product extends tx_ttproducts_article_base {
 
 
 
-	public function getSystemCategories ($uid, $orderBy) {
-		$funcTablename = $this->getFuncTablename();
-		$fieldName = 'syscat';
+    public function getSystemCategories ($uid, $orderBy) {
+        $funcTablename = $this->getFuncTablename();
+        $fieldName = 'syscat';
 
-		$systemCategoryTablename = 'sys_category';
+        $systemCategoryTablename = 'sys_category';
 
-		$uidArray = [];
-		if (
-			MathUtility::canBeInterpretedAsInteger($uid)
-		) {
-			$uidArray = [$uid];
-		} else if (is_array($uid)) {
-			$uidArray = $uid;
-		}
+        $uidArray = [];
+        if (
+            MathUtility::canBeInterpretedAsInteger($uid)
+        ) {
+            $uidArray = [$uid];
+        } else if (is_array($uid)) {
+            $uidArray = $uid;
+        }
 
-		$categoryUids =
-			SystemCategoryUtility::getUids(
-				$funcTablename,
-				$fieldName,
-				$uidArray
-			);
+        $categoryUids =
+            SystemCategoryUtility::getUids(
+                $funcTablename,
+                $fieldName,
+                $uidArray
+            );
 
-		$productUids =
-			SystemCategoryUtility::getForeignUids(
-				$funcTablename,
-				$fieldName,
-				$categoryUids,
-				$orderBy
-			);
+        $productUids =
+            SystemCategoryUtility::getForeignUids(
+                $funcTablename,
+                $fieldName,
+                $categoryUids,
+                $orderBy
+            );
 
         $productUids = array_diff($productUids, $uidArray);
 
-		return $productUids;
-	}
+        return $productUids;
+    }
 
-	/* types:
-		'accessories' ... accessory products
-		'articles' ... related articles
-		'products' ... related products
-		returns the uids of the related products or articles
-	*/
-	public function getRelated (
-		&$parentFuncTablename,
-		&$parentRows,
+    /* types:
+        'accessories' ... accessory products
+        'articles' ... related articles
+        'products' ... related products
+        returns the uids of the related products or articles
+    */
+    public function getRelated (
+        &$parentFuncTablename,
+        &$parentRows,
         $multiOrderArray,
-		$uid,
-		$type,
-		$orderBy = ''
-	) {
-		$rcArray = [];
+        $uid,
+        $type,
+        $orderBy = ''
+    ) {
+        $rcArray = [];
         $rowArray = [];
-		$parentFuncTablename = '';
+        $parentFuncTablename = '';
 
-		if (
-			in_array($type, $this->allowedTypeArray)
-		) {
-			if ($type == 'articles') {
-				$relatedArticles = $this->getArticleRows($uid, '', $orderBy);
+        if (
+            in_array($type, $this->allowedTypeArray)
+        ) {
+            if ($type == 'articles') {
+                $relatedArticles = $this->getArticleRows($uid, '', $orderBy);
 
-				if (is_array($relatedArticles) && ($relatedArticles)) {
-					$rowArray = [];
-					foreach ($relatedArticles as $k => $articleRow) {
-						$rcArray[] = $articleRow['uid'];
-					}
-				}
-			} else {
-				if ($uid) {
-					if ($type == 'productsbysystemcategory') {
-						$rcArray = $this->getSystemCategories($uid, $orderBy);
-					} else {
-						$mmTable = [
-							'accessories' => ['table' =>  'tt_products_accessory_products_products_mm'],
+                if (is_array($relatedArticles) && ($relatedArticles)) {
+                    $rowArray = [];
+                    foreach ($relatedArticles as $k => $articleRow) {
+                        $rcArray[] = $articleRow['uid'];
+                    }
+                }
+            } else {
+                if ($uid) {
+                    if ($type == 'productsbysystemcategory') {
+                        $rcArray = $this->getSystemCategories($uid, $orderBy);
+                    } else {
+                        $mmTable = [
+                            'accessories' => ['table' =>  'tt_products_accessory_products_products_mm'],
                             'all_downloads' => ['table' =>  'tt_products_products_mm_downloads'],
-							'complete_downloads' => ['table' =>  'tt_products_products_mm_downloads'],
-							'partial_downloads' => ['table' =>  'tt_products_products_mm_downloads'],
-							'products' => ['table' =>  'tt_products_related_products_products_mm']
-						];
+                            'complete_downloads' => ['table' =>  'tt_products_products_mm_downloads'],
+                            'partial_downloads' => ['table' =>  'tt_products_products_mm_downloads'],
+                            'products' => ['table' =>  'tt_products_related_products_products_mm']
+                        ];
 
-						$where_clause = '';
-						if (
-							MathUtility::canBeInterpretedAsInteger($uid)
-						) {
-							$where_clause = 'uid_local = ' . intval($uid);
-						} else if (is_array($uid)) {
-							$where_clause = 'uid_local IN (' . implode(',', $uid) . ')';
-						}
+                        $where_clause = '';
+                        if (
+                            MathUtility::canBeInterpretedAsInteger($uid)
+                        ) {
+                            $where_clause = 'uid_local = ' . intval($uid);
+                        } else if (is_array($uid)) {
+                            $where_clause = 'uid_local IN (' . implode(',', $uid) . ')';
+                        }
 
-						$falUidArray = [];
- 						$downloadUidArray = [];
+                        $falUidArray = [];
+                        $downloadUidArray = [];
                         if (
                             isset($multiOrderArray) &&
                             is_array($multiOrderArray) &&
@@ -572,67 +572,67 @@ class tx_ttproducts_product extends tx_ttproducts_article_base {
                             $where_clause .= ' AND uid_foreign IN(' . implode(',', $downloadUidArray) . ')';
                         }
 
-						$rowArray =
-							$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-								'*',
-								$mmTable[$type]['table'],
-								$where_clause,
-								'',
-								'sorting_foreign'
-							);
-					}
-				}
+                        $rowArray =
+                            $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                                '*',
+                                $mmTable[$type]['table'],
+                                $where_clause,
+                                '',
+                                'sorting_foreign'
+                            );
+                    }
+                }
 
-				if (
-					isset($rowArray) &&
-					is_array($rowArray) &&
-					!empty($rowArray)
-				) {
-					if (
+                if (
+                    isset($rowArray) &&
+                    is_array($rowArray) &&
+                    !empty($rowArray)
+                ) {
+                    if (
                         $type == 'all_downloads' ||
-						$type == 'complete_downloads' ||
-						$type == 'partial_downloads'
-					) {
+                        $type == 'complete_downloads' ||
+                        $type == 'partial_downloads'
+                    ) {
 
-						$uidArray = [];
-						foreach ($rowArray as $k => $row) {
-							$uidArray[] = $row['uid_foreign'];
-						}
-						$where_clause = 'uid IN (' . implode(',', $uidArray) . ')';
+                        $uidArray = [];
+                        foreach ($rowArray as $k => $row) {
+                            $uidArray[] = $row['uid_foreign'];
+                        }
+                        $where_clause = 'uid IN (' . implode(',', $uidArray) . ')';
 
-						if (
-							$type == 'complete_downloads'
-						) {
-							$where_clause .= 'AND edition=0';
-						} else if (
-							$type == 'partial_downloads'
-						) {
-							$where_clause .= 'AND edition=1';
-						}
+                        if (
+                            $type == 'complete_downloads'
+                        ) {
+                            $where_clause .= 'AND edition=0';
+                        } else if (
+                            $type == 'partial_downloads'
+                        ) {
+                            $where_clause .= 'AND edition=1';
+                        }
 
                         $parentFuncTablename = $tablename = 'tt_products_downloads';
-						$where_clause .=
-							\JambageCom\Div2007\Utility\TableUtility::enableFields(
-								$tablename
-							);
+                        $where_clause .=
+                            \JambageCom\Div2007\Utility\TableUtility::enableFields(
+                                $tablename
+                            );
 
                         $downloadRowArray =
-							$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-								'*',
-								$tablename,
-								$where_clause,
-								'',
-								$orderBy
-							);
-						$fileTablename = 'sys_file_reference';
-						$fileField = 'file_uid';
+                            $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                                '*',
+                                $tablename,
+                                $where_clause,
+                                '',
+                                $orderBy
+                            );
+                        $fileTablename = 'sys_file_reference';
+                        $fileField = 'file_uid';
 
-						$enable_where_clause = \JambageCom\Div2007\Utility\TableUtility::enableFields($fileTablename);
+                        $enable_where_clause = \JambageCom\Div2007\Utility\TableUtility::enableFields($fileTablename);
 
-						if (
-							isset($downloadRowArray) &&
-							is_array($downloadRowArray)
-						) {
+                        if (
+                            isset($downloadRowArray) &&
+                            is_array($downloadRowArray)
+                        ) {
                             $whereUid = '';
                             if (
                                 isset($falUidArray) &&
@@ -642,332 +642,332 @@ class tx_ttproducts_product extends tx_ttproducts_article_base {
                                 $whereUid = ' AND uid IN(' . implode(',', $falUidArray) . ')';
                             }
 
-							foreach ($downloadRowArray as $downloadRow) {
-								$uid = $downloadRow['uid'];
-								if ($downloadRow[$fileField]) {
-									$where_clause = 'uid_foreign=' . intval($uid) . ' AND tablenames="' . $tablename . '" AND fieldname="' . $fileField . '"';
+                            foreach ($downloadRowArray as $downloadRow) {
+                                $uid = $downloadRow['uid'];
+                                if ($downloadRow[$fileField]) {
+                                    $where_clause = 'uid_foreign=' . intval($uid) . ' AND tablenames="' . $tablename . '" AND fieldname="' . $fileField . '"';
 
-									$where_clause .= $enable_where_clause . $whereUid;
-									$fileRowArray =
-										$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-											'uid,uid_local,uid_foreign',
-											$fileTablename,
-											$where_clause,
-											'',
-											'sorting_foreign', // 'sorting'
-											'',
-											'uid_local'
-										);
+                                    $where_clause .= $enable_where_clause . $whereUid;
+                                    $fileRowArray =
+                                        $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                                            'uid,uid_local,uid_foreign',
+                                            $fileTablename,
+                                            $where_clause,
+                                            '',
+                                            'sorting_foreign', // 'sorting'
+                                            '',
+                                            'uid_local'
+                                        );
 
                                     if (
-										isset($fileRowArray) &&
-										is_array($fileRowArray)
-									) {
-										$downloadRow['childs'] = [];
-										foreach ($fileRowArray as $fileRow) {
-											$childUid = $fileRow['uid'];
-											$downloadRow['childs'][] = $childUid;
-											$rcArray[] = $childUid;
-										}
-									}
-									$parentRows[$uid] = $downloadRow;
-								}
-							}
-						}
-					} else {
-						foreach ($rowArray as $k => $row) {
-							$rcArray[] = $row['uid_foreign'];
-						}
-					}
-				}
-			}
-		}
+                                        isset($fileRowArray) &&
+                                        is_array($fileRowArray)
+                                    ) {
+                                        $downloadRow['childs'] = [];
+                                        foreach ($fileRowArray as $fileRow) {
+                                            $childUid = $fileRow['uid'];
+                                            $downloadRow['childs'][] = $childUid;
+                                            $rcArray[] = $childUid;
+                                        }
+                                    }
+                                    $parentRows[$uid] = $downloadRow;
+                                }
+                            }
+                        }
+                    } else {
+                        foreach ($rowArray as $k => $row) {
+                            $rcArray[] = $row['uid_foreign'];
+                        }
+                    }
+                }
+            }
+        }
 
-		return $rcArray;
-	}
-
-
-	// returns the Path of all categories above, separated by '/'
-	public function getPath ($uid) {
-		$rc = '';
-
-		return $rc;
-	}
+        return $rcArray;
+    }
 
 
-	/**
-	 * Reduces the instock value of the orderRecord with the sold items and returns the result
-	 *
-	 */
-	public function reduceInStockItems (
-		$itemArray,
-		$useArticles
-	) {
-		$instockTableArray = [];
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+    // returns the Path of all categories above, separated by '/'
+    public function getPath ($uid) {
+        $rc = '';
 
-		$instockField = $cnfObj->getTableDesc($this->getTableObj()->name, 'inStock');
-		$instockField = ($instockField ? $instockField : 'inStock');
-		if (
-			$this->getTableObj()->name == 'tt_products' ||
-			is_array($GLOBALS['TCA'][$this->getTableObj()->name]['columns']['inStock'])
-		) {
-			// Reduce inStock
-			if ($useArticles == 1) {
-				// loop over all items in the basket indexed by a sorting text
-				foreach ($itemArray as $sort => $actItemArray) {
-					foreach ($actItemArray as $k1 => $actItem) {
-						$row = $this->getArticleRow($actItem['rec'], $theCode);
-						if ($row) {
-							$tt_products_articles = $tablesObj->get('tt_products_articles');
-							$tt_products_articles->reduceInStock($row['uid'], $actItem['count']);
-							$instockTableArray['tt_products_articles'][$row['uid'] . ',' . $row['itemnumber'] . ',' .$row['title']] = intval($row[$instockField] - $actItem['count']);
-						}
-					}
-				}
-			}
-			// loop over all items in the basket indexed by a sorting text
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					if (!$this->hasAdditional($row,'alwaysInStock')) {
-						$this->reduceInStock($row['uid'], $actItem['count']);
-						$instockTableArray['tt_products'][$row['uid'] . ',' . $row['itemnumber'] . ',' . $row['title']] = intval($row[$instockField] - $actItem['count']);
-					}
-				}
-			}
-		}
-		return $instockTableArray;
-	}
+        return $rc;
+    }
 
 
-	/**
-	 * Returns true if the item has the $check value checked
-	 *
-	 */
-	public function hasAdditional (&$row, $check)  {
-		$hasAdditional = false;
-		if (isset($row['additional'])) {
-			$additional = GeneralUtility::xml2array($row['additional']);
-			$hasAdditional = \JambageCom\Div2007\Utility\FlexformUtility::get($additional, $check);
-		}
+    /**
+     * Reduces the instock value of the orderRecord with the sold items and returns the result
+     *
+     */
+    public function reduceInStockItems (
+        $itemArray,
+        $useArticles
+    ) {
+        $instockTableArray = [];
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		return $hasAdditional;
-	}
+        $instockField = $cnfObj->getTableDesc($this->getTableObj()->name, 'inStock');
+        $instockField = ($instockField ? $instockField : 'inStock');
+        if (
+            $this->getTableObj()->name == 'tt_products' ||
+            is_array($GLOBALS['TCA'][$this->getTableObj()->name]['columns']['inStock'])
+        ) {
+            // Reduce inStock
+            if ($useArticles == 1) {
+                // loop over all items in the basket indexed by a sorting text
+                foreach ($itemArray as $sort => $actItemArray) {
+                    foreach ($actItemArray as $k1 => $actItem) {
+                        $row = $this->getArticleRow($actItem['rec'], $theCode);
+                        if ($row) {
+                            $tt_products_articles = $tablesObj->get('tt_products_articles');
+                            $tt_products_articles->reduceInStock($row['uid'], $actItem['count']);
+                            $instockTableArray['tt_products_articles'][$row['uid'] . ',' . $row['itemnumber'] . ',' .$row['title']] = intval($row[$instockField] - $actItem['count']);
+                        }
+                    }
+                }
+            }
+            // loop over all items in the basket indexed by a sorting text
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    if (!$this->hasAdditional($row,'alwaysInStock')) {
+                        $this->reduceInStock($row['uid'], $actItem['count']);
+                        $instockTableArray['tt_products'][$row['uid'] . ',' . $row['itemnumber'] . ',' . $row['title']] = intval($row[$instockField] - $actItem['count']);
+                    }
+                }
+            }
+        }
+        return $instockTableArray;
+    }
 
 
-	public function addWhereCat (
-		$catObject,
-		$theCode,
-		$cat,
-		$categoryAnd,
-		$pid_list,
-		$bLeadingOperator = true
-	) {
-		$bOpenBracket = false;
-		$where = '';
+    /**
+     * Returns true if the item has the $check value checked
+     *
+     */
+    public function hasAdditional (&$row, $check)  {
+        $hasAdditional = false;
+        if (isset($row['additional'])) {
+            $additional = GeneralUtility::xml2array($row['additional']);
+            $hasAdditional = \JambageCom\Div2007\Utility\FlexformUtility::get($additional, $check);
+        }
 
-			// Call all addWhere hooks for categories at the end of this method
-		if (
+        return $hasAdditional;
+    }
+
+
+    public function addWhereCat (
+        $catObject,
+        $theCode,
+        $cat,
+        $categoryAnd,
+        $pid_list,
+        $bLeadingOperator = true
+    ) {
+        $bOpenBracket = false;
+        $where = '';
+
+            // Call all addWhere hooks for categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
-				$hookObj = GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addWhereCat')) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
+                $hookObj = GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addWhereCat')) {
                     $operator = '';
-					$whereNew =
-						$hookObj->addWhereCat(
-							$this,
-							$catObject,
-							$cat,
-							$where,
-							$operator,
-							$pid_list,
-							$catObject->getDepth($theCode),
-							$categoryAnd
-						);
-					if ($bLeadingOperator) {
-						$operator = ($operator ? $operator : 'OR');
-						$where .= ($whereNew ? ' ' . $operator . ' ' . $whereNew : '');
-					} else {
-						$where .= $whereNew;
-					}
-				}
-			}
-		} else {
-			$catArray = [];
-			$categoryAndArray = [];
+                    $whereNew =
+                        $hookObj->addWhereCat(
+                            $this,
+                            $catObject,
+                            $cat,
+                            $where,
+                            $operator,
+                            $pid_list,
+                            $catObject->getDepth($theCode),
+                            $categoryAnd
+                        );
+                    if ($bLeadingOperator) {
+                        $operator = ($operator ? $operator : 'OR');
+                        $where .= ($whereNew ? ' ' . $operator . ' ' . $whereNew : '');
+                    } else {
+                        $where .= $whereNew;
+                    }
+                }
+            }
+        } else {
+            $catArray = [];
+            $categoryAndArray = [];
 
-			if($cat || $cat == '0') {
-				$catArray = GeneralUtility::intExplode(',', $cat);
-			}
-			if($categoryAnd != '') {
-				$categoryAndArray = GeneralUtility::intExplode(',', $categoryAnd);
-			}
-			$newcatArray = array_merge($categoryAndArray, $catArray);
-			$newcatArray = array_unique($newcatArray);
+            if($cat || $cat == '0') {
+                $catArray = GeneralUtility::intExplode(',', $cat);
+            }
+            if($categoryAnd != '') {
+                $categoryAndArray = GeneralUtility::intExplode(',', $categoryAnd);
+            }
+            $newcatArray = array_merge($categoryAndArray, $catArray);
+            $newcatArray = array_unique($newcatArray);
 
-			if (count($newcatArray)) {
+            if (count($newcatArray)) {
 // 				$newcats = $newcatArray['0']; // only one category can be searched for
-				$newcats = implode(',', $newcatArray);
-				$where = 'category IN (' . $newcats . ')';
+                $newcats = implode(',', $newcatArray);
+                $where = 'category IN (' . $newcats . ')';
 
-				if ($bLeadingOperator) {
-					$where = ' AND ( ' . $where . ')';
-				}
-			}
-		}
+                if ($bLeadingOperator) {
+                    $where = ' AND ( ' . $where . ')';
+                }
+            }
+        }
 
-		return $where;
-	}
+        return $where;
+    }
 
 
-	public function addConfCat (
-		$catObject,
-		&$selectConf,
-		$aliasArray
-	) {
-		$tableNameArray = [];
+    public function addConfCat (
+        $catObject,
+        &$selectConf,
+        $aliasArray
+    ) {
+        $tableNameArray = [];
 
-			// Call all addWhere hooks for categories at the end of this method
-		if (
+            // Call all addWhere hooks for categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addConfCatProduct')) {
-					$newTablenames = $hookObj->addConfCatProduct($this, $catObject, $selectConf, $aliasArray);
-					if ($newTablenames != '') {
-						$tableNameArray[] = $newTablenames;
-					}
-				}
-			}
-		}
-		return implode(',', $tableNameArray);
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addConfCatProduct')) {
+                    $newTablenames = $hookObj->addConfCatProduct($this, $catObject, $selectConf, $aliasArray);
+                    if ($newTablenames != '') {
+                        $tableNameArray[] = $newTablenames;
+                    }
+                }
+            }
+        }
+        return implode(',', $tableNameArray);
+    }
 
 
-	public function addselectConfCat (
-		$catObject,
-		$cat,
-		&$selectConf
-	) {
-		$tableNameArray = [];
+    public function addselectConfCat (
+        $catObject,
+        $cat,
+        &$selectConf
+    ) {
+        $tableNameArray = [];
 
-			// Call all addWhere hooks for categories at the end of this method
-		if (
+            // Call all addWhere hooks for categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addselectConfCat')) {
-					$newTablenames = $hookObj->addselectConfCat($this, $catObject, $cat, $selectConf,$catObject->getDepth());
-					if ($newTablenames != '') {
-						$tableNameArray[] = $newTablenames;
-					}
-				}
-			}
-		}
-		return implode(',', $tableNameArray);
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addselectConfCat')) {
+                    $newTablenames = $hookObj->addselectConfCat($this, $catObject, $cat, $selectConf,$catObject->getDepth());
+                    if ($newTablenames != '') {
+                        $tableNameArray[] = $newTablenames;
+                    }
+                }
+            }
+        }
+        return implode(',', $tableNameArray);
+    }
 
 
-	public function getPageUidsCat ($cat) {
-		$uidArray = [];
+    public function getPageUidsCat ($cat) {
+        $uidArray = [];
 
-			// Call all addWhere hooks for categories at the end of this method
-		if (
+            // Call all addWhere hooks for categories at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'getPageUidsCat')) {
-					$hookObj->getPageUidsCat($this, $cat, $uidArray);
-				}
-			}
-		}
-		$uidArray = array_unique($uidArray);
-		return (implode(',', $uidArray));
-	}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['prodCategory'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'getPageUidsCat')) {
+                    $hookObj->getPageUidsCat($this, $cat, $uidArray);
+                }
+            }
+        }
+        $uidArray = array_unique($uidArray);
+        return (implode(',', $uidArray));
+    }
 
 
-	public function getProductField (
-		&$row,
-		$field
-	) {
-		return $row[$field];
-	}
+    public function getProductField (
+        &$row,
+        $field
+    ) {
+        return $row[$field];
+    }
 
 
-	public function getRequiredFields (
-		$theCode = ''
-	) {
-		$tableConf = $this->getTableConf($theCode);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    public function getRequiredFields (
+        $theCode = ''
+    ) {
+        $tableConf = $this->getTableConf($theCode);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		if (!empty($tableConf['requiredFields'])) {
-			$requiredFields = $tableConf['requiredFields'];
-		} else {
-			$requiredFields = 'uid,pid,category,price,price2,discount,discount_disable,directcost,tax,deposit';
-		}
-		$instockField = $cnfObj->getTableDesc($this->getFuncTablename(), 'inStock');
-		if ($instockField && empty($conf['alwaysInStock'])) {
-			$requiredFields = $requiredFields.','.$instockField;
-		}
-		$rc = $requiredFields;
-		return $rc;
-	}
+        if (!empty($tableConf['requiredFields'])) {
+            $requiredFields = $tableConf['requiredFields'];
+        } else {
+            $requiredFields = 'uid,pid,category,price,price2,discount,discount_disable,directcost,tax,deposit';
+        }
+        $instockField = $cnfObj->getTableDesc($this->getFuncTablename(), 'inStock');
+        if ($instockField && empty($conf['alwaysInStock'])) {
+            $requiredFields = $requiredFields.','.$instockField;
+        }
+        $rc = $requiredFields;
+        return $rc;
+    }
 
 
-	public function getTotalDiscount (
-		&$row,
-		$pid = 0
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    public function getTotalDiscount (
+        &$row,
+        $pid = 0
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		if (
-			$this->getFuncTablename() == 'tt_products' &&
-			isset($this->conf['discountFieldMode']) &&
-			in_array(
-				$conf['discountFieldMode'],
-				['1', '2']
-			)
-		) {
-			$categoryfunctablename = 'tt_products_cat';
-			$categoryTable = $tablesObj->get($categoryfunctablename, false);
-			$discount = 0;
+        if (
+            $this->getFuncTablename() == 'tt_products' &&
+            isset($this->conf['discountFieldMode']) &&
+            in_array(
+                $conf['discountFieldMode'],
+                ['1', '2']
+            )
+        ) {
+            $categoryfunctablename = 'tt_products_cat';
+            $categoryTable = $tablesObj->get($categoryfunctablename, false);
+            $discount = 0;
 
-			switch ($conf['discountFieldMode']) {
-				case '1':
-					$catArray = $categoryTable->getCategoryArray($row, 'sorting');
-					$discount = $categoryTable->getMaxDiscount(
-						$row['discount'],
-						$row['discount_disable'],
-						$catArray,
-						$pid
-					);
-					break;
-				case '2':
-					$discount = $categoryTable->getFirstDiscount(
-						$row['discount'],
-						$row['discount_disable'],
-						$row['category'],
-						$pid
-					);
-					break;
-			}
+            switch ($conf['discountFieldMode']) {
+                case '1':
+                    $catArray = $categoryTable->getCategoryArray($row, 'sorting');
+                    $discount = $categoryTable->getMaxDiscount(
+                        $row['discount'],
+                        $row['discount_disable'],
+                        $catArray,
+                        $pid
+                    );
+                    break;
+                case '2':
+                    $discount = $categoryTable->getFirstDiscount(
+                        $row['discount'],
+                        $row['discount_disable'],
+                        $row['category'],
+                        $pid
+                    );
+                    break;
+            }
 
-			$discountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
-			$row[$discountField] = $discount;
-		}
-	}
+            $discountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
+            $row[$discountField] = $discount;
+        }
+    }
 }
 

--- a/model/class.tx_ttproducts_static_tax.php
+++ b/model/class.tx_ttproducts_static_tax.php
@@ -45,294 +45,294 @@ use JambageCom\Div2007\Utility\ExtensionUtility;
 
 
 class tx_ttproducts_static_tax extends tx_ttproducts_table_base {
-	protected $uidStore;
-	protected $setShopCountryCode;
-	private $allTaxesArray = [];
-	private $taxArray;
-	private $countryArray = [];
-	private $taxIdArray = [];
-	static private $isInstalled = false;
-	static private $need4StaticTax = false; // if the usage of static_info_tables_taxes is required due to some circumstances: E.g. if download products inside of the EU are sold
+    protected $uidStore;
+    protected $setShopCountryCode;
+    private $allTaxesArray = [];
+    private $taxArray;
+    private $countryArray = [];
+    private $taxIdArray = [];
+    static private $isInstalled = false;
+    static private $need4StaticTax = false; // if the usage of static_info_tables_taxes is required due to some circumstances: E.g. if download products inside of the EU are sold
 
-	/**
-	 * Getting all tt_products_cat categories into internal array
-	 */
-	public function init ($functablename) {
-		$result = false;
+    /**
+     * Getting all tt_products_cat categories into internal array
+     */
+    public function init ($functablename) {
+        $result = false;
 
-		if (self::isInstalled()) {
-			$result = parent::init($functablename);
-			if (!$result) {
-				return false;
-			}
-			$tablename = $this->getTablename();
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableconf = $cnf->getTableConf('static_taxes');
-			$this->getTableObj()->setDefaultFieldArray(['uid' => 'uid', 'pid' => 'pid']);
-			$this->getTableObj()->setTCAFieldArray('static_taxes');
+        if (self::isInstalled()) {
+            $result = parent::init($functablename);
+            if (!$result) {
+                return false;
+            }
+            $tablename = $this->getTablename();
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableconf = $cnf->getTableConf('static_taxes');
+            $this->getTableObj()->setDefaultFieldArray(['uid' => 'uid', 'pid' => 'pid']);
+            $this->getTableObj()->setTCAFieldArray('static_taxes');
 
-			$requiredFields = 'uid,pid';
-			if (!empty($this->tableconf['requiredFields']))	{
-				$tmp = $tableconf['requiredFields'];
-				$requiredFields = ($tmp ? $tmp : $requiredFields);
-			}
-			$requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$this->getTableObj()->setRequiredFieldArray($requiredListArray);
-		}
+            $requiredFields = 'uid,pid';
+            if (!empty($this->tableconf['requiredFields']))	{
+                $tmp = $tableconf['requiredFields'];
+                $requiredFields = ($tmp ? $tmp : $requiredFields);
+            }
+            $requiredListArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $this->getTableObj()->setRequiredFieldArray($requiredListArray);
+        }
 
-		return $result;
-	} // init
+        return $result;
+    } // init
 
-	public function initTaxes (
-		$infoArray,
-		$conf
-	) {
-		if (
-			isset($infoArray) &&
-			is_array($infoArray) &&
-			isset($infoArray['billing']) &&
-			isset($infoArray['billing']['country_code']) &&
-			isset($conf['TAXpercentage.'])
-		) {
-			$whereArray = [];
-			$taxRateArray = [];
-			$taxTitleArray = [];
+    public function initTaxes (
+        $infoArray,
+        $conf
+    ) {
+        if (
+            isset($infoArray) &&
+            is_array($infoArray) &&
+            isset($infoArray['billing']) &&
+            isset($infoArray['billing']['country_code']) &&
+            isset($conf['TAXpercentage.'])
+        ) {
+            $whereArray = [];
+            $taxRateArray = [];
+            $taxTitleArray = [];
 
-			foreach ($conf['TAXpercentage.'] as $key => $confArray) {
+            foreach ($conf['TAXpercentage.'] as $key => $confArray) {
 
-				$position = strpos($key, '.');
-				$index = substr($key, 0, $position);
-				$whereArray[$index] = $confArray['where.']['static_countries'];
-				$taxRateArray[$index] = $confArray['tax.']['tx_rate'];
-				$taxTitleArray[$index] = $confArray['tax.']['title'];
-			}
+                $position = strpos($key, '.');
+                $index = substr($key, 0, $position);
+                $whereArray[$index] = $confArray['where.']['static_countries'];
+                $taxRateArray[$index] = $confArray['tax.']['tx_rate'];
+                $taxTitleArray[$index] = $confArray['tax.']['title'];
+            }
 
-			$shippingCountryCode = $infoArray['billing']['country_code'];
-			if (
-				isset($infoArray['delivery']) &&
-				isset($infoArray['delivery']['country_code'])
-			) {
-				$shippingCountryCode = $infoArray['delivery']['country_code'];
-			}
+            $shippingCountryCode = $infoArray['billing']['country_code'];
+            if (
+                isset($infoArray['delivery']) &&
+                isset($infoArray['delivery']['country_code'])
+            ) {
+                $shippingCountryCode = $infoArray['delivery']['country_code'];
+            }
 
-			\JambageCom\StaticInfoTablesTaxes\Api\TaxApi::init(
-				$shopCountryCode = '',
-				$shopCountrySubdivisionCode = '',
-				$shippingCountryCode,
-				$shippingCountrySubdivisionCode = '',
-				$billingCountryCode = '',
-				$billingCountrySubdivisionCode = '',
-				$whereArray,
-				$taxRateArray,
-				$taxTitleArray
-			);
-		}
-	}
+            \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::init(
+                $shopCountryCode = '',
+                $shopCountrySubdivisionCode = '',
+                $shippingCountryCode,
+                $shippingCountrySubdivisionCode = '',
+                $billingCountryCode = '',
+                $billingCountrySubdivisionCode = '',
+                $whereArray,
+                $taxRateArray,
+                $taxTitleArray
+            );
+        }
+    }
 
-	static public function isInstalled () {
-		$result = self::$isInstalled;
+    static public function isInstalled () {
+        $result = self::$isInstalled;
 
-		if (
-			!$result &&
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')) {
-			$eInfo = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
+        if (
+            !$result &&
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables_taxes')) {
+            $eInfo = ExtensionUtility::getExtensionInfo('static_info_tables_taxes');
 
-			if (is_array($eInfo)) {
-				$sittVersion = $eInfo['version'];
-				if (version_compare($sittVersion, '0.3.0', '>=')) {
-					$result = self::$isInstalled = true;
-				}
-			}
-		}
+            if (is_array($eInfo)) {
+                $sittVersion = $eInfo['version'];
+                if (version_compare($sittVersion, '0.3.0', '>=')) {
+                    $result = self::$isInstalled = true;
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function isValid () {
-		$result = self::isInstalled() && !$this->needsInit() && $this->getUidStore();
-		return $result;
-	}
+    public function isValid () {
+        $result = self::isInstalled() && !$this->needsInit() && $this->getUidStore();
+        return $result;
+    }
 
-	public function getUidStore () {
-		return $this->uidStore;
-	}
+    public function getUidStore () {
+        return $this->uidStore;
+    }
 
-	public function setUidStore ($uid) {
-		$this->uidStore = $uid;
-	}
+    public function setUidStore ($uid) {
+        $this->uidStore = $uid;
+    }
 
-	public function getShopCountryCode () {
-		return $this->setShopCountryCode;
-	}
+    public function getShopCountryCode () {
+        return $this->setShopCountryCode;
+    }
 
-	public function setShopCountryCode ($setShopCountryCode) {
-		$this->setShopCountryCode = $setShopCountryCode;
-	}
+    public function setShopCountryCode ($setShopCountryCode) {
+        $this->setShopCountryCode = $setShopCountryCode;
+    }
 
-	public function setStoreData ($uidStore) {
-		if (self::isInstalled() && $uidStore > 0) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$orderAdressObj = $tablesObj->get('address', false);
-			$storeRow = $orderAdressObj->get($uidStore);
-			$theCountryCode = '';
+    public function setStoreData ($uidStore) {
+        if (self::isInstalled() && $uidStore > 0) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $orderAdressObj = $tablesObj->get('address', false);
+            $storeRow = $orderAdressObj->get($uidStore);
+            $theCountryCode = '';
 
-			if (!empty($storeRow)) {
-				$staticInfoCountryField = $orderAdressObj->getField('static_info_country');
-				if (
-					!isset($storeRow[$staticInfoCountryField]) &&
-					isset($storeRow['country'])
-				) {
-					$staticInfoCountryField = 'country';
-				}
-				$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-				$tableconf = $cnf->getTableConf('address');
+            if (!empty($storeRow)) {
+                $staticInfoCountryField = $orderAdressObj->getField('static_info_country');
+                if (
+                    !isset($storeRow[$staticInfoCountryField]) &&
+                    isset($storeRow['country'])
+                ) {
+                    $staticInfoCountryField = 'country';
+                }
+                $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+                $tableconf = $cnf->getTableConf('address');
 
-				if (
-					$tableconf['countryReference'] == 'uid' &&
-					MathUtility::canBeInterpretedAsInteger($storeRow[$staticInfoCountryField])
-				) {
-					$countryObj = $tablesObj->get('static_countries');
-					if (is_object($countryObj)) {
-						$countryRow = $countryObj->get($storeRow[$staticInfoCountryField]);
-						$theCountryCode = $countryRow['cn_iso_3'];
-					}
-				} else {
-					$theCountryCode = $storeRow[$staticInfoCountryField];
-				}
+                if (
+                    $tableconf['countryReference'] == 'uid' &&
+                    MathUtility::canBeInterpretedAsInteger($storeRow[$staticInfoCountryField])
+                ) {
+                    $countryObj = $tablesObj->get('static_countries');
+                    if (is_object($countryObj)) {
+                        $countryRow = $countryObj->get($storeRow[$staticInfoCountryField]);
+                        $theCountryCode = $countryRow['cn_iso_3'];
+                    }
+                } else {
+                    $theCountryCode = $storeRow[$staticInfoCountryField];
+                }
 
-				if ($theCountryCode != '') {
-					$zoneField = $orderAdressObj->getField('zone');
-					if ($tableconf['zoneReference'] == 'uid') {
-						$zoneArray =
-							$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-								'zn_code',
-								'static_country_zones',
-								'uid=' . intval($storeRow[$zoneField])
-							);
-						if (isset($zoneArray) && is_array($zoneArray) && isset($zoneArray[0])) {
-							$theZoneCode = $zoneArray[0]['zn_code'];
-						}
-					} else {
-						$theZoneCode = $storeRow[$zoneField];
-					}
-					$this->countryArray['shop'] = [];
-					$this->countryArray['shipping'] = [];
-					$this->countryArray['billing'] = [];
-					$this->countryArray['shop']['country_code'] = $theCountryCode;
-					$this->countryArray['shop']['zone'] = $theZoneCode;
-					$this->countryArray['shipping']['country_code'] = $theCountryCode;
-					$this->countryArray['shipping']['zone'] = $theZoneCode;
-					$this->countryArray['billing']['country_code'] = '';
-					$this->countryArray['billing']['zone'] = '';
-					$this->setUidStore($uidStore); // this must be done at the end of successful processing
-					$this->setShopCountryCode($theCountryCode);
-				}
-			}
+                if ($theCountryCode != '') {
+                    $zoneField = $orderAdressObj->getField('zone');
+                    if ($tableconf['zoneReference'] == 'uid') {
+                        $zoneArray =
+                            $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                                'zn_code',
+                                'static_country_zones',
+                                'uid=' . intval($storeRow[$zoneField])
+                            );
+                        if (isset($zoneArray) && is_array($zoneArray) && isset($zoneArray[0])) {
+                            $theZoneCode = $zoneArray[0]['zn_code'];
+                        }
+                    } else {
+                        $theZoneCode = $storeRow[$zoneField];
+                    }
+                    $this->countryArray['shop'] = [];
+                    $this->countryArray['shipping'] = [];
+                    $this->countryArray['billing'] = [];
+                    $this->countryArray['shop']['country_code'] = $theCountryCode;
+                    $this->countryArray['shop']['zone'] = $theZoneCode;
+                    $this->countryArray['shipping']['country_code'] = $theCountryCode;
+                    $this->countryArray['shipping']['zone'] = $theZoneCode;
+                    $this->countryArray['billing']['country_code'] = '';
+                    $this->countryArray['billing']['zone'] = '';
+                    $this->setUidStore($uidStore); // this must be done at the end of successful processing
+                    $this->setShopCountryCode($theCountryCode);
+                }
+            }
 /*			$allTaxesArray = [];
-			$this->getStaticTax($row,$tax,$allTaxesArray); // call it to set the member variables*/
-		}
-	}
+            $this->getStaticTax($row,$tax,$allTaxesArray); // call it to set the member variables*/
+        }
+    }
 
-	protected function didValuesChange (array $countryArray) {
-		if (
+    protected function didValuesChange (array $countryArray) {
+        if (
             is_array($this->countryArray['shipping']) && 
             count($this->countryArray['shipping'])
         ) {
-			$result = (
-				count(
-					array_diff_assoc($this->countryArray['shipping'], $countryArray['shipping'])
-				) > 0
-			);
-		} else {
-			$result = (is_array($countryArray['shipping']) && (count($countryArray['shipping']) > 0));
-		}
-		return $result;
-	}
+            $result = (
+                count(
+                    array_diff_assoc($this->countryArray['shipping'], $countryArray['shipping'])
+                ) > 0
+            );
+        } else {
+            $result = (is_array($countryArray['shipping']) && (count($countryArray['shipping']) > 0));
+        }
+        return $result;
+    }
 
-	public function setAllTaxesArray ($taxArray, $taxId = '') {
-		if ($taxId > 0) {
-			$this->allTaxesArray[$taxId] = $taxArray;
-		} else {
-			$this->allTaxesArray = $taxArray;
-		}
-	}
+    public function setAllTaxesArray ($taxArray, $taxId = '') {
+        if ($taxId > 0) {
+            $this->allTaxesArray[$taxId] = $taxArray;
+        } else {
+            $this->allTaxesArray = $taxArray;
+        }
+    }
 
-	public function getAllTaxesArray ($taxId = '') {
-		if ($taxId > 0) {
-			$result = $this->allTaxesArray[$taxId];
-		} else {
-			$result = $this->allTaxesArray;
-		}
-		return $result;
-	}
+    public function getAllTaxesArray ($taxId = '') {
+        if ($taxId > 0) {
+            $result = $this->allTaxesArray[$taxId];
+        } else {
+            $result = $this->allTaxesArray;
+        }
+        return $result;
+    }
 
-	public function setTax ($tax, $taxId) {
-		if ($taxId > 0) {
-			$this->taxArray[$taxId] = $tax;
-		}
-	}
+    public function setTax ($tax, $taxId) {
+        if ($taxId > 0) {
+            $this->taxArray[$taxId] = $tax;
+        }
+    }
 
-	public function getTaxArray ($taxId) {
-		$result = false;
-		if ($taxId > 0) {
-			$result = $this->taxArray[$taxId];
-		}
+    public function getTaxArray ($taxId) {
+        $result = false;
+        if ($taxId > 0) {
+            $result = $this->taxArray[$taxId];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function setTaxId ($taxId) {
-		$this->taxIdArray[] = $taxId;
-		$this->taxIdArray = array_unique($this->taxIdArray);
-	}
+    public function setTaxId ($taxId) {
+        $this->taxIdArray[] = $taxId;
+        $this->taxIdArray = array_unique($this->taxIdArray);
+    }
 
-	public function storeValues ($countryArray) {
-		$this->countryArray = $countryArray;
-	}
+    public function storeValues ($countryArray) {
+        $this->countryArray = $countryArray;
+    }
 
-	public function getCategoryArray ($uidArray) {
-		$result = [];
+    public function getCategoryArray ($uidArray) {
+        $result = [];
         $pageRepository = \JambageCom\Div2007\Utility\CompatibilityUtility::getPageRepository();
 
-		$isValid = true;
-		foreach ($uidArray as $uid) {
-			if (!MathUtility::canBeInterpretedAsInteger($uid)) {
-				$isValid = false;
-				$result = false;
-				break;
-			}
-		}
+        $isValid = true;
+        foreach ($uidArray as $uid) {
+            if (!MathUtility::canBeInterpretedAsInteger($uid)) {
+                $isValid = false;
+                $result = false;
+                break;
+            }
+        }
 
-		if ($isValid) {
-			$uids = implode(',', $uidArray);
-			$where = 'uid_local IN (' . $uids . ')' . $pageRepository->enableFields('tt_products_products_mm_tax_categories');
-			$rowArray =
-				$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-					'*',
-					'tt_products_products_mm_tax_categories',
-					$where
-				);
+        if ($isValid) {
+            $uids = implode(',', $uidArray);
+            $where = 'uid_local IN (' . $uids . ')' . $pageRepository->enableFields('tt_products_products_mm_tax_categories');
+            $rowArray =
+                $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                    '*',
+                    'tt_products_products_mm_tax_categories',
+                    $where
+                );
 
             if (
-				is_array($rowArray) &&
-				!empty($rowArray)
-			) {
-				foreach ($rowArray as $categoryRow) {
-					$result[] = $categoryRow['uid_foreign'];
-				}
-			}
-		}
+                is_array($rowArray) &&
+                !empty($rowArray)
+            ) {
+                foreach ($rowArray as $categoryRow) {
+                    $result[] = $categoryRow['uid_foreign'];
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getTaxInfo (
-		&$taxInfoArray,
-		&$shopCountryArray,
-		$tax,
-		array $uidArray,
-		array $basketRecs
-	) {
+    public function getTaxInfo (
+        &$taxInfoArray,
+        &$shopCountryArray,
+        $tax,
+        array $uidArray,
+        array $basketRecs
+    ) {
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
         } else {
@@ -340,255 +340,255 @@ class tx_ttproducts_static_tax extends tx_ttproducts_table_base {
         }
 
         $countryArray = $this->countryArray;
-		if (
-			!isset($countryArray['shop']) ||
-			$countryArray['shop']['country_code'] == ''
-		) {
-			return false;
-		}
+        if (
+            !isset($countryArray['shop']) ||
+            $countryArray['shop']['country_code'] == ''
+        ) {
+            return false;
+        }
 
-		if (
-			isset($basketRecs) &&
-			is_array($basketRecs) &&
-			!empty($basketRecs)
-		) {
-			$personInfo = $basketRecs['personinfo'];
-			$deliveryInfo = $basketRecs['delivery'];
-		}
+        if (
+            isset($basketRecs) &&
+            is_array($basketRecs) &&
+            !empty($basketRecs)
+        ) {
+            $personInfo = $basketRecs['personinfo'];
+            $deliveryInfo = $basketRecs['delivery'];
+        }
 
-		if (
-			isset($deliveryInfo) &&
-			is_array($deliveryInfo)
-		) {
-			$countryArray['shipping']['country_code'] =  $deliveryInfo['country_code'];
-			$countryArray['shipping']['zone'] = $deliveryInfo['zone'];
-		}
+        if (
+            isset($deliveryInfo) &&
+            is_array($deliveryInfo)
+        ) {
+            $countryArray['shipping']['country_code'] =  $deliveryInfo['country_code'];
+            $countryArray['shipping']['zone'] = $deliveryInfo['zone'];
+        }
 
-		if (
-			isset($personInfo) &&
-			is_array($personInfo)
-		) {
-			$countryArray['billing']['country_code'] =  $personInfo['country_code'];
-			$countryArray['billing']['zone'] = $personInfo['zone'];
-		}
-		$categoryArray = [];
-		if (!empty($uidArray)) {
- 			$categoryArray = $this->getCategoryArray($uidArray);
-		}
+        if (
+            isset($personInfo) &&
+            is_array($personInfo)
+        ) {
+            $countryArray['billing']['country_code'] =  $personInfo['country_code'];
+            $countryArray['billing']['zone'] = $personInfo['zone'];
+        }
+        $categoryArray = [];
+        if (!empty($uidArray)) {
+            $categoryArray = $this->getCategoryArray($uidArray);
+        }
 
-		$countryCode = '';
-		$zoneCode = '';
+        $countryCode = '';
+        $zoneCode = '';
 
-		$taxInfoArray =
-			\JambageCom\StaticInfoTablesTaxes\Api\TaxApi::fetchCountryTaxes(
-				$countryCode,
-				$zoneCode,
-				$staticInfoApi,
-				$tax,
-				$categoryArray,
-				-1,
-				$countryArray['shop']['country_code'],
-				$countryArray['shop']['zone'],
-				$countryArray['shipping']['country_code'],
-				$countryArray['shipping']['zone'],
-				$countryArray['billing']['country_code'],
-				$countryArray['billing']['zone'],
-				0,
-				true
-			);
-		$shopCountryArray = $countryArray['shop'];
-		return true;
-	}
+        $taxInfoArray =
+            \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::fetchCountryTaxes(
+                $countryCode,
+                $zoneCode,
+                $staticInfoApi,
+                $tax,
+                $categoryArray,
+                -1,
+                $countryArray['shop']['country_code'],
+                $countryArray['shop']['zone'],
+                $countryArray['shipping']['country_code'],
+                $countryArray['shipping']['zone'],
+                $countryArray['billing']['country_code'],
+                $countryArray['billing']['zone'],
+                0,
+                true
+            );
+        $shopCountryArray = $countryArray['shop'];
+        return true;
+    }
 
-	static public function setNeed4StaticTax ($value) {
-		self::$need4StaticTax = $value;
-	}
+    static public function setNeed4StaticTax ($value) {
+        self::$need4StaticTax = $value;
+    }
 
-	static public function getNeed4StaticTax () {
-		return self::$need4StaticTax;
-	}
+    static public function getNeed4StaticTax () {
+        return self::$need4StaticTax;
+    }
 
-	static public function need4StaticTax (
-		array $row
-	) {
-		if (self::getNeed4StaticTax()) {
-			return true;
-		}
+    static public function need4StaticTax (
+        array $row
+    ) {
+        if (self::getNeed4StaticTax()) {
+            return true;
+        }
 
-		$result = false;
+        $result = false;
 
-		if (
-			isset($row['ext']) &&
-			is_array($row['ext'])
-		) {
-			$extArray = $row['ext'];
-		}
+        if (
+            isset($row['ext']) &&
+            is_array($row['ext'])
+        ) {
+            $extArray = $row['ext'];
+        }
 
-		if (
-			self::isInstalled() &&
-			isset($extArray['records']) &&
-			is_array($extArray['records']) &&
-			isset($extArray['records']['tt_products_downloads']) &&
-			isset($extArray['records']['sys_file_reference'])
-		) {
-			$result = true;
-			self::setNeed4StaticTax(true);
-		}
+        if (
+            self::isInstalled() &&
+            isset($extArray['records']) &&
+            is_array($extArray['records']) &&
+            isset($extArray['records']['tt_products_downloads']) &&
+            isset($extArray['records']['sys_file_reference'])
+        ) {
+            $result = true;
+            self::setNeed4StaticTax(true);
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getStaticTax (
-		$basketRecs,
-		array $row,
-		&$tax,
-		&$taxInfoArray
-	) {
-		$extArray = [];
-		$categoryArray = [];
+    public function getStaticTax (
+        $basketRecs,
+        array $row,
+        &$tax,
+        &$taxInfoArray
+    ) {
+        $extArray = [];
+        $categoryArray = [];
 
-		if (
-			!empty($row) &&
-			$this->getUidStore() &&
-			self::isInstalled()
-		) {
-			if (
-				isset($basketRecs) &&
-				is_array($basketRecs) &&
-				!empty($basketRecs)
-			) {
-				$deliveryInfo = $basketRecs['delivery'];
-				$personInfo = $basketRecs['personinfo'];
-			}
-			$taxId = 0;
-			if (isset($row['tax_id'])) {
-				$taxId = intval($row['tax_id']);
-			}
-			$taxCatId = 0;
-			if (isset($row['taxcat_id'])) {
-				$taxCatId = intval($row['taxcat_id']);
-			}
+        if (
+            !empty($row) &&
+            $this->getUidStore() &&
+            self::isInstalled()
+        ) {
+            if (
+                isset($basketRecs) &&
+                is_array($basketRecs) &&
+                !empty($basketRecs)
+            ) {
+                $deliveryInfo = $basketRecs['delivery'];
+                $personInfo = $basketRecs['personinfo'];
+            }
+            $taxId = 0;
+            if (isset($row['tax_id'])) {
+                $taxId = intval($row['tax_id']);
+            }
+            $taxCatId = 0;
+            if (isset($row['taxcat_id'])) {
+                $taxCatId = intval($row['taxcat_id']);
+            }
 
-			if (
-				isset($row['ext']) &&
-				is_array($row['ext'])
-			) {
-				$extArray = $row['ext'];
-			}
+            if (
+                isset($row['ext']) &&
+                is_array($row['ext'])
+            ) {
+                $extArray = $row['ext'];
+            }
 
-			if (
-				isset($extArray['records']) &&
-				is_array($extArray['records']) &&
-				isset($extArray['records']['tt_products_downloads']) &&
-				isset($extArray['records']['sys_file_reference'])
-			) {
-				// TODO
-				$categoryArray[] = \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::EU_CATEGORY_DIGITAL_MEDIA_EBOOK;
-				// EU download media detected. This overwrites the tax class of the product, if available.
-			}
+            if (
+                isset($extArray['records']) &&
+                is_array($extArray['records']) &&
+                isset($extArray['records']['tt_products_downloads']) &&
+                isset($extArray['records']['sys_file_reference'])
+            ) {
+                // TODO
+                $categoryArray[] = \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::EU_CATEGORY_DIGITAL_MEDIA_EBOOK;
+                // EU download media detected. This overwrites the tax class of the product, if available.
+            }
 
-			if (
-				isset($this->countryArray['shop']['country_code']) &&
-				(
-					$taxId > 0 ||
-					$taxCatId > 0 ||
-					is_array($categoryArray) && count($categoryArray)
-				)
-			) {
-				$uid = $row['uid'];
-				$taxInfoArray = [];
+            if (
+                isset($this->countryArray['shop']['country_code']) &&
+                (
+                    $taxId > 0 ||
+                    $taxCatId > 0 ||
+                    is_array($categoryArray) && count($categoryArray)
+                )
+            ) {
+                $uid = $row['uid'];
+                $taxInfoArray = [];
                 if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
                     $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
                 } else {
                     $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\OldStaticInfoTablesApi::class);
                 }
-				$countryArray = $this->countryArray;
+                $countryArray = $this->countryArray;
 
-				if (isset($personInfo) && is_array($personInfo)) {
-					$countryArray['billing']['country_code'] = $personInfo['country_code'];
-					$countryArray['billing']['zone'] = $personInfo['zone'];
-				}
+                if (isset($personInfo) && is_array($personInfo)) {
+                    $countryArray['billing']['country_code'] = $personInfo['country_code'];
+                    $countryArray['billing']['zone'] = $personInfo['zone'];
+                }
 
-				if (isset($deliveryInfo) && is_array($deliveryInfo)) {
-					$countryArray['shipping']['country_code'] = $deliveryInfo['country_code'];
-					$countryArray['shipping']['zone'] = $deliveryInfo['zone'];
-				}
+                if (isset($deliveryInfo) && is_array($deliveryInfo)) {
+                    $countryArray['shipping']['country_code'] = $deliveryInfo['country_code'];
+                    $countryArray['shipping']['zone'] = $deliveryInfo['zone'];
+                }
 
-				if ($taxCatId && empty($categoryArray)) {
-					$categoryArray = $this->getCategoryArray([$uid]);
-				}
+                if ($taxCatId && empty($categoryArray)) {
+                    $categoryArray = $this->getCategoryArray([$uid]);
+                }
 
-				if (empty($categoryArray) && $taxId) {
-					$taxInfoArray = $this->getAllTaxesArray($taxId);
-				}
+                if (empty($categoryArray) && $taxId) {
+                    $taxInfoArray = $this->getAllTaxesArray($taxId);
+                }
 
-				if (
-					$this->didValuesChange($countryArray) ||
-					empty($taxInfoArray)
-				) {
-					$countryCode = '';
-					$zoneCode = '';
+                if (
+                    $this->didValuesChange($countryArray) ||
+                    empty($taxInfoArray)
+                ) {
+                    $countryCode = '';
+                    $zoneCode = '';
 
-					$taxInfoArray =
-						\JambageCom\StaticInfoTablesTaxes\Api\TaxApi::fetchCountryTaxes(
-							$countryCode,
-							$zoneCode,
-							$staticInfoApi,
-							0.0,
-							$categoryArray,
-							$taxId,
-							$countryArray['shop']['country_code'],
-							$countryArray['shop']['zone'],
-							$countryArray['shipping']['country_code'],
-							$countryArray['shipping']['zone'],
-							$countryArray['billing']['country_code'],
-							$countryArray['billing']['zone'],
-							0,
-							true
-						);
+                    $taxInfoArray =
+                        \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::fetchCountryTaxes(
+                            $countryCode,
+                            $zoneCode,
+                            $staticInfoApi,
+                            0.0,
+                            $categoryArray,
+                            $taxId,
+                            $countryArray['shop']['country_code'],
+                            $countryArray['shop']['zone'],
+                            $countryArray['shipping']['country_code'],
+                            $countryArray['shipping']['zone'],
+                            $countryArray['billing']['country_code'],
+                            $countryArray['billing']['zone'],
+                            0,
+                            true
+                        );
 
-					$this->storeValues(
-						$countryArray
-					);
+                    $this->storeValues(
+                        $countryArray
+                    );
 
-					if (empty($categoryArray) && $taxId) {
-						$this->setAllTaxesArray(
-							$taxInfoArray,
-							$taxId
-						);
-					}
-					$tax = 0.0;
+                    if (empty($categoryArray) && $taxId) {
+                        $this->setAllTaxesArray(
+                            $taxInfoArray,
+                            $taxId
+                        );
+                    }
+                    $tax = 0.0;
 
-					if (
-						isset($taxInfoArray) &&
-						is_array($taxInfoArray) &&
-						!empty($taxInfoArray) &&
-						isset($taxInfoArray[$countryCode]) &&
-						is_array($taxInfoArray[$countryCode])
-					) {
-						if (count($taxInfoArray) == 1) {
-							$taxRow = current($taxInfoArray[$countryCode]);
-							$tax = $taxRow['tx_rate'];
-						} else { // calculate together many taxes and use them as one single tax. (Canada)
-							$priceOne =
-								\JambageCom\StaticInfoTablesTaxes\Api\TaxApi::applyConsumerTaxes(
-									$taxInfoArray,
-									doubleval(1)
-								);
-							if ($priceOne !== false) {
-								$tax = ($priceOne - 1) * 100;
-							}
-						}
-					}
-					if (empty($categoryArray)) {
-						$this->setTax($tax, $taxId);
-					}
-				} else {
-					$tax = $this->getTaxArray($taxId);
-				}
-			}
-		}
-	}
+                    if (
+                        isset($taxInfoArray) &&
+                        is_array($taxInfoArray) &&
+                        !empty($taxInfoArray) &&
+                        isset($taxInfoArray[$countryCode]) &&
+                        is_array($taxInfoArray[$countryCode])
+                    ) {
+                        if (count($taxInfoArray) == 1) {
+                            $taxRow = current($taxInfoArray[$countryCode]);
+                            $tax = $taxRow['tx_rate'];
+                        } else { // calculate together many taxes and use them as one single tax. (Canada)
+                            $priceOne =
+                                \JambageCom\StaticInfoTablesTaxes\Api\TaxApi::applyConsumerTaxes(
+                                    $taxInfoArray,
+                                    doubleval(1)
+                                );
+                            if ($priceOne !== false) {
+                                $tax = ($priceOne - 1) * 100;
+                            }
+                        }
+                    }
+                    if (empty($categoryArray)) {
+                        $this->setTax($tax, $taxId);
+                    }
+                } else {
+                    $tax = $this->getTaxArray($taxId);
+                }
+            }
+        }
+    }
 }
 
 

--- a/model/class.tx_ttproducts_syscategory.php
+++ b/model/class.tx_ttproducts_syscategory.php
@@ -40,6 +40,6 @@
 
 
 class tx_ttproducts_syscategory extends tx_ttproducts_category {
-	protected $tableAlias = 'syscat';
+    protected $tableAlias = 'syscat';
 
 }

--- a/model/class.tx_ttproducts_table_base.php
+++ b/model/class.tx_ttproducts_table_base.php
@@ -43,81 +43,81 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 abstract class tx_ttproducts_table_base implements \TYPO3\CMS\Core\SingletonInterface {
-	protected $bHasBeenInitialised = false;
-	public $conf;
-	public $config;
-	public $tableObj;	// object of the type tx_table_db
-	public $defaultFieldArray = ['uid' => 'uid', 'pid' => 'pid']; // fields which must always be read in
-	public $relatedFromTableArray = [];
-	public $fieldArray = []; // field replacements
-	protected $insertRowArray;	// array of stored insert records
-	protected $insertKey;		// array for insertion
+    protected $bHasBeenInitialised = false;
+    public $conf;
+    public $config;
+    public $tableObj;	// object of the type tx_table_db
+    public $defaultFieldArray = ['uid' => 'uid', 'pid' => 'pid']; // fields which must always be read in
+    public $relatedFromTableArray = [];
+    public $fieldArray = []; // field replacements
+    protected $insertRowArray;	// array of stored insert records
+    protected $insertKey;		// array for insertion
 
-	protected $tableAlias;	// must be overridden
-	protected $dataArray;
-	protected $labelfieldname = 'title';
-	protected $enable = false;
-	private $functablename,
-		$tablename,
-		$tableConf,
-		$tableDesc,
-		$theCode,
-		$orderBy,
-		$fieldClassArray = array (
-			'ac_uid' => 'tx_ttproducts_field_foreign_table',
-			'crdate' => 'tx_ttproducts_field_datetime',
-			'creditpoints' => 'tx_ttproducts_field_creditpoints',
-			'datasheet' => 'tx_ttproducts_field_datafield',
-			'datasheet_uid' => 'tx_ttproducts_field_datafield',
-			'delivery' => 'tx_ttproducts_field_delivery',
-			'directcost' => 'tx_ttproducts_field_price',
-			'endtime' => 'tx_ttproducts_field_datetime',
-			'graduated_price_uid' => 'tx_ttproducts_field_graduated_price',
-			'image' => 'tx_ttproducts_field_image',
-			'image_uid' => 'tx_ttproducts_field_image',
-			'smallimage' => 'tx_ttproducts_field_image',
-			'smallimage_uid' => 'tx_ttproducts_field_image',
-			'itemnumber' => 'tx_ttproducts_field_text',
-			'note' => 'tx_ttproducts_field_note',
-			'note2' => 'tx_ttproducts_field_note',
-			'price' => 'tx_ttproducts_field_price',
-			'price2' => 'tx_ttproducts_field_price',
-			'sellendtime' => 'tx_ttproducts_field_datetime',
-			'sellstarttime' => 'tx_ttproducts_field_datetime',
-			'starttime' => 'tx_ttproducts_field_datetime',
-			'subtitle' => 'tx_ttproducts_field_text',
-			'tax' => 'tx_ttproducts_field_tax',
-			'title' => 'tx_ttproducts_field_text',
-			'tstamp' => 'tx_ttproducts_field_datetime',
-			'usebydate' => 'tx_ttproducts_field_datetime',
-		);
+    protected $tableAlias;	// must be overridden
+    protected $dataArray;
+    protected $labelfieldname = 'title';
+    protected $enable = false;
+    private $functablename,
+        $tablename,
+        $tableConf,
+        $tableDesc,
+        $theCode,
+        $orderBy,
+        $fieldClassArray = array (
+            'ac_uid' => 'tx_ttproducts_field_foreign_table',
+            'crdate' => 'tx_ttproducts_field_datetime',
+            'creditpoints' => 'tx_ttproducts_field_creditpoints',
+            'datasheet' => 'tx_ttproducts_field_datafield',
+            'datasheet_uid' => 'tx_ttproducts_field_datafield',
+            'delivery' => 'tx_ttproducts_field_delivery',
+            'directcost' => 'tx_ttproducts_field_price',
+            'endtime' => 'tx_ttproducts_field_datetime',
+            'graduated_price_uid' => 'tx_ttproducts_field_graduated_price',
+            'image' => 'tx_ttproducts_field_image',
+            'image_uid' => 'tx_ttproducts_field_image',
+            'smallimage' => 'tx_ttproducts_field_image',
+            'smallimage_uid' => 'tx_ttproducts_field_image',
+            'itemnumber' => 'tx_ttproducts_field_text',
+            'note' => 'tx_ttproducts_field_note',
+            'note2' => 'tx_ttproducts_field_note',
+            'price' => 'tx_ttproducts_field_price',
+            'price2' => 'tx_ttproducts_field_price',
+            'sellendtime' => 'tx_ttproducts_field_datetime',
+            'sellstarttime' => 'tx_ttproducts_field_datetime',
+            'starttime' => 'tx_ttproducts_field_datetime',
+            'subtitle' => 'tx_ttproducts_field_text',
+            'tax' => 'tx_ttproducts_field_tax',
+            'title' => 'tx_ttproducts_field_text',
+            'tstamp' => 'tx_ttproducts_field_datetime',
+            'usebydate' => 'tx_ttproducts_field_datetime',
+        );
 
-	public function init ($functablename) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->config = $cnf->getConfig();
-		$this->conf = $cnf->getConf();
+    public function init ($functablename) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->config = $cnf->getConfig();
+        $this->conf = $cnf->getConf();
 
-		$this->tableObj = GeneralUtility::makeInstance('tx_table_db');
-		$this->insertKey = 0;
+        $this->tableObj = GeneralUtility::makeInstance('tx_table_db');
+        $this->insertKey = 0;
 
-		$this->setFuncTablename($functablename);
-		$tablename = $cnf->getTableName($functablename);
-		$tablename = ($tablename ? $tablename : $functablename);
+        $this->setFuncTablename($functablename);
+        $tablename = $cnf->getTableName($functablename);
+        $tablename = ($tablename ? $tablename : $functablename);
 
-		if (!isset($GLOBALS['TCA'][$tablename])) {
-			debug ($tablename, 'Table not found in $GLOBALS[\'TCA\']: ' . $tablename . ' in file class.tx_ttproducts_table_base.php'); // keep this
-			$errorText = 'ERROR in the setup of "tt_products.table.' . $functablename . '": wrong table name "' . $tablename . '".';
-			$lastUnderscore = strrpos($tablename, '_');
-			$extName = substr($tablename, 0, $lastUnderscore);
-			if (strpos($extName, 'tx') === 0) {
-				$errorText .= '<br/>' . ' Consider to install the extension "' . $extName . '" or change this setup.';
-			}
-			debug ($errorText); // keep this
-			return false;
-		}
+        if (!isset($GLOBALS['TCA'][$tablename])) {
+            debug ($tablename, 'Table not found in $GLOBALS[\'TCA\']: ' . $tablename . ' in file class.tx_ttproducts_table_base.php'); // keep this
+            $errorText = 'ERROR in the setup of "tt_products.table.' . $functablename . '": wrong table name "' . $tablename . '".';
+            $lastUnderscore = strrpos($tablename, '_');
+            $extName = substr($tablename, 0, $lastUnderscore);
+            if (strpos($extName, 'tx') === 0) {
+                $errorText .= '<br/>' . ' Consider to install the extension "' . $extName . '" or change this setup.';
+            }
+            debug ($errorText); // keep this
+            return false;
+        }
 
-		$this->setTablename($tablename);
-		$this->tableDesc = $cnf->getTableDesc($functablename);
+        $this->setTablename($tablename);
+        $this->tableDesc = $cnf->getTableDesc($functablename);
 
         $checkDefaultFieldArray =
             [
@@ -130,8 +130,8 @@ abstract class tx_ttproducts_table_base implements \TYPO3\CMS\Core\SingletonInte
                 'tstamp' => 'tstamp'
             ];
 
-		if (isset($GLOBALS['TCA'][$tablename]['ctrl']) && is_array($GLOBALS['TCA'][$tablename]['ctrl'])) {
-			foreach ($checkDefaultFieldArray as $theField) {
+        if (isset($GLOBALS['TCA'][$tablename]['ctrl']) && is_array($GLOBALS['TCA'][$tablename]['ctrl'])) {
+            foreach ($checkDefaultFieldArray as $theField) {
                 if (
                         isset($GLOBALS['TCA'][$tablename]['ctrl'][$theField]) &&
                         isset($GLOBALS['TCA'][$tablename]['columns'][$theField]) &&
@@ -144,251 +144,251 @@ abstract class tx_ttproducts_table_base implements \TYPO3\CMS\Core\SingletonInte
                         in_array($theField, $GLOBALS['TCA'][$tablename]['ctrl']['enablecolumns'], true)
                     )
                 ) {
-					$this->defaultFieldArray[$theField] = $theField;
-				}
-			}
-		}
+                    $this->defaultFieldArray[$theField] = $theField;
+                }
+            }
+        }
 
-		if (isset($this->tableDesc) && is_array($this->tableDesc)) {
-			$this->fieldArray = array_merge($this->fieldArray, $this->tableDesc);
-		}
+        if (isset($this->tableDesc) && is_array($this->tableDesc)) {
+            $this->fieldArray = array_merge($this->fieldArray, $this->tableDesc);
+        }
 
-		$labelfieldname = $this->getLabelFieldname();
+        $labelfieldname = $this->getLabelFieldname();
 
-		$this->fieldArray[$labelfieldname] = (!empty($this->tableDesc['name']) && is_array($GLOBALS['TCA'][$this->tableDesc['name']]['ctrl']) ? $this->tableDesc['name'] : ($GLOBALS['TCA'][$tablename]['ctrl']['label'] ? $GLOBALS['TCA'][$tablename]['ctrl']['label'] : 'name'));
+        $this->fieldArray[$labelfieldname] = (!empty($this->tableDesc['name']) && is_array($GLOBALS['TCA'][$this->tableDesc['name']]['ctrl']) ? $this->tableDesc['name'] : ($GLOBALS['TCA'][$tablename]['ctrl']['label'] ? $GLOBALS['TCA'][$tablename]['ctrl']['label'] : 'name'));
 
-		$this->defaultFieldArray[$this->fieldArray[$labelfieldname]] = $this->fieldArray[$labelfieldname];
+        $this->defaultFieldArray[$this->fieldArray[$labelfieldname]] = $this->fieldArray[$labelfieldname];
 
-		if (isset($GLOBALS['TCA'][$tablename]['ctrl']['label_userFunc'])) {
-			$this->fieldArray[$labelfieldname] = 'userFunc:' . $GLOBALS['TCA'][$tablename]['ctrl']['label_userFunc'];
-		}
+        if (isset($GLOBALS['TCA'][$tablename]['ctrl']['label_userFunc'])) {
+            $this->fieldArray[$labelfieldname] = 'userFunc:' . $GLOBALS['TCA'][$tablename]['ctrl']['label_userFunc'];
+        }
 
-		if (
-			isset($this->defaultFieldArray) &&
-			is_array($this->defaultFieldArray) &&
-			count($this->defaultFieldArray)
-		) {
-			$this->tableObj->setDefaultFieldArray($this->defaultFieldArray);
-		}
+        if (
+            isset($this->defaultFieldArray) &&
+            is_array($this->defaultFieldArray) &&
+            count($this->defaultFieldArray)
+        ) {
+            $this->tableObj->setDefaultFieldArray($this->defaultFieldArray);
+        }
 
-		$this->tableObj->setName($tablename);
-		$this->tableConf = $this->getTableConf('');
-		$this->initCodeConf('ALL', $this->tableConf);
+        $this->tableObj->setName($tablename);
+        $this->tableConf = $this->getTableConf('');
+        $this->initCodeConf('ALL', $this->tableConf);
 
-		$this->tableObj->setTCAFieldArray($tablename, $this->tableAlias);
-		$this->tableObj->setNewFieldArray();
-		$this->bHasBeenInitialised = true;
-		$this->enable = true;
+        $this->tableObj->setTCAFieldArray($tablename, $this->tableAlias);
+        $this->tableObj->setNewFieldArray();
+        $this->bHasBeenInitialised = true;
+        $this->enable = true;
 
-		return true;
-	}
+        return true;
+    }
 
-	public function isEnabled () {
-		return $this->enable;
-	}
+    public function isEnabled () {
+        return $this->enable;
+    }
 
-	public function clear () {
-		$this->dataArray = [];
-	}
+    public function clear () {
+        $this->dataArray = [];
+    }
 
-	public function setLabelFieldname ($labelfieldname) {
-		$this->labelfieldname = $labelfieldname;
-	}
+    public function setLabelFieldname ($labelfieldname) {
+        $this->labelfieldname = $labelfieldname;
+    }
 
-	public function getLabelFieldname () {
-		return $this->labelfieldname;
-	}
+    public function getLabelFieldname () {
+        return $this->labelfieldname;
+    }
 
-	public function getField ($theField) {
-		$result = $theField;
-		if (isset($this->fieldArray[$theField])) {
-			$result = $this->fieldArray[$theField];
-		}
-		return $result;
-	}
+    public function getField ($theField) {
+        $result = $theField;
+        if (isset($this->fieldArray[$theField])) {
+            $result = $this->fieldArray[$theField];
+        }
+        return $result;
+    }
 
-	/* uid can be a string. Add a blank character to your uid integer if you want to have muliple rows as a result
-	*/
-	public function get (
-		$uid = '0',
-		$pid = 0,
-		$bStore = true,
-		$where_clause = '',
-		$groupBy = '',
-		$orderBy = '',
-		$limit = '',
-		$fields = '',
-		$bCount = false,
-		$aliasPostfix = '',
-		$bUseEnableFields = true,
-		$fallback = false
-	) {
-		$rc = false;
-		if (!$this->isEnabled()) {
-			return false;
-		}
+    /* uid can be a string. Add a blank character to your uid integer if you want to have muliple rows as a result
+    */
+    public function get (
+        $uid = '0',
+        $pid = 0,
+        $bStore = true,
+        $where_clause = '',
+        $groupBy = '',
+        $orderBy = '',
+        $limit = '',
+        $fields = '',
+        $bCount = false,
+        $aliasPostfix = '',
+        $bUseEnableFields = true,
+        $fallback = false
+    ) {
+        $rc = false;
+        if (!$this->isEnabled()) {
+            return false;
+        }
 
-		$tableObj = $this->getTableObj();
-		$alias = $this->getAlias() . $aliasPostfix;
+        $tableObj = $this->getTableObj();
+        $alias = $this->getAlias() . $aliasPostfix;
 
-		if (
-			MathUtility::canBeInterpretedAsInteger($uid) &&
-			isset($this->dataArray[$uid]) &&
-			is_array($this->dataArray[$uid]) &&
-			!$where_clause &&
-			!$fields
-		) {
-			if (!$pid || ($pid && $this->dataArray[$uid]['pid'] == $pid)) {
-				$rc = $this->dataArray[$uid];
-			} else {
-				$rc = [];
-			}
-		}
+        if (
+            MathUtility::canBeInterpretedAsInteger($uid) &&
+            isset($this->dataArray[$uid]) &&
+            is_array($this->dataArray[$uid]) &&
+            !$where_clause &&
+            !$fields
+        ) {
+            if (!$pid || ($pid && $this->dataArray[$uid]['pid'] == $pid)) {
+                $rc = $this->dataArray[$uid];
+            } else {
+                $rc = [];
+            }
+        }
 
-		if (!$rc) {
-			$enableFields = $tableObj->enableFields($aliasPostfix);
-			$where = '1=1';
+        if (!$rc) {
+            $enableFields = $tableObj->enableFields($aliasPostfix);
+            $where = '1=1';
 
-			if (is_int($uid)) {
-				$where .= ' AND ' . $alias . '.uid = ' . intval($uid);
-			} else if($uid) {
-				$uidArray = GeneralUtility::trimExplode(',', $uid);
-				foreach ($uidArray as $k => $v) {
-					$uidArray[$k] = intval($v);
-				}
-				$where .= ' AND ' . $alias . '.uid IN (' . implode(',', $uidArray) . ')';
-			}
+            if (is_int($uid)) {
+                $where .= ' AND ' . $alias . '.uid = ' . intval($uid);
+            } else if($uid) {
+                $uidArray = GeneralUtility::trimExplode(',', $uid);
+                foreach ($uidArray as $k => $v) {
+                    $uidArray[$k] = intval($v);
+                }
+                $where .= ' AND ' . $alias . '.uid IN (' . implode(',', $uidArray) . ')';
+            }
 
-			if ($pid) {
-				$pidArray = GeneralUtility::trimExplode(',', $pid);
-				foreach ($pidArray as $k => $v) {
-					$pidArray[$k] = intval($v);
-				}
-				$where .= ' AND ' . $alias . '.pid IN (' . implode(',', $pidArray) . ')';
-			}
+            if ($pid) {
+                $pidArray = GeneralUtility::trimExplode(',', $pid);
+                foreach ($pidArray as $k => $v) {
+                    $pidArray[$k] = intval($v);
+                }
+                $where .= ' AND ' . $alias . '.pid IN (' . implode(',', $pidArray) . ')';
+            }
 
-			if ($where_clause) {
-				if (strpos($where_clause, $enableFields) !== false) {
-					$bUseEnableFields = false;
-				}
-				$where .= ' AND ( ' . $where_clause . ' )';
-			}
+            if ($where_clause) {
+                if (strpos($where_clause, $enableFields) !== false) {
+                    $bUseEnableFields = false;
+                }
+                $where .= ' AND ( ' . $where_clause . ' )';
+            }
 
-			if ($bUseEnableFields) {
-				$where .= $enableFields;
-			}
+            if ($bUseEnableFields) {
+                $where .= $enableFields;
+            }
 
-			if (!$fields) {
-				if ($bCount) {
-					$fields = 'count(*)';
-				} else {
-					$fields = '*';
-				}
-			}
+            if (!$fields) {
+                if ($bCount) {
+                    $fields = 'count(*)';
+                } else {
+                    $fields = '*';
+                }
+            }
 
-			// Fetching the records
-			$res =
-				$tableObj->exec_SELECTquery(
-					$fields,
-					$where,
-					$groupBy,
-					$orderBy,
-					$limit,
-					'',
-					$aliasPostfix,
-					$fallback
-				);
+            // Fetching the records
+            $res =
+                $tableObj->exec_SELECTquery(
+                    $fields,
+                    $where,
+                    $groupBy,
+                    $orderBy,
+                    $limit,
+                    '',
+                    $aliasPostfix,
+                    $fallback
+                );
 
-			if ($res !== false) {
+            if ($res !== false) {
 
-				$rc = [];
+                $rc = [];
 
-				while ($dbRow = $GLOBALS['TYPO3_DB']->sql_fetch_row($res)) {
-					$row = [];
-					foreach ($dbRow as $index => $value) {
-						if ($res instanceof mysqli_result) {
-							$fieldObject = mysqli_fetch_field_direct($res, $index);
-							$field = $fieldObject->name;
-						} else {
-							$field = mysql_field_name($res, $index);
-						}
+                while ($dbRow = $GLOBALS['TYPO3_DB']->sql_fetch_row($res)) {
+                    $row = [];
+                    foreach ($dbRow as $index => $value) {
+                        if ($res instanceof mysqli_result) {
+                            $fieldObject = mysqli_fetch_field_direct($res, $index);
+                            $field = $fieldObject->name;
+                        } else {
+                            $field = mysql_field_name($res, $index);
+                        }
 
-						if (!isset($row[$field]) || !empty($value)) {
-							$row[$field] = $value;
-						}
-					}
+                        if (!isset($row[$field]) || !empty($value)) {
+                            $row[$field] = $value;
+                        }
+                    }
 
-					if (
-						!$fallback &&
-						is_array($tableObj->langArray) &&
-						isset($row['title']) &&
-						!empty($tableObj->langArray[$row['title']])
-					) {
-						$row['title'] = $tableObj->langArray[$row['title']];
-					}
+                    if (
+                        !$fallback &&
+                        is_array($tableObj->langArray) &&
+                        isset($row['title']) &&
+                        !empty($tableObj->langArray[$row['title']])
+                    ) {
+                        $row['title'] = $tableObj->langArray[$row['title']];
+                    }
 
-					if ($row && !empty($row['uid'])) {
-						$rc[$row['uid']] = $row;
-						if($bStore && $fields == '*') {
-							$this->dataArray[$row['uid']] = $row;
-						}
-					} else {
-						break;
-					}
-				}
+                    if ($row && !empty($row['uid'])) {
+                        $rc[$row['uid']] = $row;
+                        if($bStore && $fields == '*') {
+                            $this->dataArray[$row['uid']] = $row;
+                        }
+                    } else {
+                        break;
+                    }
+                }
 
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				if (
-					MathUtility::canBeInterpretedAsInteger($uid)
-				) {
-					reset($rc);
-					$rc = current ($rc);
-				}
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                if (
+                    MathUtility::canBeInterpretedAsInteger($uid)
+                ) {
+                    reset($rc);
+                    $rc = current ($rc);
+                }
 
-				if ($bCount && is_array($rc[0])) {
-					reset($rc[0]);
-					$rc = intval(current($rc[0]));
-				}
+                if ($bCount && is_array($rc[0])) {
+                    reset($rc[0]);
+                    $rc = intval(current($rc[0]));
+                }
 
-				if (!$rc) {
-					$rc = [];
-				}
-			} else {
-				$rc = false;
-			}
-		}
+                if (!$rc) {
+                    $rc = [];
+                }
+            } else {
+                $rc = false;
+            }
+        }
 
-		return $rc;
-	}
+        return $rc;
+    }
 
-	/**
-	 * Returns the label of the record, Usage in the following format:
-	 *
-	 * @param	array		$row: current record
-	 * @return	string		Label of the record
-	 */
-	public function getLabel ($row) {
+    /**
+     * Returns the label of the record, Usage in the following format:
+     *
+     * @param	array		$row: current record
+     * @return	string		Label of the record
+     */
+    public function getLabel ($row) {
 
-		return $row['title'];
-	}
+        return $row['title'];
+    }
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
 
-	public function destruct () {
-		$this->bHasBeenInitialised = false;
-	}
+    public function destruct () {
+        $this->bHasBeenInitialised = false;
+    }
 
-	public function getDefaultFieldArray () {
-		return $this->defaultFieldArray;
-	}
+    public function getDefaultFieldArray () {
+        return $this->defaultFieldArray;
+    }
 
-	public function getFieldClass ($fieldname) {
-		$class = '';
-		$result = false;
+    public function getFieldClass ($fieldname) {
+        $class = '';
+        $result = false;
 
-		$tablename = $this->getTablename();
+        $tablename = $this->getTablename();
 
         if (
             $fieldname &&
@@ -401,283 +401,283 @@ abstract class tx_ttproducts_table_base implements \TYPO3\CMS\Core\SingletonInte
                 is_array($GLOBALS['TCA'][$tablename]['columns'][$fieldname . '_uid'])
             )
         ) {
-			$funcTablename = $this->getFuncTablename();
+            $funcTablename = $this->getFuncTablename();
 
-			if (
-				isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass']) &&
-				is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass']) &&
-				isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename]) &&
-				is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename])
-			) {
-				foreach (
-					$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename] as
-						$extKey => $hookArray
-				) {
-					if (
-						\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey) &&
-						is_array($hookArray) &&
-						isset($hookArray[$fieldname])
-					) {
-						$class = $hookArray[$fieldname];
-					}
-				}
-			}
-			if (!$class && isset($this->fieldClassArray[$fieldname])) {
-				$class = $this->fieldClassArray[$fieldname];
-			}
+            if (
+                isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass']) &&
+                is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass']) &&
+                isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename]) &&
+                is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename])
+            ) {
+                foreach (
+                    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['fieldClass'][$funcTablename] as
+                        $extKey => $hookArray
+                ) {
+                    if (
+                        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey) &&
+                        is_array($hookArray) &&
+                        isset($hookArray[$fieldname])
+                    ) {
+                        $class = $hookArray[$fieldname];
+                    }
+                }
+            }
+            if (!$class && isset($this->fieldClassArray[$fieldname])) {
+                $class = $this->fieldClassArray[$fieldname];
+            }
 
-			$result = $class;
-		}
+            $result = $class;
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	public function getAlias () {
-		$tableObj = $this->getTableObj();
-		return $tableObj->getAlias();
-	}
+    public function getAlias () {
+        $tableObj = $this->getTableObj();
+        return $tableObj->getAlias();
+    }
 
-	public function getFuncTablename () {
-		return $this->functablename;
-	}
+    public function getFuncTablename () {
+        return $this->functablename;
+    }
 
-	private function setFuncTablename ($tablename) {
-		$this->functablename = $tablename;
-	}
+    private function setFuncTablename ($tablename) {
+        $this->functablename = $tablename;
+    }
 
-	public function getTablename () {
-		return $this->tablename;
-	}
+    public function getTablename () {
+        return $this->tablename;
+    }
 
-	private function setTablename ($tablename) {
-		$this->tablename = $tablename;
-	}
+    private function setTablename ($tablename) {
+        $this->tablename = $tablename;
+    }
 
-	public function getLangName () {
-		$tableObj = $this->getTableObj();
-		return $tableObj->getLangName();
-	}
+    public function getLangName () {
+        $tableObj = $this->getTableObj();
+        return $tableObj->getLangName();
+    }
 
-	public function getCode () {
-		return $this->theCode;
-	}
+    public function getCode () {
+        return $this->theCode;
+    }
 
-	public function setCode ($theCode) {
-		$this->theCode = $theCode;
-	}
+    public function setCode ($theCode) {
+        $this->theCode = $theCode;
+    }
 
-	public function getOrderBy () {
-		return $this->orderBy;
-	}
+    public function getOrderBy () {
+        return $this->orderBy;
+    }
 
-	/* initalisation for code dependant configuration */
-	public function initCodeConf (
-		$theCode,
-		$tableConf
-	) {
-		if ($theCode != $this->getCode()) {
-			$this->setCode($theCode);
-			if (
+    /* initalisation for code dependant configuration */
+    public function initCodeConf (
+        $theCode,
+        $tableConf
+    ) {
+        if ($theCode != $this->getCode()) {
+            $this->setCode($theCode);
+            if (
                 isset($tableConf['orderBy']) &&
                 $this->orderBy != $tableConf['orderBy']
             ) {
-				$this->orderBy = $tableConf['orderBy'];
-				$this->dataArray = [];
-			}
+                $this->orderBy = $tableConf['orderBy'];
+                $this->dataArray = [];
+            }
 
-			$requiredFields = $this->getRequiredFields($theCode);
-			$requiredFieldArray = GeneralUtility::trimExplode(',', $requiredFields);
-			$this->getTableObj()->setRequiredFieldArray($requiredFieldArray);
+            $requiredFields = $this->getRequiredFields($theCode);
+            $requiredFieldArray = GeneralUtility::trimExplode(',', $requiredFields);
+            $this->getTableObj()->setRequiredFieldArray($requiredFieldArray);
 
-			if (
+            if (
                 isset($tableConf['language.']) &&
                 isset($tableConf['language.']['type']) &&
-				$tableConf['language.']['type'] == 'field' &&
-				isset($tableConf['language.']['field.'])
-				) {
-				$addRequiredFields = [];
-				$addRequiredFields = $tableConf['language.']['field.'];
-				$this->getTableObj()->addRequiredFieldArray($addRequiredFields);
-			}
-			$tableObj = $this->getTableObj();
-			if ($this->bUseLanguageTable($tableConf)) {
-				$tableObj->setLanguage($this->config['LLkey']);
-				$tableObj->setLangName($tableConf['language.']['table']);
-				$tableObj->setTCAFieldArray($tableObj->getLangName(), $tableObj->getAlias().'lang', false);
-			}
-			if (
+                $tableConf['language.']['type'] == 'field' &&
+                isset($tableConf['language.']['field.'])
+                ) {
+                $addRequiredFields = [];
+                $addRequiredFields = $tableConf['language.']['field.'];
+                $this->getTableObj()->addRequiredFieldArray($addRequiredFields);
+            }
+            $tableObj = $this->getTableObj();
+            if ($this->bUseLanguageTable($tableConf)) {
+                $tableObj->setLanguage($this->config['LLkey']);
+                $tableObj->setLangName($tableConf['language.']['table']);
+                $tableObj->setTCAFieldArray($tableObj->getLangName(), $tableObj->getAlias().'lang', false);
+            }
+            if (
                 isset($tableConf['language.']) &&
                 isset($tableConf['language.']['type']) &&
                 $tableConf['language.']['type'] == 'csv'
             ) {
-				$tableObj->initLanguageFile($tableConf['language.']['file']);
-			}
+                $tableObj->initLanguageFile($tableConf['language.']['file']);
+            }
 
-			if (!empty($tableConf['language.']['marker.']['file'])) {
-				$tableObj->initMarkerFile($tableConf['language.']['marker.']['file']);
-			}
-		}
-	}
+            if (!empty($tableConf['language.']['marker.']['file'])) {
+                $tableObj->initMarkerFile($tableConf['language.']['marker.']['file']);
+            }
+        }
+    }
 
-	public function translateByFields (&$dataArray, $theCode) {
+    public function translateByFields (&$dataArray, $theCode) {
 
-		$langFieldArray = $this->getLanguageFieldArray($theCode);
+        $langFieldArray = $this->getLanguageFieldArray($theCode);
 
-		if (is_array($dataArray) && is_array($langFieldArray) && count($langFieldArray)) {
-			foreach ($dataArray as $uid => $row) {
-				foreach ($row as $field => $value) {
-					$realField = $langFieldArray[$field];
+        if (is_array($dataArray) && is_array($langFieldArray) && count($langFieldArray)) {
+            foreach ($dataArray as $uid => $row) {
+                foreach ($row as $field => $value) {
+                    $realField = $langFieldArray[$field];
 
-					if (isset($realField) && $realField != $field) {
-						$newValue = $dataArray[$uid][$realField];
-						if ($newValue != '') {
-							$dataArray[$uid][$field] = $newValue;
-						}
-					}
-				}
-			}
-		}
-	}
+                    if (isset($realField) && $realField != $field) {
+                        $newValue = $dataArray[$uid][$realField];
+                        if ($newValue != '') {
+                            $dataArray[$uid][$field] = $newValue;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	public function bUseLanguageTable ($tableConf) {
-		$rc = false;
+    public function bUseLanguageTable ($tableConf) {
+        $rc = false;
         $api =
             GeneralUtility::makeInstance(\JambageCom\Div2007\Api\Frontend::class);
         $sys_language_uid = $api->getLanguageId();
 
-		if (is_numeric($sys_language_uid)) {
-			if (
-				isset($tableConf['language.']) &&
-				isset($tableConf['language.']['type']) &&
-				$tableConf['language.']['type'] == 'table' &&
-				$sys_language_uid > 0
-			) {
-				$rc = true;
-			}
-		}
-		return $rc;
-	}
+        if (is_numeric($sys_language_uid)) {
+            if (
+                isset($tableConf['language.']) &&
+                isset($tableConf['language.']['type']) &&
+                $tableConf['language.']['type'] == 'table' &&
+                $sys_language_uid > 0
+            ) {
+                $rc = true;
+            }
+        }
+        return $rc;
+    }
 
-	public function fixTableConf (&$tableConf) {
-		// nothing. Override this for your table if needed
-	}
+    public function fixTableConf (&$tableConf) {
+        // nothing. Override this for your table if needed
+    }
 
-	public function getTableConf ($theCode = '') {
-		if ($theCode == '' && $this->getCode() != '') {
-			$result = $this->tableConf;
-		} else {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$result = $cnf->getTableConf($this->getFuncTablename(), $theCode);
-		}
-		$this->fixTableConf($result);
-		return $result;
-	}
+    public function getTableConf ($theCode = '') {
+        if ($theCode == '' && $this->getCode() != '') {
+            $result = $this->tableConf;
+        } else {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $result = $cnf->getTableConf($this->getFuncTablename(), $theCode);
+        }
+        $this->fixTableConf($result);
+        return $result;
+    }
 
-	public function setTableConf ($tableConf) {
-		$this->tableConf = $tableConf;
-	}
+    public function setTableConf ($tableConf) {
+        $this->tableConf = $tableConf;
+    }
 
-	public function getTableDesc () {
-		return $this->tableDesc;
-	}
+    public function getTableDesc () {
+        return $this->tableDesc;
+    }
 
-	public function setTableDesc ($tableDesc) {
-		$this->tableDesc = tableDesc;
-	}
+    public function setTableDesc ($tableDesc) {
+        $this->tableDesc = tableDesc;
+    }
 
-	public function getKeyFieldArray ($theCode = '') {
-		$tableConf = $this->getTableConf($theCode);
-		$rc = [];
-		if (isset($tableConf['keyfield.']) && is_array($tableConf['keyfield.'])) {
-			$rc = $tableConf['keyfield.'];
-		}
-		return $rc;
-	}
+    public function getKeyFieldArray ($theCode = '') {
+        $tableConf = $this->getTableConf($theCode);
+        $rc = [];
+        if (isset($tableConf['keyfield.']) && is_array($tableConf['keyfield.'])) {
+            $rc = $tableConf['keyfield.'];
+        }
+        return $rc;
+    }
 
-	public function getRequiredFields ($theCode = '') {
+    public function getRequiredFields ($theCode = '') {
 
-		$tableObj = $this->getTableObj();
-		$tablename = $this->getTablename();
-		$tableConf = $this->getTableConf($theCode);
-		$fields = '';
-		if (!empty($tableConf['requiredFields'])) {
-			$fields = $tableConf['requiredFields'];
-		} else {
-			$fields = 'uid,pid';
-		}
+        $tableObj = $this->getTableObj();
+        $tablename = $this->getTablename();
+        $tableConf = $this->getTableConf($theCode);
+        $fields = '';
+        if (!empty($tableConf['requiredFields'])) {
+            $fields = $tableConf['requiredFields'];
+        } else {
+            $fields = 'uid,pid';
+        }
 
-		$requiredFieldArray = [];
-		$defaultFieldArray = $tableObj->getDefaultFieldArray();
-		$noTcaFieldArray = $tableObj->getNoTcaFieldArray();
+        $requiredFieldArray = [];
+        $defaultFieldArray = $tableObj->getDefaultFieldArray();
+        $noTcaFieldArray = $tableObj->getNoTcaFieldArray();
 
-		$fieldArray = GeneralUtility::trimExplode(',', $fields);
+        $fieldArray = GeneralUtility::trimExplode(',', $fields);
 
-		if (is_array($fieldArray)) {
-			foreach ($fieldArray as $field) {
-				if (
-					in_array($field, $defaultFieldArray) ||
-					in_array($field, $noTcaFieldArray) ||
-					isset($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
-					is_array($GLOBALS['TCA'][$tablename]['columns'][$field])
-				) {
-					$requiredFieldArray[] = $field;
-				}
-			}
-		}
+        if (is_array($fieldArray)) {
+            foreach ($fieldArray as $field) {
+                if (
+                    in_array($field, $defaultFieldArray) ||
+                    in_array($field, $noTcaFieldArray) ||
+                    isset($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
+                    is_array($GLOBALS['TCA'][$tablename]['columns'][$field])
+                ) {
+                    $requiredFieldArray[] = $field;
+                }
+            }
+        }
 
-		$result = implode(',', $requiredFieldArray);
-		return $result;
-	}
+        $result = implode(',', $requiredFieldArray);
+        return $result;
+    }
 
-	public function getLanguageFieldArray ($theCode = '') {
+    public function getLanguageFieldArray ($theCode = '') {
 
-		$tableConf = $this->getTableConf($theCode);
-		if (is_array($tableConf['language.']) &&
-			$tableConf['language.']['type'] == 'field' &&
-			is_array($tableConf['language.']['field.'])
-		) {
-			$rc = $tableConf['language.']['field.'];
-		} else {
-			$rc = [];
-		}
-		return $rc;
-	}
+        $tableConf = $this->getTableConf($theCode);
+        if (is_array($tableConf['language.']) &&
+            $tableConf['language.']['type'] == 'field' &&
+            is_array($tableConf['language.']['field.'])
+        ) {
+            $rc = $tableConf['language.']['field.'];
+        } else {
+            $rc = [];
+        }
+        return $rc;
+    }
 
-	public function getTableObj () {
-		return $this->tableObj;
-	}
+    public function getTableObj () {
+        return $this->tableObj;
+    }
 
-	public function reset () {
-		$this->insertRowArray = [];
-		$this->setInsertKey(0);
-	}
+    public function reset () {
+        $this->insertRowArray = [];
+        $this->setInsertKey(0);
+    }
 
-	public function setInsertKey ($k) {
-		$this->insertKey = $k;
-	}
+    public function setInsertKey ($k) {
+        $this->insertKey = $k;
+    }
 
-	public function getInsertKey () {
-		return $this->insertKey;
-	}
+    public function getInsertKey () {
+        return $this->insertKey;
+    }
 
-	public function addInsertRow (
-		$row,
-		&$k = ''
-	) {
-		$bUseInsertKey = false;
+    public function addInsertRow (
+        $row,
+        &$k = ''
+    ) {
+        $bUseInsertKey = false;
 
-		if ($k == '') {
-			$k = $this->getInsertKey();
-			$bUseInsertKey = true;
-		}
-		$this->insertRowArray[$k++] = $row;
-		if ($bUseInsertKey) {
-			$this->setInsertKey($k);
-		}
-	}
+        if ($k == '') {
+            $k = $this->getInsertKey();
+            $bUseInsertKey = true;
+        }
+        $this->insertRowArray[$k++] = $row;
+        if ($bUseInsertKey) {
+            $this->setInsertKey($k);
+        }
+    }
 
-	public function getInsertRowArray () {
-		return $this->insertRowArray;
-	}
+    public function getInsertRowArray () {
+        return $this->insertRowArray;
+    }
 }
 

--- a/model/class.tx_ttproducts_table_label.php
+++ b/model/class.tx_ttproducts_table_label.php
@@ -41,49 +41,49 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class tx_ttproducts_table_label {
 
 
-	/**
-	 * Factory function which is called by label_userFunc. The function decides how to build the label.
-	 * The result is directly written to $params['title'], since this parameter is passed by reference.
-	 *
-	 * The function gets the label from the proper model.
-	 *
-	 * @param	array		$params: Parameters, passed by reference!
-	 * @param	object		$pObj: Parent object from the calling function, not used.
-	 * @return	string		The result is also written into $params['title']
-	 */
-	public function getLabel (
-		&$params,
-		$pObj
-	) {
-		// Only get labels for tt_products* tables
-		if (
-			!substr($params['table'], 0, 11) == 'tt_products' &&
-			!substr($params['table'], 0, 12) == 'sys_products'
-		) {
-			return '';
-		}
+    /**
+     * Factory function which is called by label_userFunc. The function decides how to build the label.
+     * The result is directly written to $params['title'], since this parameter is passed by reference.
+     *
+     * The function gets the label from the proper model.
+     *
+     * @param	array		$params: Parameters, passed by reference!
+     * @param	object		$pObj: Parent object from the calling function, not used.
+     * @return	string		The result is also written into $params['title']
+     */
+    public function getLabel (
+        &$params,
+        $pObj
+    ) {
+        // Only get labels for tt_products* tables
+        if (
+            !substr($params['table'], 0, 11) == 'tt_products' &&
+            !substr($params['table'], 0, 12) == 'sys_products'
+        ) {
+            return '';
+        }
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		// Init
-		$label = '';
-		$tablename = $params['table'];
-		$className = $tablesObj->gettableClass($tablename);
+        // Init
+        $label = '';
+        $tablename = $params['table'];
+        $className = $tablesObj->gettableClass($tablename);
 
-		// Get the label from the model
-		if ($className) {
-			$model = GeneralUtility::makeInstance($className);
-			$row =
-				$GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow('*', $tablename, 'uid=' . intval($params['row']['uid']));
-			$label = $model->getLabel($row);
-		}
+        // Get the label from the model
+        if ($className) {
+            $model = GeneralUtility::makeInstance($className);
+            $row =
+                $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow('*', $tablename, 'uid=' . intval($params['row']['uid']));
+            $label = $model->getLabel($row);
+        }
 
-		// Write new label back to the params-array (passed by reference)
-		if ($label != '') {
-			$params['title'] = $label;
-		}
+        // Write new label back to the params-array (passed by reference)
+        if ($label != '') {
+            $params['title'] = $label;
+        }
 
-		return $label;
-	}
+        return $label;
+    }
 }
 

--- a/model/class.tx_ttproducts_text.php
+++ b/model/class.tx_ttproducts_text.php
@@ -42,53 +42,53 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_text extends tx_ttproducts_table_base {
 
-	public function getChildUidArray (
-		$theCode,
-		$uid,
-		$tagMarkerArray,
-		$parenttable = 'tt_products'
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$functablename = $this->getFuncTablename();
-		$fallback = false;
-		$tableConf = $cnf->getTableConf($functablename, $theCode);
-		$fallback = $cnf->getFallback($tableConf);
+    public function getChildUidArray (
+        $theCode,
+        $uid,
+        $tagMarkerArray,
+        $parenttable = 'tt_products'
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $functablename = $this->getFuncTablename();
+        $fallback = false;
+        $tableConf = $cnf->getTableConf($functablename, $theCode);
+        $fallback = $cnf->getFallback($tableConf);
 
-		$resultArray = [];
-		$tagWhere = '';
+        $resultArray = [];
+        $tagWhere = '';
 
-		if (is_array($tagMarkerArray) && count($tagMarkerArray)) {
-			$tagMarkerArray = $GLOBALS['TYPO3_DB']->fullQuoteArray(
-				$tagMarkerArray,
-				$this->getTableObj()->getName()
-			);
-			$tags = implode(',',$tagMarkerArray);
-			$tagWhere = ' AND marker IN (' . $tags . ')';
-		}
+        if (is_array($tagMarkerArray) && count($tagMarkerArray)) {
+            $tagMarkerArray = $GLOBALS['TYPO3_DB']->fullQuoteArray(
+                $tagMarkerArray,
+                $this->getTableObj()->getName()
+            );
+            $tags = implode(',',$tagMarkerArray);
+            $tagWhere = ' AND marker IN (' . $tags . ')';
+        }
 
-		$where_clause = 'parentid = ' . intval($uid) . ' AND parenttable=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
-			$parenttable,
-			$this->getTableObj()->getName()
-		) .
-			$tagWhere;
+        $where_clause = 'parentid = ' . intval($uid) . ' AND parenttable=' . $GLOBALS['TYPO3_DB']->fullQuoteStr(
+            $parenttable,
+            $this->getTableObj()->getName()
+        ) .
+            $tagWhere;
 
-		$resultArray =
-			$this->get(
-				'',
-				'',
-				false,
-				$where_clause,
-				'', // $groupBy
-				'', // $orderBy
-				'', // $limit
-				'', // $fields
-				false, // $bCount
-				'', // $aliasPostfix
-				true, // $bUseEnableFields
-				$fallback
-			);
+        $resultArray =
+            $this->get(
+                '',
+                '',
+                false,
+                $where_clause,
+                '', // $groupBy
+                '', // $orderBy
+                '', // $limit
+                '', // $fields
+                false, // $bCount
+                '', // $aliasPostfix
+                true, // $bUseEnableFields
+                $fallback
+            );
 
-		return $resultArray;
-	}
+        return $resultArray;
+    }
 }
 

--- a/model/class.tx_ttproducts_variant_dummy.php
+++ b/model/class.tx_ttproducts_variant_dummy.php
@@ -38,97 +38,97 @@
 
 
 class tx_ttproducts_variant_dummy implements tx_ttproducts_variant_int, \TYPO3\CMS\Core\SingletonInterface {
-	private $selectableArray = [];
-	public $conf;	// reduced local conf
+    private $selectableArray = [];
+    public $conf;	// reduced local conf
 
-	/**
-	 * setting the local variables
-	 */
-	public function init ($itemTable, $tablename, $useArticles) {
-		return true;
-	} // init
+    /**
+     * setting the local variables
+     */
+    public function init ($itemTable, $tablename, $useArticles) {
+        return true;
+    } // init
 
-	/**
-	 * getting the articles for a product
-	 */
-	public function getUseArticles () {
-	}
+    /**
+     * getting the articles for a product
+     */
+    public function getUseArticles () {
+    }
 
-	public function getSeparator () {
-		return '---';
-	}
+    public function getSeparator () {
+        return '---';
+    }
 
-	public function getSplitSeparator () {
-		return '---';
-	}
+    public function getSplitSeparator () {
+        return '---';
+    }
 
-	public function getImplodeSeparator () {
-		return '---';
-	}
+    public function getImplodeSeparator () {
+        return '---';
+    }
 
-	/**
-	 * fills in the row fields from the variant extVar string
-	 *
-	 * @param	array		the row
-	 * @param	string	  variants separated by variantSeparator
-	 * @return  void
-	 * @access private
-	 * @see getVariantFromRow
-	 */
-	public function modifyRowFromVariant (&$row, $variant = '') {
-	}
+    /**
+     * fills in the row fields from the variant extVar string
+     *
+     * @param	array		the row
+     * @param	string	  variants separated by variantSeparator
+     * @return  void
+     * @access private
+     * @see getVariantFromRow
+     */
+    public function modifyRowFromVariant (&$row, $variant = '') {
+    }
 
-	/**
-	 * Returns the variant extVar string from the variant values in the row
-	 *
-	 * @param	array		the row
-	 * @return  string	  variants separated by variantSeparator
-	 * @access private
-	 * @see modifyRowFromVariant
-	 */
-	public function getVariantFromRow ($row) {
-	}
+    /**
+     * Returns the variant extVar string from the variant values in the row
+     *
+     * @param	array		the row
+     * @return  string	  variants separated by variantSeparator
+     * @access private
+     * @see modifyRowFromVariant
+     */
+    public function getVariantFromRow ($row) {
+    }
 
-	public function getVariantFromProductRow ($row, $variantRow, $useArticles) {
-	}
+    public function getVariantFromProductRow ($row, $variantRow, $useArticles) {
+    }
 
-	/**
-	 * Returns the variant extVar string from the incoming raw row into the basket
-	 *
-	 * @param	array	the basket raw row
-	 * @return  string	  variants separated by variantSeparator
-	 * @access private
-	 * @see modifyRowFromVariant
-	 */
-	public function getVariantFromRawRow ($row) {
-	}
+    /**
+     * Returns the variant extVar string from the incoming raw row into the basket
+     *
+     * @param	array	the basket raw row
+     * @return  string	  variants separated by variantSeparator
+     * @access private
+     * @see modifyRowFromVariant
+     */
+    public function getVariantFromRawRow ($row) {
+    }
 
-	public function getVariantRow($row = '', $varianArray = []) {
-	}
+    public function getVariantRow($row = '', $varianArray = []) {
+    }
 
-	public function getTableUid ($table, $uid) {
-		$rc = '|' . $table . '|' . $uid;
-		return $rc;
-	}
+    public function getTableUid ($table, $uid) {
+        $rc = '|' . $table . '|' . $uid;
+        return $rc;
+    }
 
-	public function getSelectableArray () {
-		return $this->selectableArray;
-	}
+    public function getSelectableArray () {
+        return $this->selectableArray;
+    }
 
-	public function getVariantValuesByArticle ($articleRowArray, $productRow, $withSemicolon = false) {
-	}
+    public function getVariantValuesByArticle ($articleRowArray, $productRow, $withSemicolon = false) {
+    }
 
-	public function filterArticleRowsByVariant($row, $variant, $articleRows, $bCombined = false) {
-	}
+    public function filterArticleRowsByVariant($row, $variant, $articleRows, $bCombined = false) {
+    }
 
-	public function getFieldArray () {
-	}
+    public function getFieldArray () {
+    }
 
-	public function getSelectableFieldArray () {
-		return $this->selectableFieldArray;
-	}
+    public function getSelectableFieldArray () {
+        return $this->selectableFieldArray;
+    }
 
-	public function getAdditionalKey () {
-	}
+    public function getAdditionalKey () {
+    }
 }
 

--- a/model/field/class.tx_ttproducts_field_base.php
+++ b/model/field/class.tx_ttproducts_field_base.php
@@ -41,36 +41,36 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 abstract class tx_ttproducts_field_base implements tx_ttproducts_field_int, \TYPO3\CMS\Core\SingletonInterface {
-	private $bHasBeenInitialised = false;
-	public $conf;		// original configuration
-	public $config;		// modified configuration
+    private $bHasBeenInitialised = false;
+    public $conf;		// original configuration
+    public $config;		// modified configuration
 
-	public function init () {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->conf;
-		$this->config = $cnf->config;
+    public function init () {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->conf;
+        $this->config = $cnf->config;
 
-		$this->bHasBeenInitialised = true;
-	}
+        $this->bHasBeenInitialised = true;
+    }
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
 
-	public function getFieldValue (
-		&$taxInfoArray,
-		array $row,
-		$fieldname,
-		$basketExtra = [],
-		$basketRecs = [],
-		$bEnableTaxZero = false
-	) {
-		$result = false;
+    public function getFieldValue (
+        &$taxInfoArray,
+        array $row,
+        $fieldname,
+        $basketExtra = [],
+        $basketRecs = [],
+        $bEnableTaxZero = false
+    ) {
+        $result = false;
 
-		if (isset($row[$fieldname])) {
-			$result = $row[$fieldname];
-		}
-		return $result;
-	}
+        if (isset($row[$fieldname])) {
+            $result = $row[$fieldname];
+        }
+        return $result;
+    }
 }
 

--- a/model/field/class.tx_ttproducts_field_creditpoints.php
+++ b/model/field/class.tx_ttproducts_field_creditpoints.php
@@ -43,92 +43,92 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class tx_ttproducts_field_creditpoints extends tx_ttproducts_field_base {
 
 
-	public function getBasketTotal () {
-		$rc = 0;
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$itemArray = $basketObj->getItemArray();
+    public function getBasketTotal () {
+        $rc = 0;
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $itemArray = $basketObj->getItemArray();
 
-		if (count($itemArray)) {
-			$pricefactor = 0;
-			$mode = 'normal';
-			if (
-				isset($this->conf['creditpoints.']) &&
-				isset($this->conf['creditpoints.']['mode'])
-			) {
-				$mode = $this->conf['creditpoints.']['mode'];
-				$pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($this->conf);
-			}
+        if (count($itemArray)) {
+            $pricefactor = 0;
+            $mode = 'normal';
+            if (
+                isset($this->conf['creditpoints.']) &&
+                isset($this->conf['creditpoints.']['mode'])
+            ) {
+                $mode = $this->conf['creditpoints.']['mode'];
+                $pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($this->conf);
+            }
 
-			$creditpointsTotal = 0;
-			// loop over all items in the basket indexed by a sort string
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					$count = $actItem['count'];
+            $creditpointsTotal = 0;
+            // loop over all items in the basket indexed by a sort string
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    $count = $actItem['count'];
 
-					if ($row['creditpoints'] > 0) {
+                    if ($row['creditpoints'] > 0) {
 
-						$creditpointsTotal += $row['creditpoints'] * $count;
-					} else if ($mode == 'auto' && $pricefactor) {
-						$creditpointsTotal += ($actItem['priceTax'] * $count) / $pricefactor;
-					}
-				}
-			}
-			$rc = $creditpointsTotal;
-		}
-		return $rc;
-	}
-
-
-	public function getBasketMissingCreditpoints ($addCreditpoints, &$missing, &$remaining) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$feuserTable = $tablesObj->get('fe_users', false);
-
-		$feuserCreditpoints = $feuserTable->getCreditpoints();
-		$creditpointsTotal = $this->getBasketTotal() + $addCreditpoints;
-		$missing = $creditpointsTotal - $feuserCreditpoints;
-		$missing = ($missing > 0 ? $missing : 0);
-		$remaining = $feuserCreditpoints - $creditpointsTotal;
-	}
+                        $creditpointsTotal += $row['creditpoints'] * $count;
+                    } else if ($mode == 'auto' && $pricefactor) {
+                        $creditpointsTotal += ($actItem['priceTax'] * $count) / $pricefactor;
+                    }
+                }
+            }
+            $rc = $creditpointsTotal;
+        }
+        return $rc;
+    }
 
 
-	public function getMissingCreditpoints ($fieldname, $row, &$missing, &$remaining) {
+    public function getBasketMissingCreditpoints ($addCreditpoints, &$missing, &$remaining) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $feuserTable = $tablesObj->get('fe_users', false);
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$feuserTable = $tablesObj->get('fe_users', false);
-
-		$creditpointsTotal = $this->getBasketTotal();
-		$feuserCreditpoints = $feuserTable->getCreditpoints();
-		$missing = $creditpointsTotal + $row[$fieldname] - $feuserCreditpoints;
-		$missing = ($missing > 0 ? $missing : 0);
-		$remaining = $feuserCreditpoints - $creditpointsTotal - $row[$fieldname];
-	}
+        $feuserCreditpoints = $feuserTable->getCreditpoints();
+        $creditpointsTotal = $this->getBasketTotal() + $addCreditpoints;
+        $missing = $creditpointsTotal - $feuserCreditpoints;
+        $missing = ($missing > 0 ? $missing : 0);
+        $remaining = $feuserCreditpoints - $creditpointsTotal;
+    }
 
 
-	/* reduces the amount of creditpoints of the FE user by the total amount of creditpoints from the products. */
-	/* It returns the number of creditpoints by which the account of the FE user has been reduced. false is if no FE user is logged in. */
-	public function pay () {
-		$rc = false;
-		if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
+    public function getMissingCreditpoints ($fieldname, $row, &$missing, &$remaining) {
+
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $feuserTable = $tablesObj->get('fe_users', false);
+
+        $creditpointsTotal = $this->getBasketTotal();
+        $feuserCreditpoints = $feuserTable->getCreditpoints();
+        $missing = $creditpointsTotal + $row[$fieldname] - $feuserCreditpoints;
+        $missing = ($missing > 0 ? $missing : 0);
+        $remaining = $feuserCreditpoints - $creditpointsTotal - $row[$fieldname];
+    }
+
+
+    /* reduces the amount of creditpoints of the FE user by the total amount of creditpoints from the products. */
+    /* It returns the number of creditpoints by which the account of the FE user has been reduced. false is if no FE user is logged in. */
+    public function pay () {
+        $rc = false;
+        if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
 //			$whereGeneral = '(fe_users_uid="'.$GLOBALS['TSFE']->fe_user->user['uid'].'" OR fe_users_uid=0) ';
 
-			$creditpointsTotal = $this->getBasketTotal();
+            $creditpointsTotal = $this->getBasketTotal();
 
-			if ($creditpointsTotal) {
-				$fieldsArrayFeUsers = [];
-				$fieldsArrayFeUsers['tt_products_creditpoints'] = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] - $creditpointsTotal;
-				if ($fieldsArrayFeUsers['tt_products_creditpoints'] < 0) {
-					$fieldsArrayFeUsers['tt_products_creditpoints'] = 0;
-					$rc = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
-				}
-				if ($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] != $fieldsArrayFeUsers['tt_products_creditpoints']) {
-					$GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] = $fieldsArrayFeUsers['tt_products_creditpoints']; // store it also for the global FE user data
-					$GLOBALS['TYPO3_DB']->exec_UPDATEquery('fe_users', 'uid=' . intval($GLOBALS['TSFE']->fe_user->user['uid']), $fieldsArrayFeUsers);
-					$rc = $creditpointsTotal;
-				}
-			}
-		}
-		return $rc;
-	}
+            if ($creditpointsTotal) {
+                $fieldsArrayFeUsers = [];
+                $fieldsArrayFeUsers['tt_products_creditpoints'] = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] - $creditpointsTotal;
+                if ($fieldsArrayFeUsers['tt_products_creditpoints'] < 0) {
+                    $fieldsArrayFeUsers['tt_products_creditpoints'] = 0;
+                    $rc = $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'];
+                }
+                if ($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] != $fieldsArrayFeUsers['tt_products_creditpoints']) {
+                    $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] = $fieldsArrayFeUsers['tt_products_creditpoints']; // store it also for the global FE user data
+                    $GLOBALS['TYPO3_DB']->exec_UPDATEquery('fe_users', 'uid=' . intval($GLOBALS['TSFE']->fe_user->user['uid']), $fieldsArrayFeUsers);
+                    $rc = $creditpointsTotal;
+                }
+            }
+        }
+        return $rc;
+    }
 }
 

--- a/model/field/class.tx_ttproducts_field_media.php
+++ b/model/field/class.tx_ttproducts_field_media.php
@@ -43,189 +43,189 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_field_media extends tx_ttproducts_field_base {
 
-	public function getDirname ($imageRow) {
-		if (
+    public function getDirname ($imageRow) {
+        if (
             isset($imageRow['file_mime_type']) &&
-			$imageRow['file_mime_type'] == 'image' &&
-			isset($imageRow['file_path'])
-		) {
-			$dirname = $imageRow['file_path'];
-		} else {
-			$dirname = ($this->conf['defaultImageDir'] ? $this->conf['defaultImageDir'] : ( $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['imageFolder'] ? $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['imageFolder'] . '/' : 'uploads/pics/'));
-		}
-		return $dirname;
-	}
+            $imageRow['file_mime_type'] == 'image' &&
+            isset($imageRow['file_path'])
+        ) {
+            $dirname = $imageRow['file_path'];
+        } else {
+            $dirname = ($this->conf['defaultImageDir'] ? $this->conf['defaultImageDir'] : ( $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['imageFolder'] ? $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['imageFolder'] . '/' : 'uploads/pics/'));
+        }
+        return $dirname;
+    }
 
 
-	public function getFileArray (
-		$tablename,
-		$imageRow,
-		$imageField,
-		$fal = true
-	) {
-		$fileArray = [];
+    public function getFileArray (
+        $tablename,
+        $imageRow,
+        $imageField,
+        $fal = true
+    ) {
+        $fileArray = [];
 
-		if (
-			strpos($imageField, '_uid') &&
-			isset($imageRow[$imageField])
-		) {
-			$theTablename = $tablename;
-			$where_clause = '1=1';
-			$skip = false;
-			$sysfileRowArray = [];
+        if (
+            strpos($imageField, '_uid') &&
+            isset($imageRow[$imageField])
+        ) {
+            $theTablename = $tablename;
+            $where_clause = '1=1';
+            $skip = false;
+            $sysfileRowArray = [];
 
-			if (
-				$tablename == 'tt_products' &&
-				isset($imageRow['ext']) &&
-				is_array($imageRow['ext']) &&
-				isset($imageRow['ext']['tt_products_articles']) &&
-				is_array($imageRow['ext']['tt_products_articles']) &&
-				!empty($imageRow['ext']['tt_products_articles'])
-			) {
-				$uidArray = [];
-				$theTablename = 'tt_products_articles';
-				foreach ($imageRow['ext']['tt_products_articles'] as $key => $row) {
-					if (isset($row['uid']) && $row['uid']) {
-						$uidArray[] = intval($row['uid']);
-					}
-				}
+            if (
+                $tablename == 'tt_products' &&
+                isset($imageRow['ext']) &&
+                is_array($imageRow['ext']) &&
+                isset($imageRow['ext']['tt_products_articles']) &&
+                is_array($imageRow['ext']['tt_products_articles']) &&
+                !empty($imageRow['ext']['tt_products_articles'])
+            ) {
+                $uidArray = [];
+                $theTablename = 'tt_products_articles';
+                foreach ($imageRow['ext']['tt_products_articles'] as $key => $row) {
+                    if (isset($row['uid']) && $row['uid']) {
+                        $uidArray[] = intval($row['uid']);
+                    }
+                }
 
-				if (count($uidArray)) {
-					$where_clause = 'uid_foreign IN (' . implode(',', $uidArray) . ') AND tablenames="' . $theTablename . '" AND fieldname="' . $imageField . '"' ;
-					$where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
-					$sysfileRowArray =
-						$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-							'*',
-							'sys_file_reference',
-							$where_clause,
-							'',
-							'sorting_foreign',
-							'',
-							'uid_local'
-						);
-				} else {
-					$skip = true;
-				}
-			}
+                if (count($uidArray)) {
+                    $where_clause = 'uid_foreign IN (' . implode(',', $uidArray) . ') AND tablenames="' . $theTablename . '" AND fieldname="' . $imageField . '"' ;
+                    $where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
+                    $sysfileRowArray =
+                        $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                            '*',
+                            'sys_file_reference',
+                            $where_clause,
+                            '',
+                            'sorting_foreign',
+                            '',
+                            'uid_local'
+                        );
+                } else {
+                    $skip = true;
+                }
+            }
 
-			if (
-				// if the article has no image then use the image of the product if present
-				empty($sysfileRowArray)
-			) {
-				if ($imageRow[$imageField]) {
-					$theTablename = $tablename;
-					$where_clause = 'uid_foreign=' . intval($imageRow['uid']) . ' AND tablenames="' . $theTablename . '" AND fieldname="' . $imageField . '"' ;
-					$where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
-					$sysfileRowArray =
-						$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-							'*',
-							'sys_file_reference',
-							$where_clause,
-							'',
-							'sorting_foreign',
-							'',
-							'uid_local'
-						);
-					$skip = false;
-				} else {
-					$skip = true;
-				}
-			}
+            if (
+                // if the article has no image then use the image of the product if present
+                empty($sysfileRowArray)
+            ) {
+                if ($imageRow[$imageField]) {
+                    $theTablename = $tablename;
+                    $where_clause = 'uid_foreign=' . intval($imageRow['uid']) . ' AND tablenames="' . $theTablename . '" AND fieldname="' . $imageField . '"' ;
+                    $where_clause .= \JambageCom\Div2007\Utility\TableUtility::enableFields('sys_file_reference');
+                    $sysfileRowArray =
+                        $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                            '*',
+                            'sys_file_reference',
+                            $where_clause,
+                            '',
+                            'sorting_foreign',
+                            '',
+                            'uid_local'
+                        );
+                    $skip = false;
+                } else {
+                    $skip = true;
+                }
+            }
 
-			if (
-				!$skip &&
-				!empty($sysfileRowArray)
-			) {
-				$storageRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
-				$storage = $storageRepository->findByUid(1);
+            if (
+                !$skip &&
+                !empty($sysfileRowArray)
+            ) {
+                $storageRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\StorageRepository');
+                $storage = $storageRepository->findByUid(1);
 
                 foreach($sysfileRowArray as $fileUid => $sysfileRow) {
                     $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
-					$fileObj = $resourceFactory->getFileReferenceObject($sysfileRow['uid']);
-					$fileInfo = $storage->getFileInfo($fileObj);
+                    $fileObj = $resourceFactory->getFileReferenceObject($sysfileRow['uid']);
+                    $fileInfo = $storage->getFileInfo($fileObj);
 
-					if ($fal) {
-						$fileArray[$sysfileRow['uid']] = array_merge($fileInfo, $sysfileRow);
-						$keepFields = ['title', 'description', 'alternative'];
-						foreach ($keepFields as $keepField) {
+                    if ($fal) {
+                        $fileArray[$sysfileRow['uid']] = array_merge($fileInfo, $sysfileRow);
+                        $keepFields = ['title', 'description', 'alternative'];
+                        foreach ($keepFields as $keepField) {
                             if (empty($sysfileRow[$keepField]) && !empty($fileInfo[$keepField])) {
                                 $fileArray[$sysfileRow['uid']][$keepField] = $fileInfo[$keepField];
                             }
-						}
-					} else {
-						$fileArray[] = 'fileadmin' . $fileInfo['identifier'];
-					}
-				}
-			}
-		} else {
-			$fileArray = ($imageRow[$imageField] ? explode(',', $imageRow[$imageField]) : []);
-			$tmp = count($fileArray);
+                        }
+                    } else {
+                        $fileArray[] = 'fileadmin' . $fileInfo['identifier'];
+                    }
+                }
+            }
+        } else {
+            $fileArray = ($imageRow[$imageField] ? explode(',', $imageRow[$imageField]) : []);
+            $tmp = count($fileArray);
 
-			if (
-				!$tmp &&
-				isset($imageRow['file_mime_type']) &&
-				$imageRow['file_mime_type'] == 'image'
-			) {
-				$fileArray = [$imageRow['file_name']];
-			}
-		}
+            if (
+                !$tmp &&
+                isset($imageRow['file_mime_type']) &&
+                $imageRow['file_mime_type'] == 'image'
+            ) {
+                $fileArray = [$imageRow['file_name']];
+            }
+        }
 
-		return $fileArray;
-	}
+        return $fileArray;
+    }
 
 
-	public function getMediaNum (
-		$functablename,
-		$fieldname,
-		$theCode
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableConf = $cnf->getTableConf($functablename, $theCode);
+    public function getMediaNum (
+        $functablename,
+        $fieldname,
+        $theCode
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableConf = $cnf->getTableConf($functablename, $theCode);
 
-		$mediaNum = $tableConf['limitImage'] ?? '';
-		if (!$mediaNum) {
-			$codeTypeArray = [	// Todo: make this configurable
-				'list' =>
-					[
-						'real' => ['SEARCH', 'MEMO'],
-						'part' => ['LIST', 'MENU'],
-						'num' => $this->conf['limitImage']
-					],
-				'basket' =>
-					[
-						'real' => ['OVERVIEW', 'BASKET', 'FINALIZE', 'INFO', 'PAYMENT', 'TRACKING', 'BILL', 'DELIVERY', 'EMAIL'],
-						'part' =>	[] ,
-						'num' => 1
-					],
-				'single' =>
-					[
-						'real' => [],
-						'part' => ['SINGLE'],
-						'num' => $this->conf['limitImageSingle']
-					]
-			];
+        $mediaNum = $tableConf['limitImage'] ?? '';
+        if (!$mediaNum) {
+            $codeTypeArray = [	// Todo: make this configurable
+                'list' =>
+                    [
+                        'real' => ['SEARCH', 'MEMO'],
+                        'part' => ['LIST', 'MENU'],
+                        'num' => $this->conf['limitImage']
+                    ],
+                'basket' =>
+                    [
+                        'real' => ['OVERVIEW', 'BASKET', 'FINALIZE', 'INFO', 'PAYMENT', 'TRACKING', 'BILL', 'DELIVERY', 'EMAIL'],
+                        'part' =>	[] ,
+                        'num' => 1
+                    ],
+                'single' =>
+                    [
+                        'real' => [],
+                        'part' => ['SINGLE'],
+                        'num' => $this->conf['limitImageSingle']
+                    ]
+            ];
 
-			foreach ($codeTypeArray as $type => $codeArray) {
-				$realArray = $codeArray['real'];
-				if (count ($realArray)) {
-					if (in_array($theCode, $realArray)) {
-						$mediaNum = $codeArray['num'];
-						break;
-					}
-				}
-				$partArray = $codeArray['part'];
-				if (count ($partArray)) {
-					foreach ($partArray as $k => $part) {
-						if (strpos($theCode, $part) !== false) {
-							$mediaNum = $codeArray['num'];
-							break;
-						}
-					}
-				}
-			}
-		}
+            foreach ($codeTypeArray as $type => $codeArray) {
+                $realArray = $codeArray['real'];
+                if (count ($realArray)) {
+                    if (in_array($theCode, $realArray)) {
+                        $mediaNum = $codeArray['num'];
+                        break;
+                    }
+                }
+                $partArray = $codeArray['part'];
+                if (count ($partArray)) {
+                    foreach ($partArray as $k => $part) {
+                        if (strpos($theCode, $part) !== false) {
+                            $mediaNum = $codeArray['num'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
 
-		return $mediaNum;
-	}
+        return $mediaNum;
+    }
 
 }

--- a/model/field/class.tx_ttproducts_field_price.php
+++ b/model/field/class.tx_ttproducts_field_price.php
@@ -44,863 +44,863 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 use \JambageCom\TtProducts\Model\Field\FieldInterface;
 
 class tx_ttproducts_field_price extends tx_ttproducts_field_base {
-	private $bHasBeenInitialised = false;
-	private $bTaxIncluded;	// if tax is already included in the price
-	private $taxMode;
-	public $priceConf; 	// price configuration
-	static protected $priceFieldArray = array (
-		'price',
-		'price2',
-		'pricetax',
-		'price2tax',
-		'priceonlytax',
-		'price2onlytax',
-		'pricenotax',
-		'price2notax',
-		'oldpricetax',
-		'oldpricenotax',
-		'unitpricetax',
-		'unitpricenotax',
-		'weightunitpricetax',
-		'weightunitpricenotax',
-		'pricetaxdiscount',
-		'pricenotaxdiscount',
-		'surcharge',
-		'surcharge2',
-		'surchargetax',
-		'surchargenotax',
-		'surcharge2tax',
-		'surcharge2notax',
-		'deposit',
-		'deposittax',
-		'depositnotax',
-		'discountbyproductpricetax',
-		'discountbyproductpricenotax',
-		'discountbyproductutax',
-		'discountbyproductunotax',
-		'discountbyproductwtax',
-		'discountbyproductwnotax',
-	);
+    private $bHasBeenInitialised = false;
+    private $bTaxIncluded;	// if tax is already included in the price
+    private $taxMode;
+    public $priceConf; 	// price configuration
+    static protected $priceFieldArray = array (
+        'price',
+        'price2',
+        'pricetax',
+        'price2tax',
+        'priceonlytax',
+        'price2onlytax',
+        'pricenotax',
+        'price2notax',
+        'oldpricetax',
+        'oldpricenotax',
+        'unitpricetax',
+        'unitpricenotax',
+        'weightunitpricetax',
+        'weightunitpricenotax',
+        'pricetaxdiscount',
+        'pricenotaxdiscount',
+        'surcharge',
+        'surcharge2',
+        'surchargetax',
+        'surchargenotax',
+        'surcharge2tax',
+        'surcharge2notax',
+        'deposit',
+        'deposittax',
+        'depositnotax',
+        'discountbyproductpricetax',
+        'discountbyproductpricenotax',
+        'discountbyproductutax',
+        'discountbyproductunotax',
+        'discountbyproductwtax',
+        'discountbyproductwnotax',
+    );
 
-	static protected $convertArray = [
-		'tax' => 'priceTax',
-		'notax' => 'priceNoTax',
-		'0tax' => 'price0Tax',
-		'0notax' => 'price0NoTax',
-		'2tax' => 'price2Tax',
-		'2notax' => 'price2NoTax',
-		'calc' => 'calcprice',
-		'taxperc' => 'tax',
-		'utax' => 'priceUnitTax',
-		'unotax' => 'priceUnitNoTax',
-		'wtax' => 'priceWeightUnitTax',
-		'wnotax' => 'priceWeightUnitNoTax',
-	];
-	static protected $fieldConvertArray = [
-		'tax' => 'pricetax',
-		'notax' => 'pricenotax',
-		'onlytax' => 'priceonlytax',
-		'0tax' => 'oldpricetax',
-		'0notax' => 'oldpricenotax',
-		'2tax' => 'price2tax',
-		'2notax' => 'price2notax',
-		'2onlytax' => 'price2onlytax',
-		'utax' => 'unitpricetax',
-		'unotax' => 'unitpricenotax',
-		'wtax' => 'weightunitpricetax',
-		'wnotax' => 'weightunitpricenotax',
-		'skontotax' => 'pricetaxdiscount',
-		'skontonotax' => 'pricenotaxdiscount',
-	];
+    static protected $convertArray = [
+        'tax' => 'priceTax',
+        'notax' => 'priceNoTax',
+        '0tax' => 'price0Tax',
+        '0notax' => 'price0NoTax',
+        '2tax' => 'price2Tax',
+        '2notax' => 'price2NoTax',
+        'calc' => 'calcprice',
+        'taxperc' => 'tax',
+        'utax' => 'priceUnitTax',
+        'unotax' => 'priceUnitNoTax',
+        'wtax' => 'priceWeightUnitTax',
+        'wnotax' => 'priceWeightUnitNoTax',
+    ];
+    static protected $fieldConvertArray = [
+        'tax' => 'pricetax',
+        'notax' => 'pricenotax',
+        'onlytax' => 'priceonlytax',
+        '0tax' => 'oldpricetax',
+        '0notax' => 'oldpricenotax',
+        '2tax' => 'price2tax',
+        '2notax' => 'price2notax',
+        '2onlytax' => 'price2onlytax',
+        'utax' => 'unitpricetax',
+        'unotax' => 'unitpricenotax',
+        'wtax' => 'weightunitpricetax',
+        'wnotax' => 'weightunitpricenotax',
+        'skontotax' => 'pricetaxdiscount',
+        'skontonotax' => 'pricenotaxdiscount',
+    ];
 
-	static protected $fieldKeepArray = [
-		'taxperc',
-		'calc',
-		'skontotaxperc',
-		'2skontotax',
-		'2skontotaxperc',
-		'2skontonotax',
-		'surcharge',
-		'surcharge2',
-		'surchargetax',
-		'surchargenotax',
-		'surcharge2tax',
-		'surcharge2notax',
-	];
-
-
-	public function preInit ($priceConf) {
-
-		parent::init();
-
-		$this->priceConf = $priceConf;
-		if (!isset($this->priceConf['TAXincluded'])) {
-			$this->priceConf['TAXincluded'] = '1';	// default '1' for TAXincluded
-		}
-		$this->setTaxIncluded($this->priceConf['TAXincluded']);
-		$this->bHasBeenInitialised = true;
-
-		$this->taxMode = intval($this->priceConf['TAXmode'] ?? 1);
-		if (!$this->taxMode) {
-			$this->taxMode = 1;
-		}
-	} // init
+    static protected $fieldKeepArray = [
+        'taxperc',
+        'calc',
+        'skontotaxperc',
+        '2skontotax',
+        '2skontotaxperc',
+        '2skontonotax',
+        'surcharge',
+        'surcharge2',
+        'surchargetax',
+        'surchargenotax',
+        'surcharge2tax',
+        'surcharge2notax',
+    ];
 
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+    public function preInit ($priceConf) {
 
-	/**
-	 * Changes the string value to integer or float and considers the German float ',' separator
-	 *
-	 * @param		bool	convert to float?
-	 * @param		string	quantity
-	 * @return	    float or integer string value
-	 */
-	static public function toNumber ($bToFloat, $text) {
-		$result = '';
-		if ($bToFloat) {
-			$text = (string) $text;
-			// enable the German display of float
-			$result = (float) str_replace (',', '.', $text);
-		} else {
-			$result = (int) $text;
-		}
+        parent::init();
 
-		return $result;
-	}
+        $this->priceConf = $priceConf;
+        if (!isset($this->priceConf['TAXincluded'])) {
+            $this->priceConf['TAXincluded'] = '1';	// default '1' for TAXincluded
+        }
+        $this->setTaxIncluded($this->priceConf['TAXincluded']);
+        $this->bHasBeenInitialised = true;
+
+        $this->taxMode = intval($this->priceConf['TAXmode'] ?? 1);
+        if (!$this->taxMode) {
+            $this->taxMode = 1;
+        }
+    } // init
 
 
-	public function getTaxIncluded () {
-		return $this->bTaxIncluded;
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
+
+    /**
+     * Changes the string value to integer or float and considers the German float ',' separator
+     *
+     * @param		bool	convert to float?
+     * @param		string	quantity
+     * @return	    float or integer string value
+     */
+    static public function toNumber ($bToFloat, $text) {
+        $result = '';
+        if ($bToFloat) {
+            $text = (string) $text;
+            // enable the German display of float
+            $result = (float) str_replace (',', '.', $text);
+        } else {
+            $result = (int) $text;
+        }
+
+        return $result;
+    }
 
 
-	public function setTaxIncluded ($bTaxIncluded = true) {
-		$this->bTaxIncluded = $bTaxIncluded;
-	}
+    public function getTaxIncluded () {
+        return $this->bTaxIncluded;
+    }
 
 
-	public function getTaxMode () {
-		return $this->taxMode;
-	}
+    public function setTaxIncluded ($bTaxIncluded = true) {
+        $this->bTaxIncluded = $bTaxIncluded;
+    }
 
 
-	static public function getPriceTax (
-		$price,
-		$bTax,
-		$bTaxIncluded,
-		$taxFactor
-	) {
-		if ($bTax) {
-			if ($bTaxIncluded) {	// If the configuration says that prices in the database is with tax included
-				$result = $price;
-			} else {
-				$result = $price * $taxFactor;
-			}
-		} else {
-			if ($bTaxIncluded) {	// If the configuration says that prices in the database is with tax included
-				$result = $price / $taxFactor;
-			} else {
-				$result = $price;
-			}
-		}
-
-		return $result;
-	}
+    public function getTaxMode () {
+        return $this->taxMode;
+    }
 
 
-	/**
-	 * return the price with tax mode considered
-	 */
-	public function getModePrice (
-		$basketExtra,
-		$basketRecs,
-		$taxMode,
-		$price,
-		$tax = true,
-		$row,
-		$bTaxIncluded = false,
-		$bEnableTaxZero = false
-	) {
-		$result = $this->getPrice(
-			$basketExtra,
-			$basketRecs,
-			$price,
-			$tax,
-			$row,
-			$bTaxIncluded,
-			$bEnableTaxZero
-		);
+    static public function getPriceTax (
+        $price,
+        $bTax,
+        $bTaxIncluded,
+        $taxFactor
+    ) {
+        if ($bTax) {
+            if ($bTaxIncluded) {	// If the configuration says that prices in the database is with tax included
+                $result = $price;
+            } else {
+                $result = $price * $taxFactor;
+            }
+        } else {
+            if ($bTaxIncluded) {	// If the configuration says that prices in the database is with tax included
+                $result = $price / $taxFactor;
+            } else {
+                $result = $price;
+            }
+        }
 
-		if ($taxMode == '2') {
-
-			$result = round($result, 2);
-		}
-
-		return $result;
-	}
+        return $result;
+    }
 
 
-	/** reduces price by discount for FE user **/
-	static public function getDiscountPrice (
-		$price,
-		$discount = ''
-	) {
-		if (floatval($discount) != 0) {
-			$price = $price * (1 - $discount / 100);
-		}
-		return $price;
-	}
+    /**
+     * return the price with tax mode considered
+     */
+    public function getModePrice (
+        $basketExtra,
+        $basketRecs,
+        $taxMode,
+        $price,
+        $tax = true,
+        $row,
+        $bTaxIncluded = false,
+        $bEnableTaxZero = false
+    ) {
+        $result = $this->getPrice(
+            $basketExtra,
+            $basketRecs,
+            $price,
+            $tax,
+            $row,
+            $bTaxIncluded,
+            $bEnableTaxZero
+        );
+
+        if ($taxMode == '2') {
+
+            $result = round($result, 2);
+        }
+
+        return $result;
+    }
 
 
-	/**
-	 * Returns the $price with either tax or not tax, based on if $tax is true or false.
-	 * This function reads the TypoScript configuration to see whether prices in the database
-	 * are entered with or without tax. That's why this function is needed.
-	 */
-	 public function getPrice (
-		$basketExtra,
-		$basketRecs,
-		$price,
-		$tax,
-		array $row,
-		$bTaxIncluded = false,
-		$bEnableTaxZero = false
-	) {
-		$taxInfoArray = '';
-		$result = 0;
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$taxpercentage = 0.0;
-		$taxFactor = 1;
-		$bIsZeroTax = false;
-
-		$bTax = ($tax == 1);
-		$price = $this->toNumber(true, $price);
-
-		if (
-			$bEnableTaxZero &&
-			isset($row['tax']) &&
-			doubleval($row['tax']) == '0.0'
-		) {
-			$taxpercentage = 0.0;
-			$bIsZeroTax = true;
-		} else {
-			$taxpercentage =
-				$taxObj->getTax(
-					$taxInfoArray,
-					$row,
-					$basketExtra,
-					$basketRecs,
-					$bEnableTaxZero
-				);
-		}
-
-		if (!$bIsZeroTax) {
-			$calculatedTaxpercentage =
-				$taxObj->getFieldCalculatedValue(
-					$taxpercentage,
-					$basketExtra
-				);
-		}
-
-		$taxFactor = 1 + $taxpercentage / 100;
-
-		if (
-			isset($calculatedTaxpercentage) &&
-			is_double($calculatedTaxpercentage) &&
-			$calculatedTaxpercentage != $taxpercentage
-		) {
-			$newtaxFactor = 1 + $calculatedTaxpercentage / 100;
-			// we need the net price in order to apply another tax
-			if ($bTaxIncluded) {
-				$price = $price / $taxFactor;
-				$bTaxIncluded = false;
-			}
-			$taxFactor = $newtaxFactor;
-		}
-
-		$result =
-			$this->getPriceTax(
-				$price,
-				$bTax,
-				$bTaxIncluded,
-				$taxFactor
-			);
-		return $result;
-	} // getPrice
+    /** reduces price by discount for FE user **/
+    static public function getDiscountPrice (
+        $price,
+        $discount = ''
+    ) {
+        if (floatval($discount) != 0) {
+            $price = $price * (1 - $discount / 100);
+        }
+        return $price;
+    }
 
 
-	// function using getPrice and considering a reduced price for resellers
-	public function getResellerPrice (
-		$basketExtra,
-		$basketRecs,
-		$row,
-		$tax = 1,
-		$priceNo = '',
-		$bEnableTaxZero = false
-	) {
-		$result = 0;
+    /**
+     * Returns the $price with either tax or not tax, based on if $tax is true or false.
+     * This function reads the TypoScript configuration to see whether prices in the database
+     * are entered with or without tax. That's why this function is needed.
+     */
+     public function getPrice (
+        $basketExtra,
+        $basketRecs,
+        $price,
+        $tax,
+        array $row,
+        $bTaxIncluded = false,
+        $bEnableTaxZero = false
+    ) {
+        $taxInfoArray = '';
+        $result = 0;
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $taxpercentage = 0.0;
+        $taxFactor = 1;
+        $bIsZeroTax = false;
 
-		if (
+        $bTax = ($tax == 1);
+        $price = $this->toNumber(true, $price);
+
+        if (
+            $bEnableTaxZero &&
+            isset($row['tax']) &&
+            doubleval($row['tax']) == '0.0'
+        ) {
+            $taxpercentage = 0.0;
+            $bIsZeroTax = true;
+        } else {
+            $taxpercentage =
+                $taxObj->getTax(
+                    $taxInfoArray,
+                    $row,
+                    $basketExtra,
+                    $basketRecs,
+                    $bEnableTaxZero
+                );
+        }
+
+        if (!$bIsZeroTax) {
+            $calculatedTaxpercentage =
+                $taxObj->getFieldCalculatedValue(
+                    $taxpercentage,
+                    $basketExtra
+                );
+        }
+
+        $taxFactor = 1 + $taxpercentage / 100;
+
+        if (
+            isset($calculatedTaxpercentage) &&
+            is_double($calculatedTaxpercentage) &&
+            $calculatedTaxpercentage != $taxpercentage
+        ) {
+            $newtaxFactor = 1 + $calculatedTaxpercentage / 100;
+            // we need the net price in order to apply another tax
+            if ($bTaxIncluded) {
+                $price = $price / $taxFactor;
+                $bTaxIncluded = false;
+            }
+            $taxFactor = $newtaxFactor;
+        }
+
+        $result =
+            $this->getPriceTax(
+                $price,
+                $bTax,
+                $bTaxIncluded,
+                $taxFactor
+            );
+        return $result;
+    } // getPrice
+
+
+    // function using getPrice and considering a reduced price for resellers
+    public function getResellerPrice (
+        $basketExtra,
+        $basketRecs,
+        $row,
+        $tax = 1,
+        $priceNo = '',
+        $bEnableTaxZero = false
+    ) {
+        $result = 0;
+
+        if (
             empty($priceNo) &&
             isset($this->priceConf['priceNoReseller']) &&
-			MathUtility::canBeInterpretedAsInteger($this->priceConf['priceNoReseller'])
-		) {
-				// get reseller group number
-			$priceNo = intval($this->priceConf['priceNoReseller']);
-		}
+            MathUtility::canBeInterpretedAsInteger($this->priceConf['priceNoReseller'])
+        ) {
+                // get reseller group number
+            $priceNo = intval($this->priceConf['priceNoReseller']);
+        }
 
-		if ($priceNo > 0) {
-			$result =
-				$this->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$row['price' . $priceNo],
-					$tax,
-					$row,
-					$this->getTaxIncluded(),
-					$bEnableTaxZero
-				);
-		}
-		// normal price; if reseller price is zero then also the normal price applies
-		if ($result == 0) {
-			$result =
-				$this->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$row['price'],
-					$tax,
-					$row,
-					$this->getTaxIncluded(),
-					$bEnableTaxZero
-				);
-		}
+        if ($priceNo > 0) {
+            $result =
+                $this->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $row['price' . $priceNo],
+                    $tax,
+                    $row,
+                    $this->getTaxIncluded(),
+                    $bEnableTaxZero
+                );
+        }
+        // normal price; if reseller price is zero then also the normal price applies
+        if ($result == 0) {
+            $result =
+                $this->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $row['price'],
+                    $tax,
+                    $row,
+                    $this->getTaxIncluded(),
+                    $bEnableTaxZero
+                );
+        }
 
-		return $result;
-	} // getResellerPrice
-
-
-	static public function getPriceFieldArray () {
-		return self::$priceFieldArray;
-	}
-
-	static public function convertIntoRow (&$row, $priceTaxArray) {
-		foreach ($priceTaxArray as $field => $value) {
-			if (isset(self::$fieldConvertArray[$field])) {
-				$finalField = self::$fieldConvertArray[$field];
-				if (!isset($row[$finalField])) {
-					$row[$finalField] = $value;
-				}
-			} else if (in_array($field, self::$fieldKeepArray)) {
-				if (!isset($row[$field])) {
-					$row[$field] = $value;
-				}
-			}
-		}
-	}
-
-	static public function getSkonto (
-		$relativePrice,
-		$priceNumTax,
-		&$skonto,
-		&$skontoTaxPerc
-	) {
-		$skonto = ((double) $relativePrice - (double) $priceNumTax);
-
-		if (floatval($relativePrice) != 0) {
-			$skontoTaxPerc = (($skonto / $relativePrice) * 100);
-		} else {
-			$skontoTaxPerc = 'undefined';
-		}
-	}
+        return $result;
+    } // getResellerPrice
 
 
-	static public function calculateEndPrice (
-		$price,
-		$row,
-		$discountField
-	) {
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
-		$maxDiscount = 0;
-		$discount = 0;
+    static public function getPriceFieldArray () {
+        return self::$priceFieldArray;
+    }
 
-		if ($discountField != '' && isset($row[$discountField])) {
-			$maxDiscount = $row[$discountField];
-		}
+    static public function convertIntoRow (&$row, $priceTaxArray) {
+        foreach ($priceTaxArray as $field => $value) {
+            if (isset(self::$fieldConvertArray[$field])) {
+                $finalField = self::$fieldConvertArray[$field];
+                if (!isset($row[$finalField])) {
+                    $row[$finalField] = $value;
+                }
+            } else if (in_array($field, self::$fieldKeepArray)) {
+                if (!isset($row[$field])) {
+                    $row[$field] = $value;
+                }
+            }
+        }
+    }
 
-		if (
+    static public function getSkonto (
+        $relativePrice,
+        $priceNumTax,
+        &$skonto,
+        &$skontoTaxPerc
+    ) {
+        $skonto = ((double) $relativePrice - (double) $priceNumTax);
+
+        if (floatval($relativePrice) != 0) {
+            $skontoTaxPerc = (($skonto / $relativePrice) * 100);
+        } else {
+            $skontoTaxPerc = 'undefined';
+        }
+    }
+
+
+    static public function calculateEndPrice (
+        $price,
+        $row,
+        $discountField
+    ) {
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $maxDiscount = 0;
+        $discount = 0;
+
+        if ($discountField != '' && isset($row[$discountField])) {
+            $maxDiscount = $row[$discountField];
+        }
+
+        if (
             \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
             isset($GLOBALS['TSFE']->fe_user) &&
             isset($GLOBALS['TSFE']->fe_user->user)
         ) {
-			$discount = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'];
-		}
+            $discount = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'];
+        }
 
-		if ($discount > $maxDiscount) {
-			$maxDiscount = $discount;
-		}
-		$price = self::getDiscountPrice($price, $maxDiscount);
+        if ($discount > $maxDiscount) {
+            $maxDiscount = $discount;
+        }
+        $price = self::getDiscountPrice($price, $maxDiscount);
 
-		if (
-			isset($row[$calculationField]) &&
-			floatval($row[$calculationField]) > 0
-		) {
-			$price = $row[$calculationField];
-		}
+        if (
+            isset($row[$calculationField]) &&
+            floatval($row[$calculationField]) > 0
+        ) {
+            $price = $row[$calculationField];
+        }
 
-		$result = $price;
+        $result = $price;
 
-		return $result;
-	}
+        return $result;
+    }
 
 
-	// fetches all calculated prices for a row
-	public function getPriceTaxArray (
-		&$taxInfoArray,
-		$discountPriceMode,
-		$basketExtra,
-		$basketRecs,
-		$fieldname,
-		$roundFormat,
-		$discountRoundFormat,
-		$row,
-		$discountField,
-		$bEnableTaxZero = false,
+    // fetches all calculated prices for a row
+    public function getPriceTaxArray (
+        &$taxInfoArray,
+        $discountPriceMode,
+        $basketExtra,
+        $basketRecs,
+        $fieldname,
+        $roundFormat,
+        $discountRoundFormat,
+        $row,
+        $discountField,
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
-	) {
-		$internalRow = $row;
-		$priceArray = [];
-		$bIsZeroTax = false;
+    ) {
+        $internalRow = $row;
+        $priceArray = [];
+        $bIsZeroTax = false;
 
         if (
             $notOverwritePriceIfSet &&
             isset($internalRow['pricetax']) &&
             isset($internalRow['pricenotax'])
         ) {
-			foreach ($internalRow as $priceField => $value) {
-				$shortField = array_search($priceField, self::$fieldConvertArray);
+            foreach ($internalRow as $priceField => $value) {
+                $shortField = array_search($priceField, self::$fieldConvertArray);
 
-				if (
-					$shortField !== false
-				) {
-					$priceArray[$shortField] = $value;
-				} else if (
-					in_array($priceField, self::$fieldKeepArray)
-				) {
-					$priceArray[$priceField] = $value;
-				}
-			}
-		} else {
-			$price0tax =
-				$this->getResellerPrice(
-					$basketExtra,
-					$basketRecs,
-					$internalRow,
-					1,
-					0,
-					$bEnableTaxZero
-				);
+                if (
+                    $shortField !== false
+                ) {
+                    $priceArray[$shortField] = $value;
+                } else if (
+                    in_array($priceField, self::$fieldKeepArray)
+                ) {
+                    $priceArray[$priceField] = $value;
+                }
+            }
+        } else {
+            $price0tax =
+                $this->getResellerPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $internalRow,
+                    1,
+                    0,
+                    $bEnableTaxZero
+                );
 
-			if ($fieldname == 'price') {
-				$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+            if ($fieldname == 'price') {
+                $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
 
-				if (
-					$bEnableTaxZero &&
-					isset($row['tax']) &&
-					doubleval($row['tax']) == '0.0'
-				) {
-					$bIsZeroTax = true;
-					$taxpercentage = 0.0;
-				} else {
-					$taxpercentage =
-						$taxObj->getTax(
-							$taxInfoArray,
-							$row,
-							$basketExtra,
-							$basketRecs,
-							$bEnableTaxZero
-						);
-				}
+                if (
+                    $bEnableTaxZero &&
+                    isset($row['tax']) &&
+                    doubleval($row['tax']) == '0.0'
+                ) {
+                    $bIsZeroTax = true;
+                    $taxpercentage = 0.0;
+                } else {
+                    $taxpercentage =
+                        $taxObj->getTax(
+                            $taxInfoArray,
+                            $row,
+                            $basketExtra,
+                            $basketRecs,
+                            $bEnableTaxZero
+                        );
+                }
 
-				if (!$bIsZeroTax) {
-					$tax = '';
-					if (isset($row['tax'])) {
-						$tax = $row['tax'];
-					}
-					$calculatedTaxpercentage =
-						$taxObj->getFieldCalculatedValue(
-							$tax,
-							$basketExtra
-						);
-					if ($calculatedTaxpercentage !== false) {
-						$taxpercentage = $calculatedTaxpercentage;
-					}
-				}
+                if (!$bIsZeroTax) {
+                    $tax = '';
+                    if (isset($row['tax'])) {
+                        $tax = $row['tax'];
+                    }
+                    $calculatedTaxpercentage =
+                        $taxObj->getFieldCalculatedValue(
+                            $tax,
+                            $basketExtra
+                        );
+                    if ($calculatedTaxpercentage !== false) {
+                        $taxpercentage = $calculatedTaxpercentage;
+                    }
+                }
 
-				$priceArray['taxperc'] = $taxpercentage;
-				$internalRow['price'] =
-					self::calculateEndPrice(
-						$row['price'],
-						$row,
-						$discountField
-					);
+                $priceArray['taxperc'] = $taxpercentage;
+                $internalRow['price'] =
+                    self::calculateEndPrice(
+                        $row['price'],
+                        $row,
+                        $discountField
+                    );
 
-				$priceArray['tax'] =
-					$this->getResellerPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow,
-						1,
-						'',
-						$bEnableTaxZero
-					);
+                $priceArray['tax'] =
+                    $this->getResellerPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow,
+                        1,
+                        '',
+                        $bEnableTaxZero
+                    );
 
-				if (
-					$roundFormat != '' &&
-					!empty($priceArray['tax'])
-				) {
-					$oldPrice = $priceArray['tax'];
-					$priceArray['tax'] =
-						tx_ttproducts_api::roundPrice(
-							$oldPrice,
-							$roundFormat
-						);
-					$factor = $priceArray['tax'] / $oldPrice;
-					$internalRow['price'] *= $factor; // fix the starting price with the same variance coming from the rounding
-				}
+                if (
+                    $roundFormat != '' &&
+                    !empty($priceArray['tax'])
+                ) {
+                    $oldPrice = $priceArray['tax'];
+                    $priceArray['tax'] =
+                        tx_ttproducts_api::roundPrice(
+                            $oldPrice,
+                            $roundFormat
+                        );
+                    $factor = $priceArray['tax'] / $oldPrice;
+                    $internalRow['price'] *= $factor; // fix the starting price with the same variance coming from the rounding
+                }
 
-				$priceArray['notax'] =
-					$this->getResellerPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow,
-						0,
-						'',
-						$bEnableTaxZero
-					);
+                $priceArray['notax'] =
+                    $this->getResellerPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow,
+                        0,
+                        '',
+                        $bEnableTaxZero
+                    );
 
                 for ($i = 1; $i <= 2; ++$i) {
-					$suffix = '';
-					if ($i > 1) {
-						$suffix = $i;
-					}
+                    $suffix = '';
+                    if ($i > 1) {
+                        $suffix = $i;
+                    }
 
-					$priceArray['surcharge' . $suffix . 'notax'] =
-						$this->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$internalRow['surcharge' . $suffix] ?? 0,
-							false,
-							$row,
-							false,
-							$bEnableTaxZero
-						);
+                    $priceArray['surcharge' . $suffix . 'notax'] =
+                        $this->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $internalRow['surcharge' . $suffix] ?? 0,
+                            false,
+                            $row,
+                            false,
+                            $bEnableTaxZero
+                        );
 
-					$priceArray['surcharge' . $suffix . 'tax'] =
-						$this->getPrice(
-							$basketExtra,
-							$basketRecs,
-							$priceArray['surcharge' . $suffix . 'notax'],
-							true,
-							$row,
-							false,
-							$bEnableTaxZero
-						);
-				}
+                    $priceArray['surcharge' . $suffix . 'tax'] =
+                        $this->getPrice(
+                            $basketExtra,
+                            $basketRecs,
+                            $priceArray['surcharge' . $suffix . 'notax'],
+                            true,
+                            $row,
+                            false,
+                            $bEnableTaxZero
+                        );
+                }
 
-				$priceArray['0tax'] = $price0tax;
-				$priceArray['0notax'] =
-					$this->getResellerPrice(
-						$basketExtra,
-						$basketRecs,
-						$row,
-						0,
-						0,
-						$bEnableTaxZero
-					);
+                $priceArray['0tax'] = $price0tax;
+                $priceArray['0notax'] =
+                    $this->getResellerPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $row,
+                        0,
+                        0,
+                        $bEnableTaxZero
+                    );
 
-				$priceArray['unotax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						(
-							isset($row['unit_factor']) && ($row['unit_factor'] > 0) ?
-								($priceArray['notax'] / $row['unit_factor']) :
-								0
-						),
-						false,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
+                $priceArray['unotax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        (
+                            isset($row['unit_factor']) && ($row['unit_factor'] > 0) ?
+                                ($priceArray['notax'] / $row['unit_factor']) :
+                                0
+                        ),
+                        false,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
 
-				$priceArray['utax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceArray['unotax'],
-						true,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
+                $priceArray['utax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceArray['unotax'],
+                        true,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
 
-				$priceArray['wnotax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						(
-							$row['weight'] > 0 ?
-								($priceArray['notax'] / $internalRow['weight']) :
-								0
-						),
-						false,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
-				$priceArray['wtax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceArray['wnotax'],
-						true,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
+                $priceArray['wnotax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        (
+                            $row['weight'] > 0 ?
+                                ($priceArray['notax'] / $internalRow['weight']) :
+                                0
+                        ),
+                        false,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
+                $priceArray['wtax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceArray['wnotax'],
+                        true,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
 
-				self::getSkonto(
-					$price0tax,
-					$priceArray['tax'],
-					$priceArray['skontotax'],
-					$priceArray['skontotaxperc']
-				);
+                self::getSkonto(
+                    $price0tax,
+                    $priceArray['tax'],
+                    $priceArray['skontotax'],
+                    $priceArray['skontotaxperc']
+                );
 
-				if ($discountRoundFormat != '') {
-					$priceArray['skontotax'] =
-						tx_ttproducts_api::roundPrice(
-							$priceArray['skontotax'],
-							$discountRoundFormat
-						);
-				}
+                if ($discountRoundFormat != '') {
+                    $priceArray['skontotax'] =
+                        tx_ttproducts_api::roundPrice(
+                            $priceArray['skontotax'],
+                            $discountRoundFormat
+                        );
+                }
 
-				$priceArray['skontonotax'] = $priceArray['skontotax'] / (1 + $taxpercentage / 100);
-				$priceArray['onlytax'] = $priceArray['tax'] - $priceArray['notax'];
-				$priceArray['discountbyproductpricetax'] = $priceArray['0tax'];
-				$priceArray['discountbyproductpricenotax'] = $priceArray['0notax'];
+                $priceArray['skontonotax'] = $priceArray['skontotax'] / (1 + $taxpercentage / 100);
+                $priceArray['onlytax'] = $priceArray['tax'] - $priceArray['notax'];
+                $priceArray['discountbyproductpricetax'] = $priceArray['0tax'];
+                $priceArray['discountbyproductpricenotax'] = $priceArray['0notax'];
 
-				if (
-					isset($row[FieldInterface::DISCOUNT]) &&
-					isset($row[FieldInterface::DISCOUNT_DISABLE]) &&
-					$row[FieldInterface::DISCOUNT] != 0 &&
-					$row[FieldInterface::DISCOUNT_DISABLE] == 0
-				) {
-					$priceArray['discountbyproductpricetax'] =
-						self::getDiscountPrice(
-							$priceArray['discountbyproductpricetax'],
-							$row[FieldInterface::DISCOUNT]
-						);
-					$priceArray['discountbyproductpricenotax'] =
-						self::getDiscountPrice(
-							$priceArray['discountbyproductpricenotax'],
-							$row[FieldInterface::DISCOUNT]
-						);
-				}
+                if (
+                    isset($row[FieldInterface::DISCOUNT]) &&
+                    isset($row[FieldInterface::DISCOUNT_DISABLE]) &&
+                    $row[FieldInterface::DISCOUNT] != 0 &&
+                    $row[FieldInterface::DISCOUNT_DISABLE] == 0
+                ) {
+                    $priceArray['discountbyproductpricetax'] =
+                        self::getDiscountPrice(
+                            $priceArray['discountbyproductpricetax'],
+                            $row[FieldInterface::DISCOUNT]
+                        );
+                    $priceArray['discountbyproductpricenotax'] =
+                        self::getDiscountPrice(
+                            $priceArray['discountbyproductpricenotax'],
+                            $row[FieldInterface::DISCOUNT]
+                        );
+                }
 
-				$priceArray['discountbyproductunotax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						(isset($row['unit_factor']) && ($row['unit_factor'] > 0) ?  ($priceArray['discountbyproductpricenotax'] / $row['unit_factor']) : 0),
-						false,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
-				$priceArray['discountbyproductutax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceArray['discountbyproductunotax'],
-						true,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
+                $priceArray['discountbyproductunotax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        (isset($row['unit_factor']) && ($row['unit_factor'] > 0) ?  ($priceArray['discountbyproductpricenotax'] / $row['unit_factor']) : 0),
+                        false,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
+                $priceArray['discountbyproductutax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceArray['discountbyproductunotax'],
+                        true,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
 
-				$priceArray['discountbyproductwnotax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						(
-							$row['weight'] > 0 ?
-								($priceArray['discountbyproductpricenotax'] / $internalRow['weight']) :
-								0
-						),
-						false,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
-				$priceArray['discountbyproductwtax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$priceArray['discountbyproductwnotax'],
-						true,
-						$row,
-						false,
-						$bEnableTaxZero
-					);
-			} else if (strpos($fieldname, 'price') === 0) {
-				$internalRow['price'] =
-					self::calculateEndPrice(
-						$row['price'],
-						$row,
-						$discountField
-					);
+                $priceArray['discountbyproductwnotax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        (
+                            $row['weight'] > 0 ?
+                                ($priceArray['discountbyproductpricenotax'] / $internalRow['weight']) :
+                                0
+                        ),
+                        false,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
+                $priceArray['discountbyproductwtax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $priceArray['discountbyproductwnotax'],
+                        true,
+                        $row,
+                        false,
+                        $bEnableTaxZero
+                    );
+            } else if (strpos($fieldname, 'price') === 0) {
+                $internalRow['price'] =
+                    self::calculateEndPrice(
+                        $row['price'],
+                        $row,
+                        $discountField
+                    );
 
-				if ($roundFormat != '') {
-					$internalRow[$fieldname] =
-						tx_ttproducts_api::roundPrice(
-							$internalRow[$fieldname] ?? 0,
-							$roundFormat
-						);
-				}
+                if ($roundFormat != '') {
+                    $internalRow[$fieldname] =
+                        tx_ttproducts_api::roundPrice(
+                            $internalRow[$fieldname] ?? 0,
+                            $roundFormat
+                        );
+                }
 
-				$pricelen = strlen('price');
-				$priceNum = substr($fieldname, $pricelen /*, strlen($fieldName) - $pricelen*/);
-				$priceArray[$priceNum . 'tax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow[$fieldname] ?? 0,
-						1,
-						$row,
-						$this->getTaxIncluded(),
-						$bEnableTaxZero
-					);
+                $pricelen = strlen('price');
+                $priceNum = substr($fieldname, $pricelen /*, strlen($fieldName) - $pricelen*/);
+                $priceArray[$priceNum . 'tax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow[$fieldname] ?? 0,
+                        1,
+                        $row,
+                        $this->getTaxIncluded(),
+                        $bEnableTaxZero
+                    );
 
-				$priceArray[$priceNum . 'notax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow[$fieldname] ?? 0,
-						0,
-						$row,
-						$this->getTaxIncluded(),
-						$bEnableTaxZero
-					);
-				$priceArray[$priceNum . 'onlytax'] = $priceArray[$priceNum . 'tax'] - $priceArray[$priceNum . 'notax'];
+                $priceArray[$priceNum . 'notax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow[$fieldname] ?? 0,
+                        0,
+                        $row,
+                        $this->getTaxIncluded(),
+                        $bEnableTaxZero
+                    );
+                $priceArray[$priceNum . 'onlytax'] = $priceArray[$priceNum . 'tax'] - $priceArray[$priceNum . 'notax'];
 
-				$relativePrice = $price0tax;
-				$priceNumTax = '';
-				if ($discountPriceMode == 0) {
-					$relativePrice = $price0tax;
-					$priceNumTax = $priceArray[$priceNum . 'tax'];
-				} else if ($discountPriceMode == 1) {
-					$relativePrice = $priceArray[$priceNum . 'tax'];
-					$priceNumTax = $internalRow['price'];
-				}
+                $relativePrice = $price0tax;
+                $priceNumTax = '';
+                if ($discountPriceMode == 0) {
+                    $relativePrice = $price0tax;
+                    $priceNumTax = $priceArray[$priceNum . 'tax'];
+                } else if ($discountPriceMode == 1) {
+                    $relativePrice = $priceArray[$priceNum . 'tax'];
+                    $priceNumTax = $internalRow['price'];
+                }
 
-				self::getSkonto(
-					$relativePrice,
-					$priceNumTax,
-					$priceArray[$priceNum . 'skontotax'],
-					$priceArray[$priceNum . 'skontotaxperc']
-				);
-			} else if (in_array($fieldname, ['directcost', 'deposit'])) {
-				$priceArray[$fieldname . 'tax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow[$fieldname] ?? 0,
-						1,
-						$row,
-						$this->getTaxIncluded(),
-						$bEnableTaxZero
-					);
-				$priceArray[$fieldname . 'notax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$internalRow[$fieldname] ?? 0,
-						0,
-						$row,
-						$this->getTaxIncluded(),
-						$bEnableTaxZero
-					);
-			} else {
-				$value = $row[$fieldname];
-				$priceArray['tax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$value,
-						1,
-						$row,
-						$this->priceConf['TAXincluded'],
-						$bEnableTaxZero
-					);
-				$priceArray['notax'] =
-					$this->getPrice(
-						$basketExtra,
-						$basketRecs,
-						$value,
-						0,
-						$row,
-						$this->priceConf['TAXincluded'],
-						$bEnableTaxZero
-					);
-				$priceArray['onlytax'] = $priceArray['tax'] - $priceArray['notax'];
-			}
+                self::getSkonto(
+                    $relativePrice,
+                    $priceNumTax,
+                    $priceArray[$priceNum . 'skontotax'],
+                    $priceArray[$priceNum . 'skontotaxperc']
+                );
+            } else if (in_array($fieldname, ['directcost', 'deposit'])) {
+                $priceArray[$fieldname . 'tax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow[$fieldname] ?? 0,
+                        1,
+                        $row,
+                        $this->getTaxIncluded(),
+                        $bEnableTaxZero
+                    );
+                $priceArray[$fieldname . 'notax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $internalRow[$fieldname] ?? 0,
+                        0,
+                        $row,
+                        $this->getTaxIncluded(),
+                        $bEnableTaxZero
+                    );
+            } else {
+                $value = $row[$fieldname];
+                $priceArray['tax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $value,
+                        1,
+                        $row,
+                        $this->priceConf['TAXincluded'],
+                        $bEnableTaxZero
+                    );
+                $priceArray['notax'] =
+                    $this->getPrice(
+                        $basketExtra,
+                        $basketRecs,
+                        $value,
+                        0,
+                        $row,
+                        $this->priceConf['TAXincluded'],
+                        $bEnableTaxZero
+                    );
+                $priceArray['onlytax'] = $priceArray['tax'] - $priceArray['notax'];
+            }
 
-			if ($this->getTaxMode() == 2) {
-				foreach ($priceArray as $field => $v) {
-					$priceArray[$field] = round($priceArray[$field], 2);
-				}
-			}
-		}
+            if ($this->getTaxMode() == 2) {
+                foreach ($priceArray as $field => $v) {
+                    $priceArray[$field] = round($priceArray[$field], 2);
+                }
+            }
+        }
 
-		return $priceArray;
-	}
-
-
-	static public function convertOldPriceArray ($row) {
-		$result = [];
-
-		foreach (self::$convertArray as $newField => $oldField) {
-			if (isset($row[$newField])) {
-				$result[$oldField] = $row[$newField];
-			}
-		}
-		return $result;
-	}
+        return $priceArray;
+    }
 
 
-	static public function convertNewPriceArray ($row) {
-		$result = [];
+    static public function convertOldPriceArray ($row) {
+        $result = [];
 
-		foreach (self::$convertArray as $newField => $oldField) {
-			if (isset($row[$oldField])) {
-				$result[$newField] = $row[$oldField];
-			}
-		}
-		return $result;
-	}
+        foreach (self::$convertArray as $newField => $oldField) {
+            if (isset($row[$newField])) {
+                $result[$oldField] = $row[$newField];
+            }
+        }
+        return $result;
+    }
 
-	static public function getWithoutTaxedPrices ($record) {
-		$newRecord = [];
-		foreach ($record as $field => $value) {
-			$hasTax = strpos($field, 'tax');
-			if (!$hasTax) {
-				$newRecord[$field] = $value;
-			}
-		}
-		return $newRecord;
-	}
+
+    static public function convertNewPriceArray ($row) {
+        $result = [];
+
+        foreach (self::$convertArray as $newField => $oldField) {
+            if (isset($row[$oldField])) {
+                $result[$newField] = $row[$oldField];
+            }
+        }
+        return $result;
+    }
+
+    static public function getWithoutTaxedPrices ($record) {
+        $newRecord = [];
+        foreach ($record as $field => $value) {
+            $hasTax = strpos($field, 'tax');
+            if (!$hasTax) {
+                $newRecord[$field] = $value;
+            }
+        }
+        return $newRecord;
+    }
 }
 

--- a/model/field/class.tx_ttproducts_field_tax.php
+++ b/model/field/class.tx_ttproducts_field_tax.php
@@ -43,191 +43,191 @@ use JambageCom\TtProducts\Api\PaymentShippingHandling;
 
 
 class tx_ttproducts_field_tax extends tx_ttproducts_field_base {
-	protected $useStaticTaxes = false;
+    protected $useStaticTaxes = false;
 
-	/**
-	 *
-	 */
-	public function preInit (
-		$useStaticTaxes,
-		$uidStore,
-		$infoArray,
-		$conf
-	) {
-		parent::init();
+    /**
+     *
+     */
+    public function preInit (
+        $useStaticTaxes,
+        $uidStore,
+        $infoArray,
+        $conf
+    ) {
+        parent::init();
 
-		if ($useStaticTaxes) { // change static_taxes
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$staticTaxObj = $tablesObj->get('static_taxes', false);
+        if ($useStaticTaxes) { // change static_taxes
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $staticTaxObj = $tablesObj->get('static_taxes', false);
 
-			if ($staticTaxObj && is_object($staticTaxObj)) {
-				$staticTaxObj->setStoreData($uidStore);
+            if ($staticTaxObj && is_object($staticTaxObj)) {
+                $staticTaxObj->setStoreData($uidStore);
 
-				if ($staticTaxObj->isValid()) {
-					$taxArray = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tax.'];
-					$taxFields = '';
+                if ($staticTaxObj->isValid()) {
+                    $taxArray = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['tax.'];
+                    $taxFields = '';
 
-					if (
-						isset($taxArray) &&
-						is_array($taxArray) &&
-						isset($taxArray['fields'])
-					) {
-						$taxFields = implode(',', GeneralUtility::trimExplode(',', $taxArray['fields']));
-					}
+                    if (
+                        isset($taxArray) &&
+                        is_array($taxArray) &&
+                        isset($taxArray['fields'])
+                    ) {
+                        $taxFields = implode(',', GeneralUtility::trimExplode(',', $taxArray['fields']));
+                    }
 
-					if (
-						GeneralUtility::inList($taxFields, 'tax_id') ||
-						GeneralUtility::inList($taxFields, 'taxcat_id')
-					) {
-						$this->setUseStaticTaxes(true);
-					}
-				}
-				$staticTaxObj->initTaxes($infoArray, $conf);
-			}
-		}
-	} // init
+                    if (
+                        GeneralUtility::inList($taxFields, 'tax_id') ||
+                        GeneralUtility::inList($taxFields, 'taxcat_id')
+                    ) {
+                        $this->setUseStaticTaxes(true);
+                    }
+                }
+                $staticTaxObj->initTaxes($infoArray, $conf);
+            }
+        }
+    } // init
 
-	public function getUseStaticTaxes () {
-		return $this->useStaticTaxes;
-	}
+    public function getUseStaticTaxes () {
+        return $this->useStaticTaxes;
+    }
 
-	public function setUseStaticTaxes ($useStaticTaxes) {
-		$this->useStaticTaxes = $useStaticTaxes;
-	}
+    public function setUseStaticTaxes ($useStaticTaxes) {
+        $this->useStaticTaxes = $useStaticTaxes;
+    }
 
-	public function getTax (
-		&$taxInfoArray,
-		array $row,
-		$basketExtra,
-		$basketRecs = [],
-		$bEnableTaxZero = false
-	) {
-		$result = $this->getFieldValue(
-			$taxInfoArray,
-			$row,
-			'tax',
-			$basketExtra,
-			$basketRecs,
-			$bEnableTaxZero
-		);
-		return $result;
-	}
+    public function getTax (
+        &$taxInfoArray,
+        array $row,
+        $basketExtra,
+        $basketRecs = [],
+        $bEnableTaxZero = false
+    ) {
+        $result = $this->getFieldValue(
+            $taxInfoArray,
+            $row,
+            'tax',
+            $basketExtra,
+            $basketRecs,
+            $bEnableTaxZero
+        );
+        return $result;
+    }
 
-	public function getFieldValue (
-		&$taxInfoArray,
-		array $row,
-		$fieldname,
-		$basketExtra = [],
-		$basketRecs = [],
-		$bEnableTaxZero = false
-	) {
-		$fieldValue = 0;
-		$newTax = '';
+    public function getFieldValue (
+        &$taxInfoArray,
+        array $row,
+        $fieldname,
+        $basketExtra = [],
+        $basketRecs = [],
+        $bEnableTaxZero = false
+    ) {
+        $fieldValue = 0;
+        $newTax = '';
 
-		if (
-			$this->getUseStaticTaxes() ||
-			tx_ttproducts_static_tax::need4StaticTax($row)
-		) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$staticTaxObj = $tablesObj->get('static_taxes', false);
-			$staticTaxObj->getStaticTax(
-				$basketRecs,
-				$row,
-				$newTax,
-				$taxInfoArray
-			);
-		}
+        if (
+            $this->getUseStaticTaxes() ||
+            tx_ttproducts_static_tax::need4StaticTax($row)
+        ) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $staticTaxObj = $tablesObj->get('static_taxes', false);
+            $staticTaxObj->getStaticTax(
+                $basketRecs,
+                $row,
+                $newTax,
+                $taxInfoArray
+            );
+        }
 
-		if (is_numeric($newTax)) {
-			$fieldValue = $newTax;
-		} else {
-			if (!empty($row)) {
-				$resultValue =
-					parent::getFieldValue(
-						$taxInfoArray,
-						$row,
-						$fieldname,
-						$basketExtra,
-						$basketRecs,
-						$bEnableTaxZero
-					);
+        if (is_numeric($newTax)) {
+            $fieldValue = $newTax;
+        } else {
+            if (!empty($row)) {
+                $resultValue =
+                    parent::getFieldValue(
+                        $taxInfoArray,
+                        $row,
+                        $fieldname,
+                        $basketExtra,
+                        $basketRecs,
+                        $bEnableTaxZero
+                    );
 
-				if (is_numeric($resultValue)) {
-					$fieldValue = $resultValue;
-				}
-			}
+                if (is_numeric($resultValue)) {
+                    $fieldValue = $resultValue;
+                }
+            }
 
-			if ($fieldValue == 0) {
-				if (!$bEnableTaxZero && $this->conf['TAXpercentage']) {
-					$fieldValue = floatval($this->conf['TAXpercentage']);
-				} else {
-					$fieldValue = 0;
-				}
-			}
+            if ($fieldValue == 0) {
+                if (!$bEnableTaxZero && $this->conf['TAXpercentage']) {
+                    $fieldValue = floatval($this->conf['TAXpercentage']);
+                } else {
+                    $fieldValue = 0;
+                }
+            }
 
-			if (
-				tx_ttproducts_static_tax::isInstalled()
-			) {
-				$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-				$staticTaxObj = $tablesObj->get('static_taxes', false);
-				$staticTaxObj->getTaxInfo(
-					$taxInfoArray,
-					$shopCountryArray,
-					$fieldValue,
-					[],
-					$basketRecs
-				);
-			}
-		}
+            if (
+                tx_ttproducts_static_tax::isInstalled()
+            ) {
+                $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+                $staticTaxObj = $tablesObj->get('static_taxes', false);
+                $staticTaxObj->getTaxInfo(
+                    $taxInfoArray,
+                    $shopCountryArray,
+                    $fieldValue,
+                    [],
+                    $basketRecs
+                );
+            }
+        }
 
-		return $fieldValue;
-	}
+        return $fieldValue;
+    }
 
-	public function getFieldCalculatedValue (
-		$fieldValue,
-		$basketExtra
-	) {
-		$taxFromShipping =
-			PaymentShippingHandling::getReplaceTaxPercentage(
-				$basketExtra,
-				'shipping',
-				$fieldValue
-			);	// if set then this has a tax which will override the tax of the products
+    public function getFieldCalculatedValue (
+        $fieldValue,
+        $basketExtra
+    ) {
+        $taxFromShipping =
+            PaymentShippingHandling::getReplaceTaxPercentage(
+                $basketExtra,
+                'shipping',
+                $fieldValue
+            );	// if set then this has a tax which will override the tax of the products
 
-		if (
-			isset($taxFromShipping) &&
-			is_double($taxFromShipping)
-		) {
-			$fieldValue = $taxFromShipping;
-		} else {
-			$fieldValue = false;
-		}
+        if (
+            isset($taxFromShipping) &&
+            is_double($taxFromShipping)
+        ) {
+            $fieldValue = $taxFromShipping;
+        } else {
+            $fieldValue = false;
+        }
 
-		return $fieldValue;
-	}
+        return $fieldValue;
+    }
 
-	public function getTaxRates (
-		&$shopCountryArray,
-		&$taxInfoArray,
-		array $uidArray,
-		array $basketRecs
-	) {
-		$result = null;
-		if (
-			tx_ttproducts_static_tax::isInstalled()
-		) {
-			$taxInfoArray = [];
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$staticTaxObj = $tablesObj->get('static_taxes', false);
-			$taxResult = $staticTaxObj->getTaxInfo(
-				$taxInfoArray,
-				$shopCountryArray,
-				0.0,
-				$uidArray,
-				$basketRecs
-			);
+    public function getTaxRates (
+        &$shopCountryArray,
+        &$taxInfoArray,
+        array $uidArray,
+        array $basketRecs
+    ) {
+        $result = null;
+        if (
+            tx_ttproducts_static_tax::isInstalled()
+        ) {
+            $taxInfoArray = [];
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $staticTaxObj = $tablesObj->get('static_taxes', false);
+            $taxResult = $staticTaxObj->getTaxInfo(
+                $taxInfoArray,
+                $shopCountryArray,
+                0.0,
+                $uidArray,
+                $basketRecs
+            );
 
-			if ($taxResult) {
+            if ($taxResult) {
 
                 $taxRates = [];
                 if (
@@ -243,14 +243,14 @@ class tx_ttproducts_field_tax extends tx_ttproducts_field_base {
                 }
                 $result = $taxRates;
             }
-		}
+        }
 
-		if (!$result) {
-			$result = GeneralUtility::trimExplode(',', $this->conf['TAXrates']);
-			$result = ['ALL' => $result];
-		}
+        if (!$result) {
+            $result = GeneralUtility::trimExplode(',', $this->conf['TAXrates']);
+            $result = ['ALL' => $result];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/model/field/interface.tx_ttproducts_field_int.php
+++ b/model/field/interface.tx_ttproducts_field_int.php
@@ -39,15 +39,15 @@
 
 interface tx_ttproducts_field_int {
 
-	public function needsInit();
-	public function getFieldValue (
-		&$taxInfoArray,
-		array $row,
-		$fieldname,
-		$basketExtra,
-		$basketRecs,
-		$bEnableTaxZero
-	);
+    public function needsInit();
+    public function getFieldValue (
+        &$taxInfoArray,
+        array $row,
+        $fieldname,
+        $basketExtra,
+        $basketRecs,
+        $bEnableTaxZero
+    );
 }
 
 

--- a/model/interface.tx_ttproducts_edit_variant_int.php
+++ b/model/interface.tx_ttproducts_edit_variant_int.php
@@ -42,11 +42,11 @@
 interface tx_ttproducts_edit_variant_int {
 
 
-	public function init ($itemTable);
-	public function getFieldArray ();
-	public function getVariantFromRawRow ($row);
-	public function getVariantRowFromProductRow ($row);
-	public function getValidConfig ($row);
+    public function init ($itemTable);
+    public function getFieldArray ();
+    public function getVariantFromRawRow ($row);
+    public function getVariantRowFromProductRow ($row);
+    public function getValidConfig ($row);
 
 }
 

--- a/model/interface.tx_ttproducts_variant_int.php
+++ b/model/interface.tx_ttproducts_variant_int.php
@@ -40,25 +40,25 @@
 
 
 interface tx_ttproducts_variant_int {
-	const EXTERNAL_QUANTITY_SEPARATOR = '_'; // to separate any information about the external table, e.g. its type and uid "fal=4"
-	const INTERNAL_VARIANT_SEPARATOR = ';';
+    const EXTERNAL_QUANTITY_SEPARATOR = '_'; // to separate any information about the external table, e.g. its type and uid "fal=4"
+    const INTERNAL_VARIANT_SEPARATOR = ';';
 
-	public function init($itemTable, $tablename, $useArticles);
-	public function getSeparator();
-	public function getSplitSeparator();
-	public function getImplodeSeparator();
-	public function getUseArticles();
-	public function modifyRowFromVariant (&$row, $variant='');
-	public function getVariantFromRow ($row);
-	public function getVariantFromProductRow ($row, $variantRow, $useArticles);
-	public function getVariantFromRawRow ($row);
-	public function getVariantRow($row='',$varianArray = []);
-	public function getTableUid ($table, $uid);
-	public function getSelectableArray();
-	public function getVariantValuesByArticle($articleRowArray, $productRow,$withSemicolon = false);
-	public function filterArticleRowsByVariant($row, $variant, $articleRows, $bCombined = false);
-	public function getFieldArray();
-	public function getSelectableFieldArray();
-	public function getAdditionalKey();
+    public function init($itemTable, $tablename, $useArticles);
+    public function getSeparator();
+    public function getSplitSeparator();
+    public function getImplodeSeparator();
+    public function getUseArticles();
+    public function modifyRowFromVariant (&$row, $variant='');
+    public function getVariantFromRow ($row);
+    public function getVariantFromProductRow ($row, $variantRow, $useArticles);
+    public function getVariantFromRawRow ($row);
+    public function getVariantRow($row='',$varianArray = []);
+    public function getTableUid ($table, $uid);
+    public function getSelectableArray();
+    public function getVariantValuesByArticle($articleRowArray, $productRow,$withSemicolon = false);
+    public function filterArticleRowsByVariant($row, $variant, $articleRows, $bCombined = false);
+    public function getFieldArray();
+    public function getSelectableFieldArray();
+    public function getAdditionalKey();
 }
 

--- a/pi1/class.tx_ttproducts_pi1.php
+++ b/pi1/class.tx_ttproducts_pi1.php
@@ -59,39 +59,39 @@ class tx_ttproducts_pi1 implements \TYPO3\CMS\Core\SingletonInterface {
     }
 
 
-	/**
-	 * Main method. Call this from TypoScript by a USER cObject.
-	 */
-	public function main ($content, $conf) {
+    /**
+     * Main method. Call this from TypoScript by a USER cObject.
+     */
+    public function main ($content, $conf) {
 
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
-		$pibaseObj->cObj = $this->cObj;
-		$languageSubpath = '/Resources/Private/Language/';
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi1_base');
+        $pibaseObj->cObj = $this->cObj;
+        $languageSubpath = '/Resources/Private/Language/';
 
-		if (!empty($conf['templateFile']) || !empty($conf['templateFile.'])) {
-			$content = $pibaseObj->main($content, $conf);
-		} else {
+        if (!empty($conf['templateFile']) || !empty($conf['templateFile.'])) {
+            $content = $pibaseObj->main($content, $conf);
+        } else {
             $errorText = $GLOBALS['TSFE']->sL(
                 'LLL:EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'Pi1/locallang.xlf:no_template'
             );
             $content = str_replace('|', 'plugin.tt_products.templateFile', $errorText);
             $content = '<p><strong>' . $content . '</strong></p>';
-		}
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 
-	/**
-	 * Main method for the cached object. Call this from TypoScript by a USER or COBJ cObject.
-	 */
-	public function getUserFunc ($content, $conf) {
-		$conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tt_products.'];
+    /**
+     * Main method for the cached object. Call this from TypoScript by a USER or COBJ cObject.
+     */
+    public function getUserFunc ($content, $conf) {
+        $conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tt_products.'];
 
-		if (
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getUserFunc']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getUserFunc'])
-		) {
-			foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getUserFunc'] as $classRef) {
+        ) {
+            foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getUserFunc'] as $classRef) {
                 $hookObj = GeneralUtility::makeInstance($classRef);
                 if (method_exists($hookObj, 'getUserFunc')) {
                     if (method_exists($hookObj, 'setContentObjectRenderer')) {
@@ -99,9 +99,9 @@ class tx_ttproducts_pi1 implements \TYPO3\CMS\Core\SingletonInterface {
                     }
                     $content .= $hookObj->getUserFunc($content, $conf);
                 }
-			}
-		}
-		return $content;
-	}
+            }
+        }
+        return $content;
+    }
 }
 

--- a/pi1/class.tx_ttproducts_pi1_base.php
+++ b/pi1/class.tx_ttproducts_pi1_base.php
@@ -47,58 +47,58 @@ use JambageCom\TtProducts\Api\PluginApi;
 
 
 class tx_ttproducts_pi1_base extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin implements \TYPO3\CMS\Core\SingletonInterface {
-	public $prefixId = TT_PRODUCTS_EXT;
-	public $scriptRelPath = 'pi1/class.tx_ttproducts_pi1_base.php';	// Path to this script relative to the extension dir.
-	public $extKey = TT_PRODUCTS_EXT;	// The extension key.
-	public $bRunAjax = false;			// overrride this
+    public $prefixId = TT_PRODUCTS_EXT;
+    public $scriptRelPath = 'pi1/class.tx_ttproducts_pi1_base.php';	// Path to this script relative to the extension dir.
+    public $extKey = TT_PRODUCTS_EXT;	// The extension key.
+    public $bRunAjax = false;			// overrride this
 
     public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
     {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * Main method. Call this from TypoScript by a USER or USER_INT cObject.
-	 */
-	public function main ($content, $conf) {
+    /**
+     * Main method. Call this from TypoScript by a USER or USER_INT cObject.
+     */
+    public function main ($content, $conf) {
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
-		$parameterApi->setPrefixId($this->prefixId);
+        $parameterApi->setPrefixId($this->prefixId);
         PluginApi::init($conf);
-		tx_ttproducts_model_control::setPrefixId($this->prefixId);
+        tx_ttproducts_model_control::setPrefixId($this->prefixId);
 
-		$this->conf = $conf;
-		$config = [];
-		$mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');	// fetch and store it as persistent object
-		$errorCode = [];
+        $this->conf = $conf;
+        $config = [];
+        $mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');	// fetch and store it as persistent object
+        $errorCode = [];
         $mainObj->setContentObjectRenderer($this->cObj);
-		$bDoProcessing =
-			$mainObj->init(
-				$conf,
-				$config,
-				$this->cObj,
-				get_class($this),
-				$errorCode
-			);
+        $bDoProcessing =
+            $mainObj->init(
+                $conf,
+                $config,
+                $this->cObj,
+                get_class($this),
+                $errorCode
+            );
 
-		if ($bDoProcessing || !empty($errorCode)) {
-			$content =
-				$mainObj->run(
-					$this->cObj,
-					get_class($this),
-					$errorCode,
-					$content
-				);
-		} else {
-			$mainObj->destruct();
-		}
+        if ($bDoProcessing || !empty($errorCode)) {
+            $content =
+                $mainObj->run(
+                    $this->cObj,
+                    get_class($this),
+                    $errorCode,
+                    $content
+                );
+        } else {
+            $mainObj->destruct();
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 
 
-	public function set ($bRunAjax) {
-		$this->bRunAjax = $bRunAjax;
-	}
+    public function set ($bRunAjax) {
+        $this->bRunAjax = $bRunAjax;
+    }
 }
 
 

--- a/pi_int/class.tx_ttproducts_pi_int.php
+++ b/pi_int/class.tx_ttproducts_pi_int.php
@@ -52,21 +52,21 @@ class tx_ttproducts_pi_int implements \TYPO3\CMS\Core\SingletonInterface {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * Main method. Call this from TypoScript by a USER cObject.
-	 */
-	public function main ($content, $conf) {
+    /**
+     * Main method. Call this from TypoScript by a USER cObject.
+     */
+    public function main ($content, $conf) {
 
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi_int_base');
-		$pibaseObj->cObj = $this->cObj;
-		$confMain = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi_int_base');
+        $pibaseObj->cObj = $this->cObj;
+        $confMain = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
         \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($confMain, $conf);
-		$conf = $confMain;
-		$languageSubpath = '/Resources/Private/Language/';
+        $conf = $confMain;
+        $languageSubpath = '/Resources/Private/Language/';
 
-		if (!empty($conf['templateFile'])) {
+        if (!empty($conf['templateFile'])) {
 
-			$content = $pibaseObj->main($content, $conf);
+            $content = $pibaseObj->main($content, $conf);
         } else {
             if (count($conf) > 2) {
                 $errorText = $GLOBALS['TSFE']->sL(
@@ -79,6 +79,6 @@ class tx_ttproducts_pi_int implements \TYPO3\CMS\Core\SingletonInterface {
                 );
             }
         }
-		return $content;
-	}
+        return $content;
+    }
 }

--- a/pi_int/class.tx_ttproducts_pi_int_base.php
+++ b/pi_int/class.tx_ttproducts_pi_int_base.php
@@ -48,55 +48,55 @@ use JambageCom\TtProducts\Api\PluginApi;
 
 
 class tx_ttproducts_pi_int_base extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin implements \TYPO3\CMS\Core\SingletonInterface {
-	public $prefixId = TT_PRODUCTS_EXT;
-	public $scriptRelPath = 'pi_int_base/class.tx_ttproducts_pi_int_base.php';	// Path to this script relative to the extension dir.
-	public $extKey = TT_PRODUCTS_EXT;	// The extension key.
-	public $bRunAjax = false;		// overrride this
+    public $prefixId = TT_PRODUCTS_EXT;
+    public $scriptRelPath = 'pi_int_base/class.tx_ttproducts_pi_int_base.php';	// Path to this script relative to the extension dir.
+    public $extKey = TT_PRODUCTS_EXT;	// The extension key.
+    public $bRunAjax = false;		// overrride this
 
     public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
     {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * Main method. Call this from TypoScript by a USER cObject.
-	 */
-	public function main ($content, $conf) {
+    /**
+     * Main method. Call this from TypoScript by a USER cObject.
+     */
+    public function main ($content, $conf) {
 
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
-		$parameterApi->setPrefixId($this->prefixId);
+        $parameterApi->setPrefixId($this->prefixId);
         PluginApi::init($conf);
-		tx_ttproducts_model_control::setPrefixId($this->prefixId);
+        tx_ttproducts_model_control::setPrefixId($this->prefixId);
 
-		$this->conf = $conf;
-		$config = [];
-		$mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');	// fetch and store it as persistent object
-		$mainObj->bNoCachePossible = false;
-		$errorCode = [];
-		$bDoProcessing =
-			$mainObj->init(
-				$conf,
-				$config,
-				$this->cObj,
-				get_class($this),
-				$errorCode
-			);
+        $this->conf = $conf;
+        $config = [];
+        $mainObj = GeneralUtility::makeInstance('tx_ttproducts_main');	// fetch and store it as persistent object
+        $mainObj->bNoCachePossible = false;
+        $errorCode = [];
+        $bDoProcessing =
+            $mainObj->init(
+                $conf,
+                $config,
+                $this->cObj,
+                get_class($this),
+                $errorCode
+            );
 
-		if ($bDoProcessing || !empty($errorCode)) {
-			$content =
-				$mainObj->run(
-					$this->cObj,
-					get_class($this),
-					$errorCode,
-					$content
-				);
-		}
-		return $content;
-	}
+        if ($bDoProcessing || !empty($errorCode)) {
+            $content =
+                $mainObj->run(
+                    $this->cObj,
+                    get_class($this),
+                    $errorCode,
+                    $content
+                );
+        }
+        return $content;
+    }
 
 
-	public function set ($bRunAjax) {
-		$this->bRunAjax = $bRunAjax;
-	}
+    public function set ($bRunAjax) {
+        $this->bRunAjax = $bRunAjax;
+    }
 }
 

--- a/pi_search/class.tx_ttproducts_pi_search.php
+++ b/pi_search/class.tx_ttproducts_pi_search.php
@@ -50,28 +50,28 @@ class tx_ttproducts_pi_search {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * Main method. Call this from TypoScript by a USER cObject.
-	 */
-	public function main($content, $conf) {
+    /**
+     * Main method. Call this from TypoScript by a USER cObject.
+     */
+    public function main($content, $conf) {
 
-		$pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi_search_base');
-		$pibaseObj->cObj = $this->cObj;
-		$languageSubpath = '/Resources/Private/Language/';
+        $pibaseObj = GeneralUtility::makeInstance('tx_ttproducts_pi_search_base');
+        $pibaseObj->cObj = $this->cObj;
+        $languageSubpath = '/Resources/Private/Language/';
 
-		if (!empty($conf['templateFile'])) {
+        if (!empty($conf['templateFile'])) {
 
-			$content = $pibaseObj->main($content, $conf);
-		} else {
+            $content = $pibaseObj->main($content, $conf);
+        } else {
             $errorText = $GLOBALS['TSFE']->sL(
                 'LLL:EXT:' . TT_PRODUCTS_EXT . $languageSubpath . 'PiSearch/locallang.xlf:no_template'
             );
 
-			$content = str_replace('|', 'plugin.tt_products_pi_search.templateFile', $errorText);
-		}
+            $content = str_replace('|', 'plugin.tt_products_pi_search.templateFile', $errorText);
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 }
 
 

--- a/pi_search/class.tx_ttproducts_pi_search_base.php
+++ b/pi_search/class.tx_ttproducts_pi_search_base.php
@@ -46,55 +46,55 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use JambageCom\TtProducts\Api\PluginApi;
 
 class tx_ttproducts_pi_search_base extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin implements \TYPO3\CMS\Core\SingletonInterface {
-	public $prefixId = TT_PRODUCTS_EXT;
-	public $scriptRelPath = 'pi_search_base/class.tx_ttproducts_pi_search_base.php';	// Path to this script relative to the extension dir.
-	public $extKey = TT_PRODUCTS_EXT;	// The extension key.
-	public $pi_checkCHash = true;		// activate cHash
-	public $bRunAjax = false;		// overrride this
+    public $prefixId = TT_PRODUCTS_EXT;
+    public $scriptRelPath = 'pi_search_base/class.tx_ttproducts_pi_search_base.php';	// Path to this script relative to the extension dir.
+    public $extKey = TT_PRODUCTS_EXT;	// The extension key.
+    public $pi_checkCHash = true;		// activate cHash
+    public $bRunAjax = false;		// overrride this
 
     public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
     {
         $this->cObj = $cObj;
     }
 
-	/**
-	 * Main method. Call this from TypoScript by a USER cObject.
-	 */
-	public function main ($content, $conf) {
-		tx_ttproducts_model_control::setPrefixId($this->prefixId);
+    /**
+     * Main method. Call this from TypoScript by a USER cObject.
+     */
+    public function main ($content, $conf) {
+        tx_ttproducts_model_control::setPrefixId($this->prefixId);
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
-		$parameterApi->setPrefixId($this->prefixId);
+        $parameterApi->setPrefixId($this->prefixId);
         PluginApi::init($conf);
 
-		$confMain = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
-		$this->conf = array_merge($confMain, $conf);
-		$config = [];
-		$mainObj = GeneralUtility::makeInstance('tx_ttproducts_control_search');	// fetch and store it as persistent object
-		$errorCode = [];
-		$bDoProcessing =
-			$mainObj->init(
-				$this->conf,
-				$config,
-				$this->cObj,
-				get_class($this),
-				$errorCode
-			);
+        $confMain = $GLOBALS['TSFE']->tmpl->setup['plugin.'][TT_PRODUCTS_EXT . '.'];
+        $this->conf = array_merge($confMain, $conf);
+        $config = [];
+        $mainObj = GeneralUtility::makeInstance('tx_ttproducts_control_search');	// fetch and store it as persistent object
+        $errorCode = [];
+        $bDoProcessing =
+            $mainObj->init(
+                $this->conf,
+                $config,
+                $this->cObj,
+                get_class($this),
+                $errorCode
+            );
 
-		if ($bDoProcessing || !empty($errorCode)) {
-			$content =
-				$mainObj->run(
-					$this->cObj,
-					get_class($this),
-					$errorCode,
-					$content
-				);
-		}
-		return $content;
-	}
+        if ($bDoProcessing || !empty($errorCode)) {
+            $content =
+                $mainObj->run(
+                    $this->cObj,
+                    get_class($this),
+                    $errorCode,
+                    $content
+                );
+        }
+        return $content;
+    }
 
 
-	public function set ($bRunAjax) {
-		$this->bRunAjax = $bRunAjax;
-	}
+    public function set ($bRunAjax) {
+        $this->bRunAjax = $bRunAjax;
+    }
 }
 

--- a/view/class.tx_ttproducts_account_view.php
+++ b/view/class.tx_ttproducts_account_view.php
@@ -38,31 +38,31 @@
  */
 
 class tx_ttproducts_account_view extends tx_ttproducts_table_base_view {
-	public $marker = 'ACCOUNT';
+    public $marker = 'ACCOUNT';
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getMarkerArray ($row, &$markerArray, $bIsAllowed) {
-		$viewRow = [];
-		$modelObj = $this->getModelObj();
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getMarkerArray ($row, &$markerArray, $bIsAllowed) {
+        $viewRow = [];
+        $modelObj = $this->getModelObj();
 
-		if ($bIsAllowed) {
-			$viewRow = $row;
-		}
+        if ($bIsAllowed) {
+            $viewRow = $row;
+        }
 
-		$fieldArray = $modelObj->requiredFieldArray;
-		foreach ($fieldArray as $field) {
-			$markerArray['###PERSON_ACCOUNTS_' . strtoupper($field) . '###'] = $viewRow[$field] ?? '';
-		}
-	} // getMarkerArray
+        $fieldArray = $modelObj->requiredFieldArray;
+        foreach ($fieldArray as $field) {
+            $markerArray['###PERSON_ACCOUNTS_' . strtoupper($field) . '###'] = $viewRow[$field] ?? '';
+        }
+    } // getMarkerArray
 }

--- a/view/class.tx_ttproducts_address_view.php
+++ b/view/class.tx_ttproducts_address_view.php
@@ -42,69 +42,69 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_address_view extends tx_ttproducts_category_base_view {
-	public $piVar = 'a';
-	public $marker = 'ADDRESS';
+    public $piVar = 'a';
+    public $marker = 'ADDRESS';
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for the address
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 				for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$category,
-		$pid,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		&$viewCatTagArray,
-		$forminfoArray = [],
-		$pageAsCategory = 0,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$id,
-		$prefix,
-		$linkWrap = ''
-	) {
-		$titleField = $this->getModelObj()->fieldArray['title'];
-		$row = ($category ? $this->getModelObj()->get($category) : array ($titleField => '', 'pid' => $pid));
-		$catTitle = '';
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for the address
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 				for the tt_producst record, $row
+     * @access private
+     */
+    public function getMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $category,
+        $pid,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        &$viewCatTagArray,
+        $forminfoArray = [],
+        $pageAsCategory = 0,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $id,
+        $prefix,
+        $linkWrap = ''
+    ) {
+        $titleField = $this->getModelObj()->fieldArray['title'];
+        $row = ($category ? $this->getModelObj()->get($category) : array ($titleField => '', 'pid' => $pid));
+        $catTitle = '';
 
-		if (($row[$titleField])) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableConfig = $cnf->getTableConf('address', $theCode);
-			$catTitle .= ($tableConfig['separator'] . $row[$titleField]);
-		}
-		$this->setMarkerArrayCatTitle($markerArray, $catTitle, $prefix);
-		parent::getRowMarkerArray(
-			'address',
-			$row,
-			$markerKey,
-			$markerArray,
-			$variantFieldArray,
-			$variantMarkerArray,
-			$viewCatTagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$bHtml,
-			$charset,
-			$imageNum,
-			$imageRenderObj,
-			$id,
-			$prefix,
-			'',
-			$linkWrap
-		);
-	}
+        if (($row[$titleField])) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableConfig = $cnf->getTableConf('address', $theCode);
+            $catTitle .= ($tableConfig['separator'] . $row[$titleField]);
+        }
+        $this->setMarkerArrayCatTitle($markerArray, $catTitle, $prefix);
+        parent::getRowMarkerArray(
+            'address',
+            $row,
+            $markerKey,
+            $markerArray,
+            $variantFieldArray,
+            $variantMarkerArray,
+            $viewCatTagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $bHtml,
+            $charset,
+            $imageNum,
+            $imageRenderObj,
+            $id,
+            $prefix,
+            '',
+            $linkWrap
+        );
+    }
 }
 

--- a/view/class.tx_ttproducts_admin_control_view.php
+++ b/view/class.tx_ttproducts_admin_control_view.php
@@ -40,29 +40,29 @@
 class tx_ttproducts_admin_control_view {
 
 
-	static public function getHiddenField ($updateCode) {
-		$result = '<input type="hidden" name="update_code" value="' . $updateCode . '" />';
-		return $result;
-	}
+    static public function getHiddenField ($updateCode) {
+        $result = '<input type="hidden" name="update_code" value="' . $updateCode . '" />';
+        return $result;
+    }
 
-	static public function getSubpartArrays (
-		$bIsAllowed,
-		$bValidUpdateCode,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
-			// Display admin-interface if access.
-		if (!$bIsAllowed) {
-			$subpartArray['###ADMIN_CONTROL###'] = '';
-		} elseif ($bValidUpdateCode) {
-			$subpartArray['###ADMIN_CONTROL_DENY###'] = '';
-			$wrappedSubpartArray['###ADMIN_CONTROL_OK###'] = '';
-			$wrappedSubpartArray['###ADMIN_CONTROL###'] = '';
-		} else {
-			$subpartArray['###ADMIN_CONTROL_OK###'] = '';
-			$wrappedSubpartArray['###ADMIN_CONTROL_DENY###'] = '';
-			$wrappedSubpartArray['###ADMIN_CONTROL###'] = '';
-		}
-	}
+    static public function getSubpartArrays (
+        $bIsAllowed,
+        $bValidUpdateCode,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
+            // Display admin-interface if access.
+        if (!$bIsAllowed) {
+            $subpartArray['###ADMIN_CONTROL###'] = '';
+        } elseif ($bValidUpdateCode) {
+            $subpartArray['###ADMIN_CONTROL_DENY###'] = '';
+            $wrappedSubpartArray['###ADMIN_CONTROL_OK###'] = '';
+            $wrappedSubpartArray['###ADMIN_CONTROL###'] = '';
+        } else {
+            $subpartArray['###ADMIN_CONTROL_OK###'] = '';
+            $wrappedSubpartArray['###ADMIN_CONTROL_DENY###'] = '';
+            $wrappedSubpartArray['###ADMIN_CONTROL###'] = '';
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_article_base_view.php
+++ b/view/class.tx_ttproducts_article_base_view.php
@@ -44,94 +44,94 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 abstract class tx_ttproducts_article_base_view extends tx_ttproducts_table_base_view {
-	private $dataArray = []; // array of read in products
-	private $table;	 // object of the type tx_table_db
+    private $dataArray = []; // array of read in products
+    private $table;	 // object of the type tx_table_db
 
-	public $tabledesc;
-	public $fields = [];
-	public $type; 	// the type of table 'article' or 'product'
-			// this gets in lower case also used for the URL parameter
-	public $variant;       // object for the product variant attributes, must initialized in the init function
-	public $editVariant; 	// object for the product editable variant attributes, must initialized in the init function
-	protected $mm_table = ''; // only set if a mm table is used
-	protected $graduatedPriceObject = false;
-
-
-	public function init ($modelObj) {
-		$result = parent::init($modelObj);
-
-		if ($result) {
-			if (!isset($this->variant)) {
-				$this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_dummy_view');
-			}
-			if (!isset($this->editVariant)) {
-				$this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_dummy_view');
-			}
-
-			$this->variant->init($modelObj->variant);
-			$this->editVariant->init($modelObj->editVariant);
-
-			$type = $modelObj->getType();
-			if (
-				$type == 'product' ||
-				$type == 'article'
-			) {
-				$graduatedPriceViewObj =
-					GeneralUtility::makeInstance('tx_ttproducts_graduated_price_view');
-				$graduatedPriceObj = $modelObj->getGraduatedPriceObject();
-				$graduatedPriceViewObj->init($graduatedPriceObj);
-				$this->setGraduatedPriceObject($graduatedPriceViewObj);
-			}
-		}
-
-		return $result;
-	}
-
-	public function setGraduatedPriceObject ($value) {
-		$this->graduatedPriceObject = $value;
-	}
+    public $tabledesc;
+    public $fields = [];
+    public $type; 	// the type of table 'article' or 'product'
+            // this gets in lower case also used for the URL parameter
+    public $variant;       // object for the product variant attributes, must initialized in the init function
+    public $editVariant; 	// object for the product editable variant attributes, must initialized in the init function
+    protected $mm_table = ''; // only set if a mm table is used
+    protected $graduatedPriceObject = false;
 
 
-	public function getGraduatedPriceObject () {
-		return $this->graduatedPriceObject;
-	}
+    public function init ($modelObj) {
+        $result = parent::init($modelObj);
 
-	public function getEditVariant () {
-		return $this->editVariant;
-	}
+        if ($result) {
+            if (!isset($this->variant)) {
+                $this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_dummy_view');
+            }
+            if (!isset($this->editVariant)) {
+                $this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_dummy_view');
+            }
 
-	public function getVariant () {
-		return $this->variant;
-	}
+            $this->variant->init($modelObj->variant);
+            $this->editVariant->init($modelObj->editVariant);
 
-	public function getItemMarkerSubpartArrays (
-		$templateCode,
-		$functablename,
-		$row,
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$tagArray,
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$iCount = ''
-	) {
-		$this->getItemSubpartArrays(
-			$templateCode,
-			$functablename,
-			$row,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$tagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$iCount
-		);
-	}
+            $type = $modelObj->getType();
+            if (
+                $type == 'product' ||
+                $type == 'article'
+            ) {
+                $graduatedPriceViewObj =
+                    GeneralUtility::makeInstance('tx_ttproducts_graduated_price_view');
+                $graduatedPriceObj = $modelObj->getGraduatedPriceObject();
+                $graduatedPriceViewObj->init($graduatedPriceObj);
+                $this->setGraduatedPriceObject($graduatedPriceViewObj);
+            }
+        }
+
+        return $result;
+    }
+
+    public function setGraduatedPriceObject ($value) {
+        $this->graduatedPriceObject = $value;
+    }
+
+
+    public function getGraduatedPriceObject () {
+        return $this->graduatedPriceObject;
+    }
+
+    public function getEditVariant () {
+        return $this->editVariant;
+    }
+
+    public function getVariant () {
+        return $this->variant;
+    }
+
+    public function getItemMarkerSubpartArrays (
+        $templateCode,
+        $functablename,
+        $row,
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $tagArray,
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $iCount = ''
+    ) {
+        $this->getItemSubpartArrays(
+            $templateCode,
+            $functablename,
+            $row,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $tagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $iCount
+        );
+    }
 
     public function getItemSubpartArrays (
         &$templateCode,
@@ -146,190 +146,190 @@ abstract class tx_ttproducts_article_base_view extends tx_ttproducts_table_base_
         $id = '',
         $checkPriceZero = false
     ) {
-		parent::getItemSubpartArrays(
-			$templateCode,
-			$functablename,
-			$row,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$tagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$id
-		);
-	}
+        parent::getItemSubpartArrays(
+            $templateCode,
+            $functablename,
+            $row,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $tagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $id
+        );
+    }
 
 
-	public function getCurrentPriceMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$originalName,
-		$originalRow,
-		$mergedName,
-		$mergedRow,
-		$id,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$bEnableTaxZero = false,
+    public function getCurrentPriceMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $originalName,
+        $originalRow,
+        $mergedName,
+        $mergedRow,
+        $id,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
-	) {
-		if (is_array($mergedRow)) {
-			$row = $mergedRow;
-			if (is_array($originalRow) && count($originalRow)) {
-				if ($mergedName != '') {
-					$id .= 'from-' . str_replace('_', '-', $mergedName);
-				}
+    ) {
+        if (is_array($mergedRow)) {
+            $row = $mergedRow;
+            if (is_array($originalRow) && count($originalRow)) {
+                if ($mergedName != '') {
+                    $id .= 'from-' . str_replace('_', '-', $mergedName);
+                }
 
-				$row['uid'] = $originalRow['uid'];
-				foreach ($originalRow as $k => $v) {
-					if (!isset($row[$k])) {
-						$row[$k] = $v;
-					}
-				}
-			}
-		} else {
-			$row = $originalRow;
-		}
+                $row['uid'] = $originalRow['uid'];
+                foreach ($originalRow as $k => $v) {
+                    if (!isset($row[$k])) {
+                        $row[$k] = $v;
+                    }
+                }
+            }
+        } else {
+            $row = $originalRow;
+        }
 
-		$this->getPriceMarkerArray(
-			$basketExtra,
-			$basketRecs,
-			$markerArray,
-			$row,
-			$markerKey,
-			$id,
-			$theCode,
-			$bEnableTaxZero,
+        $this->getPriceMarkerArray(
+            $basketExtra,
+            $basketRecs,
+            $markerArray,
+            $row,
+            $markerKey,
+            $id,
+            $theCode,
+            $bEnableTaxZero,
             $notOverwritePriceIfSet
-		);
-	}
+        );
+    }
 
 
-	public function getPriceMarkerArray (
-		$basketExtra,
-		$basketRecs,
-		&$markerArray,
-		$row,
-		$markerKey,
-		$id,
-		$theCode,
-		$bEnableTaxZero = false,
+    public function getPriceMarkerArray (
+        $basketExtra,
+        $basketRecs,
+        &$markerArray,
+        $row,
+        $markerKey,
+        $id,
+        $theCode,
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
-	) {
-		$modelObj = $this->getModelObj();
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$functablename = $modelObj->getFuncTablename();
+    ) {
+        $modelObj = $this->getModelObj();
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $functablename = $modelObj->getFuncTablename();
 
-		$mainId = $this->getId($row, $id, $theCode);
+        $mainId = $this->getId($row, $id, $theCode);
 
-		foreach ($GLOBALS['TCA'][$functablename]['columns'] as $field => $fieldTCA) {
-			if (strpos($field, 'price') === 0) {
-				$priceViewObj->getModelMarkerArray(
-					$functablename,
-					$basketExtra,
-					$basketRecs,
-					$field,
-					$row,
-					$markerArray,
-					$markerKey,
-					$mainId,
-					$bEnableTaxZero,
+        foreach ($GLOBALS['TCA'][$functablename]['columns'] as $field => $fieldTCA) {
+            if (strpos($field, 'price') === 0) {
+                $priceViewObj->getModelMarkerArray(
+                    $functablename,
+                    $basketExtra,
+                    $basketRecs,
+                    $field,
+                    $row,
+                    $markerArray,
+                    $markerKey,
+                    $mainId,
+                    $bEnableTaxZero,
                     $notOverwritePriceIfSet
-				);
-			}
-		}
-	}
+                );
+            }
+        }
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 			 		for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getModelMarkerArray (
-		$row,
-		$markerKey,
-		&$markerArray,
-		$catTitle,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		$tagArray = [],
-		$forminfoArray = [],
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '',
-		$prefix = '',
-		$suffix = '',
-		$linkWrap = '',
-		$bHtml = true,
-		$charset = '',
-		$hiddenFields = '',
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$bEnableTaxZero = false,
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 			 		for the tt_producst record, $row
+     * @access private
+     */
+    public function getModelMarkerArray (
+        $row,
+        $markerKey,
+        &$markerArray,
+        $catTitle,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        $tagArray = [],
+        $forminfoArray = [],
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '',
+        $prefix = '',
+        $suffix = '',
+        $linkWrap = '',
+        $bHtml = true,
+        $charset = '',
+        $hiddenFields = '',
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
-	) {
-		$modelObj = $this->getModelObj();
-		$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    ) {
+        $modelObj = $this->getModelObj();
+        $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		if ($markerKey) {
-			$marker = $markerKey;
-		} else {
-			$marker = $this->getMarker();
-		}
+        if ($markerKey) {
+            $marker = $markerKey;
+        } else {
+            $marker = $this->getMarker();
+        }
 
-		if (!$marker) {
-			return [];
-		}
-		$variantFieldArray = $modelObj->variant->getFieldArray();
-		$variantMarkerArray = [];
+        if (!$marker) {
+            return [];
+        }
+        $variantFieldArray = $modelObj->variant->getFieldArray();
+        $variantMarkerArray = [];
 
-		$this->getRowMarkerArray(
-			$modelObj->getFuncTablename(),
-			$row,
-			$marker,
-			$markerArray,
-			$variantFieldArray,
-			$variantMarkerArray,
-			$tagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$bHtml,
-			$charset,
-			$imageNum,
-			$imageRenderObj,
-			$id,
-			$prefix,
-			$suffix,
-			$linkWrap,
-			$bEnableTaxZero
-		);
+        $this->getRowMarkerArray(
+            $modelObj->getFuncTablename(),
+            $row,
+            $marker,
+            $markerArray,
+            $variantFieldArray,
+            $variantMarkerArray,
+            $tagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $bHtml,
+            $charset,
+            $imageNum,
+            $imageRenderObj,
+            $id,
+            $prefix,
+            $suffix,
+            $linkWrap,
+            $bEnableTaxZero
+        );
 
-		$this->getPriceMarkerArray(
-			$basketExtra,
-			$basketRecs,
-			$markerArray,
-			$row,
-			$markerKey,
-			$id,
-			$theCode,
-			$bEnableTaxZero,
+        $this->getPriceMarkerArray(
+            $basketExtra,
+            $basketRecs,
+            $markerArray,
+            $row,
+            $markerKey,
+            $id,
+            $theCode,
+            $bEnableTaxZero,
             $notOverwritePriceIfSet
-		);
-	}
+        );
+    }
 }
 

--- a/view/class.tx_ttproducts_article_view.php
+++ b/view/class.tx_ttproducts_article_view.php
@@ -40,9 +40,9 @@
 
 
 class tx_ttproducts_article_view extends tx_ttproducts_article_base_view {
-	public $marker = 'ARTICLE';
-	public $type = 'article';
-	public $piVar = 'article';
+    public $marker = 'ARTICLE';
+    public $type = 'article';
+    public $piVar = 'article';
 
 }
 

--- a/view/class.tx_ttproducts_basket_view.php
+++ b/view/class.tx_ttproducts_basket_view.php
@@ -50,76 +50,76 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 use JambageCom\TtProducts\Api\PaymentShippingHandling;
 
 class tx_ttproducts_basket_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $config;
-	public $price; // price object
-	public $urlObj; // url functions
-	public $urlArray; // overridden url destinations
-	public $funcTablename;
-	public $errorCode;
-	public $useArticles;
+    public $conf;
+    public $config;
+    public $price; // price object
+    public $urlObj; // url functions
+    public $urlArray; // overridden url destinations
+    public $funcTablename;
+    public $errorCode;
+    public $useArticles;
 
 
-	/**
-	 * Initialized the basket, setting the deliveryInfo if a users is logged in
-	 * $basketObj is the TYPO3 default shopping basket array from ses-data
-	 *
-	 * @param	string		  $fieldname is the field in the table you want to create a JavaScript for
-	 * @return	  void
-	 */
-	public function init (
-		$useArticles,
-		$errorCode,
-		$urlArray = []
-	) {
-		$this->errorCode = $errorCode;
-		$this->useArticles = $useArticles;
+    /**
+     * Initialized the basket, setting the deliveryInfo if a users is logged in
+     * $basketObj is the TYPO3 default shopping basket array from ses-data
+     *
+     * @param	string		  $fieldname is the field in the table you want to create a JavaScript for
+     * @return	  void
+     */
+    public function init (
+        $useArticles,
+        $errorCode,
+        $urlArray = []
+    ) {
+        $this->errorCode = $errorCode;
+        $this->useArticles = $useArticles;
 
-		$this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
-		$this->urlObj->setUrlArray($urlArray);
-	} // init
+        $this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
+        $this->urlObj->setUrlArray($urlArray);
+    } // init
 
 
-	public function getMarkerArray (
-		$basketExtra,
-		$calculatedArray,
-		$taxArray
-	) {
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$markerArray = [];
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->conf;
+    public function getMarkerArray (
+        $basketExtra,
+        $calculatedArray,
+        $taxArray
+    ) {
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $markerArray = [];
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->conf;
 
-			// This is the total for the goods in the basket.
-		$markerArray['###PRICE_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['goodstotal']['ALL'] + $calculatedArray['deposittax']['goodstotal']['ALL']);
-		$markerArray['###PRICE_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceNoTax']['goodstotal']['ALL'] + $calculatedArray['depositnotax']['goodstotal']['ALL']);
-		$markerArray['###PRICE_GOODSTOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['goodstotal']['ALL'] - $calculatedArray['priceNoTax']['goodstotal']['ALL'] + $calculatedArray['deposittax']['goodstotal']['ALL'] - $calculatedArray['depositnotax']['goodstotal']['ALL']);
+            // This is the total for the goods in the basket.
+        $markerArray['###PRICE_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['goodstotal']['ALL'] + $calculatedArray['deposittax']['goodstotal']['ALL']);
+        $markerArray['###PRICE_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceNoTax']['goodstotal']['ALL'] + $calculatedArray['depositnotax']['goodstotal']['ALL']);
+        $markerArray['###PRICE_GOODSTOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['goodstotal']['ALL'] - $calculatedArray['priceNoTax']['goodstotal']['ALL'] + $calculatedArray['deposittax']['goodstotal']['ALL'] - $calculatedArray['depositnotax']['goodstotal']['ALL']);
 
-		$markerArray['###PRICE2_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2Tax']['goodstotal']['ALL']);
-		$markerArray['###PRICE2_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2NoTax']['goodstotal']['ALL']);
-		$markerArray['###PRICE2_GOODSTOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2Tax']['goodstotal']['ALL'] - $calculatedArray['price2NoTax']['goodstotal']['ALL']);
+        $markerArray['###PRICE2_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2Tax']['goodstotal']['ALL']);
+        $markerArray['###PRICE2_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2NoTax']['goodstotal']['ALL']);
+        $markerArray['###PRICE2_GOODSTOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($calculatedArray['price2Tax']['goodstotal']['ALL'] - $calculatedArray['price2NoTax']['goodstotal']['ALL']);
 
-		$markerArray['###PRICE_DISCOUNT_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['noDiscountPriceTax']['goodstotal']['ALL'] - $calculatedArray['priceTax']['goodstotal']['ALL']);
-		$markerArray['###PRICE_DISCOUNT_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['noDiscountPriceNoTax']['goodstotal']['ALL'] - $calculatedArray['priceNoTax']['goodstotal']['ALL']);
+        $markerArray['###PRICE_DISCOUNT_GOODSTOTAL_TAX###'] = $priceViewObj->priceFormat($calculatedArray['noDiscountPriceTax']['goodstotal']['ALL'] - $calculatedArray['priceTax']['goodstotal']['ALL']);
+        $markerArray['###PRICE_DISCOUNT_GOODSTOTAL_NO_TAX###'] = $priceViewObj->priceFormat($calculatedArray['noDiscountPriceNoTax']['goodstotal']['ALL'] - $calculatedArray['priceNoTax']['goodstotal']['ALL']);
 
-		if (
-			isset($taxArray) &&
-			is_array($taxArray) &&
-			!empty($taxArray)
-		) {
-			foreach ($taxArray as $k => $taxrate) {
-				$calculatedTax = $taxObj->getFieldCalculatedValue($taxrate, $basketExtra);
-				if ($calculatedTax !== false) {
-					$taxrate = $calculatedTax;
-				}
-				$taxstr = strval(number_format(floatval($taxrate), 2));
-				$label = chr(ord('A') + $k);
-				$markerArray['###PRICE_TAXRATE_NAME' . ($k + 1) . '###'] = $label;
-				$markerArray['###PRICE_TAXRATE_TAX' . ($k + 1) . '###'] = $taxrate;
+        if (
+            isset($taxArray) &&
+            is_array($taxArray) &&
+            !empty($taxArray)
+        ) {
+            foreach ($taxArray as $k => $taxrate) {
+                $calculatedTax = $taxObj->getFieldCalculatedValue($taxrate, $basketExtra);
+                if ($calculatedTax !== false) {
+                    $taxrate = $calculatedTax;
+                }
+                $taxstr = strval(number_format(floatval($taxrate), 2));
+                $label = chr(ord('A') + $k);
+                $markerArray['###PRICE_TAXRATE_NAME' . ($k + 1) . '###'] = $label;
+                $markerArray['###PRICE_TAXRATE_TAX' . ($k + 1) . '###'] = $taxrate;
 
-				if (isset($calculatedArray['priceNoTax']['sametaxtotal']['ALL'][$taxstr])) {
+                if (isset($calculatedArray['priceNoTax']['sametaxtotal']['ALL'][$taxstr])) {
                     $label = $calculatedArray['priceNoTax']['sametaxtotal']['ALL'][$taxstr] + ($calculatedArray['depositnotax']['sametaxtotal']['ALL'][$taxstr] ?? 0);
                     $markerArray['###PRICE_TAXRATE_TOTAL' . ($k + 1) . '###'] = $priceViewObj->priceFormat($label);
 
@@ -146,854 +146,854 @@ class tx_ttproducts_basket_view implements \TYPO3\CMS\Core\SingletonInterface {
                     $markerArray['###PRICE_TAXRATE_ONLY_TAX' . ($k + 1) . '###'] = $zeroPrice;
                     $markerArray['###PRICE_TAXRATE_GOODSTOTAL_ONLY_TAX' . ($k + 1) . '###'] = $zeroPrice;
                 }
-			}
-		}
+            }
+        }
 
-		// This is for the Basketoverview
-		$markerArray['###NUMBER_GOODSTOTAL###'] = $calculatedArray['count'];
+        // This is for the Basketoverview
+        $markerArray['###NUMBER_GOODSTOTAL###'] = $calculatedArray['count'];
         $fileresource = FrontendUtility::fileResource($conf['basketPic']);
-		$markerArray['###IMAGE_BASKET###'] = $fileresource;
+        $markerArray['###IMAGE_BASKET###'] = $fileresource;
 
-		return $markerArray;
-	}
-
-
-	static public function getDiscountSubpartArray(
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$calculatedArray
-	) {
-		$discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray);
-		if ($discountValue) {
-			$wrappedSubpartArray['###DISCOUNT_NOT_EMPTY###'] = '';
-		} else {
-			$subpartArray['###DISCOUNT_NOT_EMPTY###'] = '';
-		}
-	}
+        return $markerArray;
+    }
 
 
-	public function getBoundaryMarkerArray (
-		$templateCode,
-		$cObj,
-		$cnf,
-		$calculatedArray,
-		$checkPriceArray,
-		$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
+    static public function getDiscountSubpartArray(
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $calculatedArray
+    ) {
+        $discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray);
+        if ($discountValue) {
+            $wrappedSubpartArray['###DISCOUNT_NOT_EMPTY###'] = '';
+        } else {
+            $subpartArray['###DISCOUNT_NOT_EMPTY###'] = '';
+        }
+    }
+
+
+    public function getBoundaryMarkerArray (
+        $templateCode,
+        $cObj,
+        $cnf,
+        $calculatedArray,
+        $checkPriceArray,
+        $markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$basketConfArray = [];
-		// check the basket limits
-		$basketConfArray['minimum'] = $cnf->getBasketConf('minPrice');
-		$basketConfArray['maximum'] = $cnf->getBasketConf('maxPrice');
-		$priceSuccessArray = [];
-		$priceSuccessArray['minimum'] = true;
-		$priceSuccessArray['maximum'] = true;
-		$boundaryArray = ['minimum', 'maximum'];
+        $basketConfArray = [];
+        // check the basket limits
+        $basketConfArray['minimum'] = $cnf->getBasketConf('minPrice');
+        $basketConfArray['maximum'] = $cnf->getBasketConf('maxPrice');
+        $priceSuccessArray = [];
+        $priceSuccessArray['minimum'] = true;
+        $priceSuccessArray['maximum'] = true;
+        $boundaryArray = ['minimum', 'maximum'];
 
-		foreach ($boundaryArray as $boundaryType) {
-			switch ($boundaryType) {
-				case 'minimum':
-					$markerKey = 'MINPRICE';
-					break;
-				case 'maximum':
-					$markerKey = 'MAXPRICE';
-					break;
-			}
+        foreach ($boundaryArray as $boundaryType) {
+            switch ($boundaryType) {
+                case 'minimum':
+                    $markerKey = 'MINPRICE';
+                    break;
+                case 'maximum':
+                    $markerKey = 'MAXPRICE';
+                    break;
+            }
 
-			if (
+            if (
                 isset($checkPriceArray[$boundaryType]) &&
-				$checkPriceArray[$boundaryType] &&
-				isset($basketConfArray[$boundaryType]['type']) &&
-				$basketConfArray[$boundaryType]['type'] == 'price'
-			) {
-				$value = $calculatedArray['priceTax'][$basketConfArray[$boundaryType]['collect']]['ALL'];
+                $checkPriceArray[$boundaryType] &&
+                isset($basketConfArray[$boundaryType]['type']) &&
+                $basketConfArray[$boundaryType]['type'] == 'price'
+            ) {
+                $value = $calculatedArray['priceTax'][$basketConfArray[$boundaryType]['collect']]['ALL'];
 
-				if (
-					isset($value) &&
-					isset($basketConfArray[$boundaryType]['collect']) &&
-					(
-						($boundaryType == 'minimum' && $value < doubleval($basketConfArray[$boundaryType]['value'])) ||
-						($boundaryType == 'maximum' && $value > doubleval($basketConfArray[$boundaryType]['value']))
-					)
-				) {
-					$subpartArray['###MESSAGE_' . $markerKey . '###'] = '';
-					$tmpSubpart = $templateService->getSubpart($templateCode, '###MESSAGE_' . $markerKey . '_ERROR###');
-					$subpartArray['###MESSAGE_' . $markerKey . '_ERROR###'] = $templateService->substituteMarkerArray($tmpSubpart,  $markerArray);
-					$priceSuccessArray[$boundaryType] = false;
-				}
-			}
+                if (
+                    isset($value) &&
+                    isset($basketConfArray[$boundaryType]['collect']) &&
+                    (
+                        ($boundaryType == 'minimum' && $value < doubleval($basketConfArray[$boundaryType]['value'])) ||
+                        ($boundaryType == 'maximum' && $value > doubleval($basketConfArray[$boundaryType]['value']))
+                    )
+                ) {
+                    $subpartArray['###MESSAGE_' . $markerKey . '###'] = '';
+                    $tmpSubpart = $templateService->getSubpart($templateCode, '###MESSAGE_' . $markerKey . '_ERROR###');
+                    $subpartArray['###MESSAGE_' . $markerKey . '_ERROR###'] = $templateService->substituteMarkerArray($tmpSubpart,  $markerArray);
+                    $priceSuccessArray[$boundaryType] = false;
+                }
+            }
 
-			if ($priceSuccessArray[$boundaryType]) {
+            if ($priceSuccessArray[$boundaryType]) {
 
-				$subpartArray['###MESSAGE_' . $markerKey . '_ERROR###'] = '';
-				$tmpSubpart = $templateService->getSubpart($templateCode, '###MESSAGE_' . $markerKey . '###');
-				$subpartArray['###MESSAGE_' . $markerKey . '###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
-			}
-		} // foreach
+                $subpartArray['###MESSAGE_' . $markerKey . '_ERROR###'] = '';
+                $tmpSubpart = $templateService->getSubpart($templateCode, '###MESSAGE_' . $markerKey . '###');
+                $subpartArray['###MESSAGE_' . $markerKey . '###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
+            }
+        } // foreach
 
-		if ($priceSuccessArray['minimum'] && $priceSuccessArray['maximum']) {
-			$wrappedSubpartArray['###MESSAGE_PRICE_VALID###'] = '';
-		} else {
-			$subpartArray['###MESSAGE_PRICE_VALID###'] = '';
-		}
-	}
+        if ($priceSuccessArray['minimum'] && $priceSuccessArray['maximum']) {
+            $wrappedSubpartArray['###MESSAGE_PRICE_VALID###'] = '';
+        } else {
+            $subpartArray['###MESSAGE_PRICE_VALID###'] = '';
+        }
+    }
 
 
-	/**
-	 * This generates the shopping basket layout and also calculates the totals. Very important function.
-	 * TODO: basket view must not make any complex reading of data of articles. Only the itemarray of the basket should be treated with at all.
-	 */
-	public function getView (
-		&$errorCode,
-		$templateCode,
-		$theCode,
-		$infoViewObj,
-		$bSelectSalutation,
-		$bSelectVariants,
-		$calculatedArray,
-		$bHtml = true,
-		$subpartMarker = 'BASKET_TEMPLATE',
-		$mainMarkerArray = [],
-		$templateFilename = '',
-		$itemArray = [],
+    /**
+     * This generates the shopping basket layout and also calculates the totals. Very important function.
+     * TODO: basket view must not make any complex reading of data of articles. Only the itemarray of the basket should be treated with at all.
+     */
+    public function getView (
+        &$errorCode,
+        $templateCode,
+        $theCode,
+        $infoViewObj,
+        $bSelectSalutation,
+        $bSelectVariants,
+        $calculatedArray,
+        $bHtml = true,
+        $subpartMarker = 'BASKET_TEMPLATE',
+        $mainMarkerArray = [],
+        $templateFilename = '',
+        $itemArray = [],
         $notOverwritePriceIfSet = false,
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$basketExtra = [],
-		$basketRecs = []
-	) {
-			/*
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $basketExtra = [],
+        $basketRecs = []
+    ) {
+            /*
 
-				Very central function in the library.
-				By default it extracts the subpart, ###BASKET_TEMPLATE###, from the $templateCode (if given, else the default $this->templateCode)
-				and substitutes a lot of fields and subparts.
-				Any pre-preparred fields can be set in $mainMarkerArray, which is substituted in the subpart before the item-and-categories part is substituted.
-			*/
-		$out = '';
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
-		$basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$articleViewTagArray = [];
-		$checkPriceZero = true;
-		$this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
+                Very central function in the library.
+                By default it extracts the subpart, ###BASKET_TEMPLATE###, from the $templateCode (if given, else the default $this->templateCode)
+                and substitutes a lot of fields and subparts.
+                Any pre-preparred fields can be set in $mainMarkerArray, which is substituted in the subpart before the item-and-categories part is substituted.
+            */
+        $out = '';
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $calculationField = \JambageCom\TtProducts\Model\Field\FieldInterface::PRICE_CALCULATED;
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $creditpointsObj = GeneralUtility::makeInstance('tx_ttproducts_field_creditpoints');
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
+        $basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $taxObj = GeneralUtility::makeInstance('tx_ttproducts_field_tax');
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $articleViewTagArray = [];
+        $checkPriceZero = true;
+        $this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view'); // a copy of it
 
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
-		$viewControlConf = $cnf->getViewControlConf($theCode);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $billdeliveryObj = GeneralUtility::makeInstance('tx_ttproducts_billdelivery');
+        $viewControlConf = $cnf->getViewControlConf($theCode);
         $context = GeneralUtility::makeInstance(Context::class);
 
-		$viewControlConf = $cnf->getViewControlConf($theCode);
-		if (!empty($viewControlConf)) {
-			if (
-				isset($viewControlConf['param.']) &&
-				is_array($viewControlConf['param.'])
-			) {
-				$viewParamConf = $viewControlConf['param.'];
-			}
-		}
+        $viewControlConf = $cnf->getViewControlConf($theCode);
+        if (!empty($viewControlConf)) {
+            if (
+                isset($viewControlConf['param.']) &&
+                is_array($viewControlConf['param.'])
+            ) {
+                $viewParamConf = $viewControlConf['param.'];
+            }
+        }
 
-		$useBackPid =
-			(
-				isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ?
-					true :
-					false
-			);
+        $useBackPid =
+            (
+                isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ?
+                    true :
+                    false
+            );
 
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
 
-		$funcTablename = tx_ttproducts_control_basket::getFuncTablename();
-		$itemTableView = $tablesObj->get($funcTablename, true);
-		$itemTable = $itemTableView->getModelObj();
-		$tableConf = $itemTable->getTableConf($theCode);
-		$itemTable->initCodeConf($theCode, $tableConf);
-		$quantityArray = [];
-		$quantityArray['minimum'] = [];
-		$quantityArray['maximum'] = [];
+        $funcTablename = tx_ttproducts_control_basket::getFuncTablename();
+        $itemTableView = $tablesObj->get($funcTablename, true);
+        $itemTable = $itemTableView->getModelObj();
+        $tableConf = $itemTable->getTableConf($theCode);
+        $itemTable->initCodeConf($theCode, $tableConf);
+        $quantityArray = [];
+        $quantityArray['minimum'] = [];
+        $quantityArray['maximum'] = [];
 
-		$articleViewObj = $tablesObj->get('tt_products_articles', true);
-		$articleTable = $articleViewObj->getModelObj();
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $articleViewObj = $tablesObj->get('tt_products_articles', true);
+        $articleTable = $articleViewObj->getModelObj();
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
-		if ($templateCode == '') {
+        if ($templateCode == '') {
             $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
             $errorCode[0] = 'empty_template';
             $errorCode[1] = ($templateFilename ? $templateFilename : $templateObj->getTemplateFile());
             return '';
-		}
-			// Getting subparts from the template code.
-		$t = [];
+        }
+            // Getting subparts from the template code.
+        $t = [];
 
-		$tempContent =
-			$templateService->getSubpart(
-				$templateCode,
-				$subpartmarkerObj->spMarker(
-					'###' . $subpartMarker . $config['templateSuffix'] . '###'
-				)
-			);
+        $tempContent =
+            $templateService->getSubpart(
+                $templateCode,
+                $subpartmarkerObj->spMarker(
+                    '###' . $subpartMarker . $config['templateSuffix'] . '###'
+                )
+            );
 
-		if (!$tempContent) {
-			$tempContent =
-				$templateService->getSubpart(
-					$templateCode,
-					$subpartmarkerObj->spMarker(
-						'###' . $subpartMarker . '###'
-					)
-				);
-		}
+        if (!$tempContent) {
+            $tempContent =
+                $templateService->getSubpart(
+                    $templateCode,
+                    $subpartmarkerObj->spMarker(
+                        '###' . $subpartMarker . '###'
+                    )
+                );
+        }
 
-		$feuserSubpartArray = [];
-		$feuserWrappedSubpartArray = [];
-		$viewTagArray = $markerObj->getAllMarkers($tempContent);
+        $feuserSubpartArray = [];
+        $feuserWrappedSubpartArray = [];
+        $viewTagArray = $markerObj->getAllMarkers($tempContent);
 
-		$orderAddressViewObj = $tablesObj->get('fe_users', true);
-		$orderAddressObj = $orderAddressViewObj->getModelObj();
-		$orderAddressViewObj->getWrappedSubpartArray(
-			$viewTagArray,
-			$useBackPid,
-			$feuserSubpartArray,
-			$feuserWrappedSubpartArray
-		);
+        $orderAddressViewObj = $tablesObj->get('fe_users', true);
+        $orderAddressObj = $orderAddressViewObj->getModelObj();
+        $orderAddressViewObj->getWrappedSubpartArray(
+            $viewTagArray,
+            $useBackPid,
+            $feuserSubpartArray,
+            $feuserWrappedSubpartArray
+        );
 
-		$feUserRow = [];
+        $feUserRow = [];
 
-		if (
+        if (
             CompatibilityUtility::isLoggedIn() &&
-			isset($GLOBALS['TSFE']->fe_user->user) &&
-			is_array($GLOBALS['TSFE']->fe_user->user)
-		) {
-			$feUserRow = $GLOBALS['TSFE']->fe_user->user;
-		}
+            isset($GLOBALS['TSFE']->fe_user->user) &&
+            is_array($GLOBALS['TSFE']->fe_user->user)
+        ) {
+            $feUserRow = $GLOBALS['TSFE']->fe_user->user;
+        }
 
-		$tmp = [];
+        $tmp = [];
         $feUsersParentArray = [];
-		$feUsersArray = $markerObj->getMarkerFields(
-			$tempContent,
-			$orderAddressObj->getTableObj()->tableFieldArray,
-			$orderAddressObj->getTableObj()->requiredFieldArray,
-			$tmp,
-			$orderAddressViewObj->getMarker(),
-			$feUsersViewTagArray,
-			$feUsersParentArray
-		);
+        $feUsersArray = $markerObj->getMarkerFields(
+            $tempContent,
+            $orderAddressObj->getTableObj()->tableFieldArray,
+            $orderAddressObj->getTableObj()->requiredFieldArray,
+            $tmp,
+            $orderAddressViewObj->getMarker(),
+            $feUsersViewTagArray,
+            $feUsersParentArray
+        );
 
-		$orderAddressViewObj->getItemSubpartArrays(
-			$tempContent,
-			'fe_users',
-			$feUserRow,
-			$feuserSubpartArray,
-			$feuserWrappedSubpartArray,
-			$feUsersViewTagArray,
-			$theCode,
-			$basketExtra
-		);
+        $orderAddressViewObj->getItemSubpartArrays(
+            $tempContent,
+            'fe_users',
+            $feUserRow,
+            $feuserSubpartArray,
+            $feuserWrappedSubpartArray,
+            $feUsersViewTagArray,
+            $theCode,
+            $basketExtra
+        );
 
-		$markerArray = [];
-		if (isset($mainMarkerArray) && is_array($mainMarkerArray)) {
-			$markerArray = array_merge($markerArray, $mainMarkerArray);
-		}
-			// add Global Marker Array
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-		$markerArray = array_merge($markerArray, $globalMarkerArray);
+        $markerArray = [];
+        if (isset($mainMarkerArray) && is_array($mainMarkerArray)) {
+            $markerArray = array_merge($markerArray, $mainMarkerArray);
+        }
+            // add Global Marker Array
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $markerArray = array_merge($markerArray, $globalMarkerArray);
 
-		$tempContent =
-			$templateService->substituteMarkerArrayCached(
-				$tempContent,
-				$markerArray,
-				$feuserSubpartArray  // The emptied subparts must be considered before the wrapped subparts are added because TYPO3 does not support nested subparts.
-			);
+        $tempContent =
+            $templateService->substituteMarkerArrayCached(
+                $tempContent,
+                $markerArray,
+                $feuserSubpartArray  // The emptied subparts must be considered before the wrapped subparts are added because TYPO3 does not support nested subparts.
+            );
 
-		$t['basketFrameWork'] =
-			$templateService->substituteMarkerArrayCached(
-				$tempContent,
-				[],
-				[],
-				$feuserWrappedSubpartArray
-			);
+        $t['basketFrameWork'] =
+            $templateService->substituteMarkerArrayCached(
+                $tempContent,
+                [],
+                [],
+                $feuserWrappedSubpartArray
+            );
 
-		$subpartEmptyArray = [
-			'EMAIL_PLAINTEXT_TEMPLATE_SHOP',
-			'EMAIL_HTML_TEMPLATE_SHOP',
-			'BASKET_ORDERCONFIRMATION_NOSAVE_TEMPLATE'
-		];
+        $subpartEmptyArray = [
+            'EMAIL_PLAINTEXT_TEMPLATE_SHOP',
+            'EMAIL_HTML_TEMPLATE_SHOP',
+            'BASKET_ORDERCONFIRMATION_NOSAVE_TEMPLATE'
+        ];
 
-		if (
-			!$t['basketFrameWork'] &&
-			!in_array($subpartMarker, $subpartEmptyArray)
-		) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$errorCode[0] = 'no_subtemplate';
-			$errorCode[1] = '###' . $subpartMarker . $templateObj->getTemplateSuffix() . '###';
-			$errorCode[2] = ($templateFilename ? $templateFilename : $templateObj->getTemplateFile());
-			return '';
-		}
+        if (
+            !$t['basketFrameWork'] &&
+            !in_array($subpartMarker, $subpartEmptyArray)
+        ) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $errorCode[0] = 'no_subtemplate';
+            $errorCode[1] = '###' . $subpartMarker . $templateObj->getTemplateSuffix() . '###';
+            $errorCode[2] = ($templateFilename ? $templateFilename : $templateObj->getTemplateFile());
+            return '';
+        }
 
-		if ($t['basketFrameWork']) {
-			$checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
-			if (!empty($checkExpression)) {
-				$wrongPounds = preg_match_all($checkExpression, $t['basketFrameWork'], $matches);
-				if ($wrongPounds) {
-					$errorCode[0] = 'template_invalid_marker_border';
-					$errorCode[1] = '###' . $subpartMarker . '###';
-					$errorCode[2] = htmlspecialchars(implode('|', $matches['0']));
-					return '';
-				}
-			}
+        if ($t['basketFrameWork']) {
+            $checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
+            if (!empty($checkExpression)) {
+                $wrongPounds = preg_match_all($checkExpression, $t['basketFrameWork'], $matches);
+                if ($wrongPounds) {
+                    $errorCode[0] = 'template_invalid_marker_border';
+                    $errorCode[1] = '###' . $subpartMarker . '###';
+                    $errorCode[2] = htmlspecialchars(implode('|', $matches['0']));
+                    return '';
+                }
+            }
 
-			if (!$bHtml) {
-				$t['basketFrameWork'] = html_entity_decode($t['basketFrameWork'], ENT_QUOTES);
-			}
+            if (!$bHtml) {
+                $t['basketFrameWork'] = html_entity_decode($t['basketFrameWork'], ENT_QUOTES);
+            }
 
-				// If there is a specific section for the billing address if user is logged in (used because the address may then be hardcoded from the database
-			if (
-				trim(
-					$templateService->getSubpart(
-						$t['basketFrameWork'],
-						'###BILLING_ADDRESS_LOGIN###'
-					)
-				)
-			) {
-				if (CompatibilityUtility::isLoggedIn() && $conf['lockLoginUserInfo']) {
-					$t['basketFrameWork'] = $templateService->substituteSubpart($t['basketFrameWork'], '###BILLING_ADDRESS###', '');
-				} else {
-					$t['basketFrameWork'] = $templateService->substituteSubpart($t['basketFrameWork'], '###BILLING_ADDRESS_LOGIN###', '');
-				}
-			}
-			$t['categoryFrameWork'] = $templateService->getSubpart($t['basketFrameWork'], '###ITEM_CATEGORY###');
-			$t['itemFrameWork'] = $templateService->getSubpart($t['basketFrameWork'], '###ITEM_LIST###');
+                // If there is a specific section for the billing address if user is logged in (used because the address may then be hardcoded from the database
+            if (
+                trim(
+                    $templateService->getSubpart(
+                        $t['basketFrameWork'],
+                        '###BILLING_ADDRESS_LOGIN###'
+                    )
+                )
+            ) {
+                if (CompatibilityUtility::isLoggedIn() && $conf['lockLoginUserInfo']) {
+                    $t['basketFrameWork'] = $templateService->substituteSubpart($t['basketFrameWork'], '###BILLING_ADDRESS###', '');
+                } else {
+                    $t['basketFrameWork'] = $templateService->substituteSubpart($t['basketFrameWork'], '###BILLING_ADDRESS_LOGIN###', '');
+                }
+            }
+            $t['categoryFrameWork'] = $templateService->getSubpart($t['basketFrameWork'], '###ITEM_CATEGORY###');
+            $t['itemFrameWork'] = $templateService->getSubpart($t['basketFrameWork'], '###ITEM_LIST###');
 
-			$t['item'] = $templateService->getSubpart($t['itemFrameWork'], '###ITEM_SINGLE###');
-			$t['taxes'] = $templateService->getSubpart($t['basketFrameWork'], '###COUNTRY_TAXRATES###');
+            $t['item'] = $templateService->getSubpart($t['itemFrameWork'], '###ITEM_SINGLE###');
+            $t['taxes'] = $templateService->getSubpart($t['basketFrameWork'], '###COUNTRY_TAXRATES###');
 
-			$currentP='';
-			$itemsOut='';
-			$viewTagArray = [];
-			$markerFieldArray = ['BULKILY_WARNING' => 'bulkily',
-				'PRODUCT_SPECIAL_PREP' => 'special_preparation',
-				'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
-				'PRODUCT_LINK_DATASHEET' => 'datasheet'];
-			$parentArray = [];
-			$fieldsArray = $markerObj->getMarkerFields(
-				$t['item'],
-				$itemTable->getTableObj()->tableFieldArray,
-				$itemTable->getTableObj()->requiredFieldArray,
-				$markerFieldArray,
-				$itemTableView->getMarker(),
-				$viewTagArray,
-				$parentArray
-			);
-			$count = 0;
-			$bCopyProduct2Article = false;
+            $currentP='';
+            $itemsOut='';
+            $viewTagArray = [];
+            $markerFieldArray = ['BULKILY_WARNING' => 'bulkily',
+                'PRODUCT_SPECIAL_PREP' => 'special_preparation',
+                'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
+                'PRODUCT_LINK_DATASHEET' => 'datasheet'];
+            $parentArray = [];
+            $fieldsArray = $markerObj->getMarkerFields(
+                $t['item'],
+                $itemTable->getTableObj()->tableFieldArray,
+                $itemTable->getTableObj()->requiredFieldArray,
+                $markerFieldArray,
+                $itemTableView->getMarker(),
+                $viewTagArray,
+                $parentArray
+            );
+            $count = 0;
+            $bCopyProduct2Article = false;
 
-			if ($this->useArticles == 0) {
-				if (
-					strpos($t['item'],
-					$articleViewObj->getMarker()) !== false
-				) {
-					$bCopyProduct2Article = true;
-				}
-			}
+            if ($this->useArticles == 0) {
+                if (
+                    strpos($t['item'],
+                    $articleViewObj->getMarker()) !== false
+                ) {
+                    $bCopyProduct2Article = true;
+                }
+            }
 
-			$checkPriceArray = [];
-			$checkPriceArray['minimum'] = false;
-			$checkPriceArray['maximum'] = false;
+            $checkPriceArray = [];
+            $checkPriceArray['minimum'] = false;
+            $checkPriceArray['maximum'] = false;
 
-			if ($this->useArticles == 1 || $this->useArticles == 3) {
-				$markerFieldArray = [];
-				$articleParentArray = [];
-				$articleFieldsArray = $markerObj->getMarkerFields(
-					$t['item'],
-					$itemTable->getTableObj()->tableFieldArray,
-					$itemTable->getTableObj()->requiredFieldArray,
-					$markerFieldArray,
-					$articleViewObj->getMarker(),
-					$articleViewTagArray,
-					$articleParentArray
-				);
+            if ($this->useArticles == 1 || $this->useArticles == 3) {
+                $markerFieldArray = [];
+                $articleParentArray = [];
+                $articleFieldsArray = $markerObj->getMarkerFields(
+                    $t['item'],
+                    $itemTable->getTableObj()->tableFieldArray,
+                    $itemTable->getTableObj()->requiredFieldArray,
+                    $markerFieldArray,
+                    $articleViewObj->getMarker(),
+                    $articleViewTagArray,
+                    $articleParentArray
+                );
 
-				$prodUidField = $cnf->getTableDesc($articleTable->getTableObj()->name, 'uid_product');
-				$fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
-				$uidKey = array_search($prodUidField, $fieldsArray);
-				if ($uidKey != '') {
-					unset($fieldsArray[$uidKey]);
-				}
-			}
+                $prodUidField = $cnf->getTableDesc($articleTable->getTableObj()->name, 'uid_product');
+                $fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
+                $uidKey = array_search($prodUidField, $fieldsArray);
+                if ($uidKey != '') {
+                    unset($fieldsArray[$uidKey]);
+                }
+            }
 
-			$damViewTagArray = [];
-			// DAM support
-			if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam') || !empty($piVars['dam'])) {
-				$damParentArray = [];
-				$damViewObj = $tablesObj->get('tx_dam', true);
-				$damObj = $damViewObj->getModelObj();
-				$fieldsArray = $markerObj->getMarkerFields(
-					$itemFrameWork,
-					$damObj->getTableObj()->tableFieldArray,
-					$damObj->getTableObj()->requiredFieldArray,
-					$markerFieldArray,
-					$damViewObj->getMarker(),
-					$damViewTagArray,
-					$damParentArray
-				);
-				$damCatViewObj = $tablesObj->get('tx_dam_cat', true);
-				$damCatObj = $damCatViewObj->getModelObj();
-				$damCatMarker = $damCatViewObj->getMarker();
-				$damCatViewObj->setMarker('DAM_CAT');
+            $damViewTagArray = [];
+            // DAM support
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam') || !empty($piVars['dam'])) {
+                $damParentArray = [];
+                $damViewObj = $tablesObj->get('tx_dam', true);
+                $damObj = $damViewObj->getModelObj();
+                $fieldsArray = $markerObj->getMarkerFields(
+                    $itemFrameWork,
+                    $damObj->getTableObj()->tableFieldArray,
+                    $damObj->getTableObj()->requiredFieldArray,
+                    $markerFieldArray,
+                    $damViewObj->getMarker(),
+                    $damViewTagArray,
+                    $damParentArray
+                );
+                $damCatViewObj = $tablesObj->get('tx_dam_cat', true);
+                $damCatObj = $damCatViewObj->getModelObj();
+                $damCatMarker = $damCatViewObj->getMarker();
+                $damCatViewObj->setMarker('DAM_CAT');
 
-				$viewDamCatTagArray = [];
-				$catParentArray = [];
-				$tmp = [];
-				$catfieldsArray = $markerObj->getMarkerFields(
-					$itemFrameWork,
-					$damCatObj->getTableObj()->tableFieldArray,
-					$damCatObj->getTableObj()->requiredFieldArray,
-					$tmp,
-					$damCatViewObj->getMarker(),
-					$viewDamCatTagArray,
-					$catParentArray
-				);
-			}
-			$hiddenFields = '';
-			$sum_pricecredits_total_totunits_no_tax = 0;
-			$sum_price_total_totunits_no_tax = 0;
-			$sum_pricecreditpoints_total_totunits = 0;
-			$creditpointsGifts = '';
+                $viewDamCatTagArray = [];
+                $catParentArray = [];
+                $tmp = [];
+                $catfieldsArray = $markerObj->getMarkerFields(
+                    $itemFrameWork,
+                    $damCatObj->getTableObj()->tableFieldArray,
+                    $damCatObj->getTableObj()->requiredFieldArray,
+                    $tmp,
+                    $damCatViewObj->getMarker(),
+                    $viewDamCatTagArray,
+                    $catParentArray
+                );
+            }
+            $hiddenFields = '';
+            $sum_pricecredits_total_totunits_no_tax = 0;
+            $sum_price_total_totunits_no_tax = 0;
+            $sum_pricecreditpoints_total_totunits = 0;
+            $creditpointsGifts = '';
 
-			// loop over all items in the basket indexed by sorting text
-			foreach ($itemArray as $sort => $actItemArray) {
-				foreach ($actItemArray as $k1 => $actItem) {
-					$row = $actItem['rec'];
-					if (!$row) {	// avoid bug with missing row
-						continue;
-					}
+            // loop over all items in the basket indexed by sorting text
+            foreach ($itemArray as $sort => $actItemArray) {
+                foreach ($actItemArray as $k1 => $actItem) {
+                    $row = $actItem['rec'];
+                    if (!$row) {	// avoid bug with missing row
+                        continue;
+                    }
 
-					$extArray = $row['ext'];
-					$pid = intval($row['pid']);
-					if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
-						// product belongs to another basket
-						continue;
-					}
-					$quantity = $itemObj->getQuantity($actItem);
-					$itemObj->getMinMaxQuantity($actItem, $minQuantity, $maxQuantity);
+                    $extArray = $row['ext'];
+                    $pid = intval($row['pid']);
+                    if (!tx_ttproducts_control_basket::getPidListObj()->getPageArray($pid)) {
+                        // product belongs to another basket
+                        continue;
+                    }
+                    $quantity = $itemObj->getQuantity($actItem);
+                    $itemObj->getMinMaxQuantity($actItem, $minQuantity, $maxQuantity);
 
-					if ($minQuantity != '0.00' && $quantity < $minQuantity) {
-						$quantityArray['minimum'][] =
-							[
-								'rec' => $row,
-								'limitQuantity' => $minQuantity,
-								'quantity' => $quantity
-							];
-					}
-					if ($maxQuantity != '0.00' && $quantity > $maxQuantity) {
-						$quantityArray['maximum'][] =
-							[
-								'rec' => $row,
-								'limitQuantity' => $maxQuantity,
-								'quantity' => $quantity
-							];
-					}
-					$count++;
-					$actItem['rec'] = $row;	// fix bug with PHP 5.2.1
-					$bIsNoMinPrice = $itemTable->hasAdditional($row, 'noMinPrice');
-					if (!$bIsNoMinPrice) {
-						$checkPriceArray['minimum'] = true;
-					}
+                    if ($minQuantity != '0.00' && $quantity < $minQuantity) {
+                        $quantityArray['minimum'][] =
+                            [
+                                'rec' => $row,
+                                'limitQuantity' => $minQuantity,
+                                'quantity' => $quantity
+                            ];
+                    }
+                    if ($maxQuantity != '0.00' && $quantity > $maxQuantity) {
+                        $quantityArray['maximum'][] =
+                            [
+                                'rec' => $row,
+                                'limitQuantity' => $maxQuantity,
+                                'quantity' => $quantity
+                            ];
+                    }
+                    $count++;
+                    $actItem['rec'] = $row;	// fix bug with PHP 5.2.1
+                    $bIsNoMinPrice = $itemTable->hasAdditional($row, 'noMinPrice');
+                    if (!$bIsNoMinPrice) {
+                        $checkPriceArray['minimum'] = true;
+                    }
 
-					$bIsNoMaxPrice = $itemTable->hasAdditional($row, 'noMaxPrice');
+                    $bIsNoMaxPrice = $itemTable->hasAdditional($row, 'noMaxPrice');
 
-					if (!$bIsNoMaxPrice) {
-						$checkPriceArray['maximum'] = true;
-					}
+                    if (!$bIsNoMaxPrice) {
+                        $checkPriceArray['maximum'] = true;
+                    }
 
-					$pidcategory = ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] == 1 ? $pid : '');
-					$currentPnew = $pidcategory . '_' . $actItem['rec']['category'];
+                    $pidcategory = ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] == 1 ? $pid : '');
+                    $currentPnew = $pidcategory . '_' . $actItem['rec']['category'];
 
-						// Print Category Title
-					if ($currentPnew != $currentP) {
-						if ($itemsOut) {
-							$out .=
-								$templateService->substituteSubpart(
-									$t['itemFrameWork'],
-									'###ITEM_SINGLE###',
-									$itemsOut
-								);
-						}
-						$itemsOut = '';		// Clear the item-code var
-						$currentP = $currentPnew;
+                        // Print Category Title
+                    if ($currentPnew != $currentP) {
+                        if ($itemsOut) {
+                            $out .=
+                                $templateService->substituteSubpart(
+                                    $t['itemFrameWork'],
+                                    '###ITEM_SINGLE###',
+                                    $itemsOut
+                                );
+                        }
+                        $itemsOut = '';		// Clear the item-code var
+                        $currentP = $currentPnew;
 
-						if ($conf['displayBasketCatHeader']) {
-							$markerArray = [];
-							$pageCatTitle = '';
-							if (
-								$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] == 1
-							) {
-								$page = $tablesObj->get('pages');
-								$pageTmp = $page->get($pid);
-								$pageCatTitle = $pageTmp['title'] . '/';
-							}
-							$catTmp = '';
-							if ($actItem['rec']['category']) {
-								$catTmp = $tablesObj->get('tt_products_cat')->get($actItem['rec']['category']);
-								$catTmp = $catTmp['title'] ?? '';
-							}
-							$catTitle = $pageCatTitle.$catTmp;
-							$cObj->setCurrentVal($catTitle);
-							$markerArray['###CATEGORY_TITLE###'] =
-								$cObj->cObjGetSingle(
-									$conf['categoryHeader'],
-									$conf['categoryHeader.'],
-									'categoryHeader'
-								);
+                        if ($conf['displayBasketCatHeader']) {
+                            $markerArray = [];
+                            $pageCatTitle = '';
+                            if (
+                                $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] == 1
+                            ) {
+                                $page = $tablesObj->get('pages');
+                                $pageTmp = $page->get($pid);
+                                $pageCatTitle = $pageTmp['title'] . '/';
+                            }
+                            $catTmp = '';
+                            if ($actItem['rec']['category']) {
+                                $catTmp = $tablesObj->get('tt_products_cat')->get($actItem['rec']['category']);
+                                $catTmp = $catTmp['title'] ?? '';
+                            }
+                            $catTitle = $pageCatTitle.$catTmp;
+                            $cObj->setCurrentVal($catTitle);
+                            $markerArray['###CATEGORY_TITLE###'] =
+                                $cObj->cObjGetSingle(
+                                    $conf['categoryHeader'],
+                                    $conf['categoryHeader.'],
+                                    'categoryHeader'
+                                );
 
-							$categoryQuantity = $basketObj->getCategoryQuantity();
+                            $categoryQuantity = $basketObj->getCategoryQuantity();
 
-								// compatible with bill/delivery
-							$currentCategory = $row['category'];
-							$markerArray['###CATEGORY_QTY###'] = $categoryQuantity[$currentCategory];
+                                // compatible with bill/delivery
+                            $currentCategory = $row['category'];
+                            $markerArray['###CATEGORY_QTY###'] = $categoryQuantity[$currentCategory];
 
- 							$categoryPriceTax = $calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$currentCategory] ?? 0;
- 							$markerArray['###PRICE_GOODS_TAX###'] = $priceViewObj->priceFormat($categoryPriceTax);
- 							$categoryPriceNoTax = $calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$currentCategory];
- 							$markerArray['###PRICE_GOODS_NO_TAX###'] = $priceViewObj->priceFormat($categoryPriceNoTax);
- 							$markerArray['###PRICE_GOODS_ONLY_TAX###'] = $priceViewObj->priceFormat($categoryPriceTax - $categoryPriceNoTax);
+                            $categoryPriceTax = $calculatedArray['categoryPriceTax']['goodstotal']['ALL'][$currentCategory] ?? 0;
+                            $markerArray['###PRICE_GOODS_TAX###'] = $priceViewObj->priceFormat($categoryPriceTax);
+                            $categoryPriceNoTax = $calculatedArray['categoryPriceNoTax']['goodstotal']['ALL'][$currentCategory];
+                            $markerArray['###PRICE_GOODS_NO_TAX###'] = $priceViewObj->priceFormat($categoryPriceNoTax);
+                            $markerArray['###PRICE_GOODS_ONLY_TAX###'] = $priceViewObj->priceFormat($categoryPriceTax - $categoryPriceNoTax);
 
-							$out .= $templateService->substituteMarkerArray($t['categoryFrameWork'], $markerArray);
-						}
-					}
-						// Fill marker arrays
-					$wrappedSubpartArray = [];
-					$subpartArray = [];
-					$markerArray = [];
+                            $out .= $templateService->substituteMarkerArray($t['categoryFrameWork'], $markerArray);
+                        }
+                    }
+                        // Fill marker arrays
+                    $wrappedSubpartArray = [];
+                    $subpartArray = [];
+                    $markerArray = [];
 
-					$bInputDisabled = ($row['inStock'] <= 0);
+                    $bInputDisabled = ($row['inStock'] <= 0);
 
-					$basketItemView->getItemMarkerArray(
-						$funcTablename,
-						false,
-						$actItem,
-						$markerArray,
-						$viewTagArray,
-						$hiddenFields,
-						$theCode,
-						$bInputDisabled,
-						$count,
-						false,
-						'UTF-8'
-					);
+                    $basketItemView->getItemMarkerArray(
+                        $funcTablename,
+                        false,
+                        $actItem,
+                        $markerArray,
+                        $viewTagArray,
+                        $hiddenFields,
+                        $theCode,
+                        $bInputDisabled,
+                        $count,
+                        false,
+                        'UTF-8'
+                    );
 
-					$basketItemView->getItemMarkerSubpartArrays(
-						$t['item'],
-						$itemTable->getFuncTablename(),
-						$row,
-						'SINGLE',
-						$viewTagArray,
-						false,
-						$productRowArray,
-						$markerArray,
-						$subpartArray,
-						$wrappedSubpartArray
-					);
+                    $basketItemView->getItemMarkerSubpartArrays(
+                        $t['item'],
+                        $itemTable->getFuncTablename(),
+                        $row,
+                        'SINGLE',
+                        $viewTagArray,
+                        false,
+                        $productRowArray,
+                        $markerArray,
+                        $subpartArray,
+                        $wrappedSubpartArray
+                    );
 
-					$catRow = $row['category'] ? $tablesObj->get('tt_products_cat')->get($row['category']) : [];
-					// $catTitle= $actItem['rec']['category'] ? $this->tt_products_cat->get($actItem['rec']['category']) : '';
-					$catTitle = $catRow['title'] ?? '';
-					$tmp = [];
+                    $catRow = $row['category'] ? $tablesObj->get('tt_products_cat')->get($row['category']) : [];
+                    // $catTitle= $actItem['rec']['category'] ? $this->tt_products_cat->get($actItem['rec']['category']) : '';
+                    $catTitle = $catRow['title'] ?? '';
+                    $tmp = [];
 
-						// use the product if no article row has been found
-					$prodVariantRow = $row;
+                        // use the product if no article row has been found
+                    $prodVariantRow = $row;
 
-					if (isset($actItem[$calculationField])) {
-						$prodVariantRow[$calculationField] = $actItem[$calculationField];
-					}
+                    if (isset($actItem[$calculationField])) {
+                        $prodVariantRow[$calculationField] = $actItem[$calculationField];
+                    }
 
-					$prodMarkerRow = $prodVariantRow;
-					$itemTable->tableObj->substituteMarkerArray($prodMarkerRow);
-					$bIsGift = tx_ttproducts_gifts_div::isGift($row, $conf['whereGift']);
-					$itemTableView->getModelMarkerArray(
-						$prodMarkerRow,
-						'',
-						$markerArray,
-						$catTitle,
-						0,
-						'basketImage',
-						$viewTagArray,
-						$tmp,
-						$theCode,
-						$basketExtra,
-						$basketRecs,
-						$count,
-						'',
-						'',
-						'',
-						$bHtml,
-						'UTF-8',
-						'',
-						$multiOrderArray,
-						$productRowArray,
+                    $prodMarkerRow = $prodVariantRow;
+                    $itemTable->tableObj->substituteMarkerArray($prodMarkerRow);
+                    $bIsGift = tx_ttproducts_gifts_div::isGift($row, $conf['whereGift']);
+                    $itemTableView->getModelMarkerArray(
+                        $prodMarkerRow,
+                        '',
+                        $markerArray,
+                        $catTitle,
+                        0,
+                        'basketImage',
+                        $viewTagArray,
+                        $tmp,
+                        $theCode,
+                        $basketExtra,
+                        $basketRecs,
+                        $count,
+                        '',
+                        '',
+                        '',
+                        $bHtml,
+                        'UTF-8',
+                        '',
+                        $multiOrderArray,
+                        $productRowArray,
                         true,
-						$notOverwritePriceIfSet
-					);
+                        $notOverwritePriceIfSet
+                    );
 
-					if (
-						$this->useArticles == 1 ||
-						$this->useArticles == 3 ||
-						$bCopyProduct2Article
-					) {
-						$articleRows = [];
+                    if (
+                        $this->useArticles == 1 ||
+                        $this->useArticles == 3 ||
+                        $bCopyProduct2Article
+                    ) {
+                        $articleRows = [];
 
-						if (!$bCopyProduct2Article) {
-							// get the article uid with these colors, sizes and gradings
-							if (
-								is_array($extArray) &&
-								isset($extArray['mergeArticles']) &&
-								is_array($extArray['mergeArticles'])
-							) {
-								$prodVariantRow = $extArray['mergeArticles'];
-							} else if (
-								isset($extArray[$articleTable->getFuncTablename()]) &&
-								is_array($extArray[$articleTable->getFuncTablename()])
-							) {
-								$articleExtArray = $extArray[$articleTable->getFuncTablename()];
-								foreach($articleExtArray as $k => $articleData) {
-									$articleRows[$k] = $articleTable->get($articleData['uid']);
-								}
-							} else {
-								$articleRow = $itemTable->getArticleRow($row, $theCode);
-								if ($articleRow) {
-									$articleRows['0'] = $articleRow;
-								}
-							}
-						}
+                        if (!$bCopyProduct2Article) {
+                            // get the article uid with these colors, sizes and gradings
+                            if (
+                                is_array($extArray) &&
+                                isset($extArray['mergeArticles']) &&
+                                is_array($extArray['mergeArticles'])
+                            ) {
+                                $prodVariantRow = $extArray['mergeArticles'];
+                            } else if (
+                                isset($extArray[$articleTable->getFuncTablename()]) &&
+                                is_array($extArray[$articleTable->getFuncTablename()])
+                            ) {
+                                $articleExtArray = $extArray[$articleTable->getFuncTablename()];
+                                foreach($articleExtArray as $k => $articleData) {
+                                    $articleRows[$k] = $articleTable->get($articleData['uid']);
+                                }
+                            } else {
+                                $articleRow = $itemTable->getArticleRow($row, $theCode);
+                                if ($articleRow) {
+                                    $articleRows['0'] = $articleRow;
+                                }
+                            }
+                        }
 
-						if (
-							is_array($articleRows) &&
-							!empty($articleRows)
-						) {
-							$bKeepNotEmpty = (boolean) $conf['keepProductData']; // Auskommentieren nicht möglich wenn mehrere Artikel dem Produkt zugewiesen werden
+                        if (
+                            is_array($articleRows) &&
+                            !empty($articleRows)
+                        ) {
+                            $bKeepNotEmpty = (boolean) $conf['keepProductData']; // Auskommentieren nicht möglich wenn mehrere Artikel dem Produkt zugewiesen werden
 
-							if ($this->useArticles == 3) {
-								$itemTable->fillVariantsFromArticles(
-									$prodVariantRow
-								);
-								$itemTable->getVariant()->modifyRowFromVariant($prodVariantRow);
-							}
-							foreach ($articleRows as $articleRow) {
+                            if ($this->useArticles == 3) {
+                                $itemTable->fillVariantsFromArticles(
+                                    $prodVariantRow
+                                );
+                                $itemTable->getVariant()->modifyRowFromVariant($prodVariantRow);
+                            }
+                            foreach ($articleRows as $articleRow) {
 
-								$itemTable->mergeAttributeFields(
-									$prodVariantRow,
-									$articleRow,
-									$bKeepNotEmpty,
-									true,
-									true,
-									$calculationField,
-									false
-								);
-							}
-						} else {
-							$variant = $itemTable->getVariant()->getVariantFromRow($row);
-							$itemTable->getVariant()->modifyRowFromVariant(
-								$prodVariantRow,
-								$variant
-							);
-						}
-						// use the fields of the article instead of the product
-						//
+                                $itemTable->mergeAttributeFields(
+                                    $prodVariantRow,
+                                    $articleRow,
+                                    $bKeepNotEmpty,
+                                    true,
+                                    true,
+                                    $calculationField,
+                                    false
+                                );
+                            }
+                        } else {
+                            $variant = $itemTable->getVariant()->getVariantFromRow($row);
+                            $itemTable->getVariant()->modifyRowFromVariant(
+                                $prodVariantRow,
+                                $variant
+                            );
+                        }
+                        // use the fields of the article instead of the product
+                        //
 
-						if (
-							isset($extArray) &&
-							isset($extArray['records']) &&
-							is_array($extArray['records'])
-						) {
-							$newTitleArray = [];
-							$externalRowArray = $extArray['records'];
-							foreach ($externalRowArray as $tablename => $externalRow) {
-								$newTitleArray[] = $externalRow['title'];
-							}
-							$prodVariantRow['title'] = implode(' | ', $newTitleArray);
-						}
-						$prodMarkerRow = $prodVariantRow;
-						$itemTable->tableObj->substituteMarkerArray($prodMarkerRow);
+                        if (
+                            isset($extArray) &&
+                            isset($extArray['records']) &&
+                            is_array($extArray['records'])
+                        ) {
+                            $newTitleArray = [];
+                            $externalRowArray = $extArray['records'];
+                            foreach ($externalRowArray as $tablename => $externalRow) {
+                                $newTitleArray[] = $externalRow['title'];
+                            }
+                            $prodVariantRow['title'] = implode(' | ', $newTitleArray);
+                        }
+                        $prodMarkerRow = $prodVariantRow;
+                        $itemTable->tableObj->substituteMarkerArray($prodMarkerRow);
 
-						$articleViewObj->getModelMarkerArray(
-							$prodMarkerRow,
-							'',
-							$markerArray,
-							$catTitle,
-							0,
-							'basketImage',
-							$articleViewTagArray,
-							$tmp,
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							$count,
-							'',
-							'',
-							'',
-							$bHtml,
-							'UTF-8',
-							'',
-							$multiOrderArray,
-							$productRowArray,
+                        $articleViewObj->getModelMarkerArray(
+                            $prodMarkerRow,
+                            '',
+                            $markerArray,
+                            $catTitle,
+                            0,
+                            'basketImage',
+                            $articleViewTagArray,
+                            $tmp,
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            $count,
+                            '',
+                            '',
+                            '',
+                            $bHtml,
+                            'UTF-8',
+                            '',
+                            $multiOrderArray,
+                            $productRowArray,
                             false, // FHO wieder zurück korrigiert, sonst wird bei Artikel Tax=0 nicht die TAXpercentage genommen.
                             $notOverwritePriceIfSet
-						);
+                        );
 
-						$articleViewObj->getItemMarkerSubpartArrays(
-							$t['item'],
-							$articleViewObj->getModelObj()->getFuncTablename(),
-							$prodVariantRow,
-							$markerArray,
-							$subpartArray,
-							$wrappedSubpartArray,
-							$articleViewTagArray,
-							$theCode,
-							$basketExtra
-						);
-					}
+                        $articleViewObj->getItemMarkerSubpartArrays(
+                            $t['item'],
+                            $articleViewObj->getModelObj()->getFuncTablename(),
+                            $prodVariantRow,
+                            $markerArray,
+                            $subpartArray,
+                            $wrappedSubpartArray,
+                            $articleViewTagArray,
+                            $theCode,
+                            $basketExtra
+                        );
+                    }
 
-					$itemTableView->getItemMarkerSubpartArrays(
-						$t['item'],
-						$itemTableView->getModelObj()->getFuncTablename(),
-						$prodVariantRow,
-						$markerArray,
-						$subpartArray,
-						$wrappedSubpartArray,
-						$viewTagArray,
-						[],
-						[],
-						$theCode,
-						$basketExtra,
-						$basketRecs,
-						$count,
-						$checkPriceZero
-					);
+                    $itemTableView->getItemMarkerSubpartArrays(
+                        $t['item'],
+                        $itemTableView->getModelObj()->getFuncTablename(),
+                        $prodVariantRow,
+                        $markerArray,
+                        $subpartArray,
+                        $wrappedSubpartArray,
+                        $viewTagArray,
+                        [],
+                        [],
+                        $theCode,
+                        $basketExtra,
+                        $basketRecs,
+                        $count,
+                        $checkPriceZero
+                    );
 
-					$cObj->setCurrentVal($catTitle);
-					$markerArray['###CATEGORY_TITLE###'] =
-						$cObj->cObjGetSingle(
-							$conf['categoryHeader'],
-							$conf['categoryHeader.'],
-							'categoryHeader'
-						);
+                    $cObj->setCurrentVal($catTitle);
+                    $markerArray['###CATEGORY_TITLE###'] =
+                        $cObj->cObjGetSingle(
+                            $conf['categoryHeader'],
+                            $conf['categoryHeader.'],
+                            'categoryHeader'
+                        );
 
-					$markerArray['###PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat($actItem['totalTax'] + $actItem['deposittax'] * $quantity);
+                    $markerArray['###PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat($actItem['totalTax'] + $actItem['deposittax'] * $quantity);
 
-					$markerArray['###PRICE_TOTAL_NO_TAX###'] = $priceViewObj->priceFormat($actItem['totalNoTax'] + $actItem['depositnotax'] * $quantity);
-					$markerArray['###PRICE_TOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($actItem['totalTax'] - $actItem['totalNoTax'] + ($actItem['deposittax'] - $actItem['depositnotax']) * $quantity);
+                    $markerArray['###PRICE_TOTAL_NO_TAX###'] = $priceViewObj->priceFormat($actItem['totalNoTax'] + $actItem['depositnotax'] * $quantity);
+                    $markerArray['###PRICE_TOTAL_ONLY_TAX###'] = $priceViewObj->priceFormat($actItem['totalTax'] - $actItem['totalNoTax'] + ($actItem['deposittax'] - $actItem['depositnotax']) * $quantity);
 
-					$markerArray['###PRICE_TOTAL_0_TAX###'] = $priceViewObj->priceFormat($actItem['total0Tax']);
-					$markerArray['###PRICE_TOTAL_0_NO_TAX###'] = $priceViewObj->priceFormat($actItem['total0NoTax']);
-					$markerArray['###PRICE_TOTAL_0_ONLY_TAX###'] = $priceViewObj->priceFormat($actItem['total0Tax'] - $actItem['total0NoTax']);
+                    $markerArray['###PRICE_TOTAL_0_TAX###'] = $priceViewObj->priceFormat($actItem['total0Tax']);
+                    $markerArray['###PRICE_TOTAL_0_NO_TAX###'] = $priceViewObj->priceFormat($actItem['total0NoTax']);
+                    $markerArray['###PRICE_TOTAL_0_ONLY_TAX###'] = $priceViewObj->priceFormat($actItem['total0Tax'] - $actItem['total0NoTax']);
 
                     $pricecredits_total_totunits_no_tax = 0;
                     $pricecredits_total_totunits_tax = 0;
-					if ($row['category'] == ($conf['creditsCategory'] ?? -1 )) {
-						// creditpoint system start
-						$pricecredits_total_totunits_no_tax = $actItem['totalNoTax'] * ($row['unit_factor'] ?? 0);
-						$pricecredits_total_totunits_tax = $actItem['totalTax'] * ( $row['unit_factor'] ?? 0);
-					}
-					$markerArray['###PRICE_TOTAL_TOTUNITS_NO_TAX###'] = $priceViewObj->priceFormat($pricecredits_total_totunits_no_tax);
-					$markerArray['###PRICE_TOTAL_TOTUNITS_TAX###'] = $priceViewObj->priceFormat($pricecredits_total_totunits_tax);
-					$sum_pricecredits_total_totunits_no_tax += $pricecredits_total_totunits_no_tax;
-					$sum_price_total_totunits_no_tax += $pricecredits_total_totunits_no_tax;
-					$sum_pricecreditpoints_total_totunits += $pricecredits_total_totunits_no_tax;
+                    if ($row['category'] == ($conf['creditsCategory'] ?? -1 )) {
+                        // creditpoint system start
+                        $pricecredits_total_totunits_no_tax = $actItem['totalNoTax'] * ($row['unit_factor'] ?? 0);
+                        $pricecredits_total_totunits_tax = $actItem['totalTax'] * ( $row['unit_factor'] ?? 0);
+                    }
+                    $markerArray['###PRICE_TOTAL_TOTUNITS_NO_TAX###'] = $priceViewObj->priceFormat($pricecredits_total_totunits_no_tax);
+                    $markerArray['###PRICE_TOTAL_TOTUNITS_TAX###'] = $priceViewObj->priceFormat($pricecredits_total_totunits_tax);
+                    $sum_pricecredits_total_totunits_no_tax += $pricecredits_total_totunits_no_tax;
+                    $sum_price_total_totunits_no_tax += $pricecredits_total_totunits_no_tax;
+                    $sum_pricecreditpoints_total_totunits += $pricecredits_total_totunits_no_tax;
 
-					// creditpoint system end
-					$page = $tablesObj->get('pages');
-					$pid = $page->getPID(
-						$conf['PIDitemDisplay'],
-						$conf['PIDitemDisplay.'] ?? '',
-						$row,
-						$GLOBALS['TSFE']->rootLine[1] ?? ''
-					);
-					$addQueryString = [];
-					$addQueryString[$itemTable->type] = intval($row['uid']);
+                    // creditpoint system end
+                    $page = $tablesObj->get('pages');
+                    $pid = $page->getPID(
+                        $conf['PIDitemDisplay'],
+                        $conf['PIDitemDisplay.'] ?? '',
+                        $row,
+                        $GLOBALS['TSFE']->rootLine[1] ?? ''
+                    );
+                    $addQueryString = [];
+                    $addQueryString[$itemTable->type] = intval($row['uid']);
 
-					if (
-						is_array($extArray) && is_array($extArray[tx_ttproducts_control_basket::getFuncTablename()])
-					) {
-						$addQueryString['variants'] = htmlspecialchars($extArray[tx_ttproducts_control_basket::getFuncTablename()][0]['vars']);
-					}
-					$isImageProduct = $itemTable->hasAdditional($row, 'isImage');
-					$damMarkerArray = [];
-					$damCategoryMarkerArray = [];
+                    if (
+                        is_array($extArray) && is_array($extArray[tx_ttproducts_control_basket::getFuncTablename()])
+                    ) {
+                        $addQueryString['variants'] = htmlspecialchars($extArray[tx_ttproducts_control_basket::getFuncTablename()][0]['vars']);
+                    }
+                    $isImageProduct = $itemTable->hasAdditional($row, 'isImage');
+                    $damMarkerArray = [];
+                    $damCategoryMarkerArray = [];
 
-					if (
-						(
-							$isImageProduct ||
-							$funcTablename == 'tt_products'
-						) &&
-						is_array($extArray) &&
-						isset($extArray['tx_dam'])
-					) {
-						reset($extArray['tx_dam']);
-						$damext = current($extArray['tx_dam']);
-						$damUid = $damext['uid'];
-						$damRow = $tablesObj->get('tx_dam')->get($damUid);
-						$damItem = [];
-						$damItem['rec'] = $damRow;
-						$damCategoryArray =
-							$tablesObj->get('tx_dam_cat')->getCategoryArray ($damRow);
-						if (!empty($damCategoryArray)) {
-							reset ($damCategoryArray);
-							$damCat = current($damCategoryArray);
-						}
+                    if (
+                        (
+                            $isImageProduct ||
+                            $funcTablename == 'tt_products'
+                        ) &&
+                        is_array($extArray) &&
+                        isset($extArray['tx_dam'])
+                    ) {
+                        reset($extArray['tx_dam']);
+                        $damext = current($extArray['tx_dam']);
+                        $damUid = $damext['uid'];
+                        $damRow = $tablesObj->get('tx_dam')->get($damUid);
+                        $damItem = [];
+                        $damItem['rec'] = $damRow;
+                        $damCategoryArray =
+                            $tablesObj->get('tx_dam_cat')->getCategoryArray ($damRow);
+                        if (!empty($damCategoryArray)) {
+                            reset ($damCategoryArray);
+                            $damCat = current($damCategoryArray);
+                        }
 
-						$tablesObj->get('tx_dam_cat', true)->getMarkerArray(
-							$damCategoryMarkerArray,
-							'',
-							$damCat,
-							$damRow['pid'],
-							0,
-							'basketImage',
-							$viewDamCatTagArray,
-							[],
-							$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
-							'SINGLE',
-							1,
-							'',
-							''
-						);
+                        $tablesObj->get('tx_dam_cat', true)->getMarkerArray(
+                            $damCategoryMarkerArray,
+                            '',
+                            $damCat,
+                            $damRow['pid'],
+                            0,
+                            'basketImage',
+                            $viewDamCatTagArray,
+                            [],
+                            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
+                            'SINGLE',
+                            1,
+                            '',
+                            ''
+                        );
 
-						$tablesObj->get('tx_dam', true)->getModelMarkerArray(
-							$damRow,
-							'',
-							$damMarkerArray,
-							$damCatRow['title'],
-							0,
-							'basketImage',
-							$damViewTagArray,
-							$tmp,
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							$count,
-							'',
-							'',
-							'',
-							$bHtml,
-							'UTF-8',
-							'',
-							$multiOrderArray,
-							$productRowArray,
+                        $tablesObj->get('tx_dam', true)->getModelMarkerArray(
+                            $damRow,
+                            '',
+                            $damMarkerArray,
+                            $damCatRow['title'],
+                            0,
+                            'basketImage',
+                            $damViewTagArray,
+                            $tmp,
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            $count,
+                            '',
+                            '',
+                            '',
+                            $bHtml,
+                            'UTF-8',
+                            '',
+                            $multiOrderArray,
+                            $productRowArray,
                             false,
                             $notOverwritePriceIfSet
-						);
-					}
-					$markerArray = array_merge($markerArray, $damMarkerArray, $damCategoryMarkerArray);
+                        );
+                    }
+                    $markerArray = array_merge($markerArray, $damMarkerArray, $damCategoryMarkerArray);
 
                     $tempUrl =
                         FrontendUtility::getTypoLink_URL(
@@ -1012,424 +1012,424 @@ class tx_ttproducts_basket_view implements \TYPO3\CMS\Core\SingletonInterface {
                         );
 
                     $css_current = '';
-					$wrappedSubpartArray['###LINK_ITEM###'] =
-						[
-							'<a class="singlelink" href="' . htmlspecialchars($tempUrl) . '"' . $css_current . '>',
-							'</a>'
-						];
+                    $wrappedSubpartArray['###LINK_ITEM###'] =
+                        [
+                            '<a class="singlelink" href="' . htmlspecialchars($tempUrl) . '"' . $css_current . '>',
+                            '</a>'
+                        ];
 
-					if (is_object($itemTableView->getVariant())) {
-						$itemTableView->getVariant()->removeEmptyMarkerSubpartArray(
-							$markerArray,
-							$subpartArray,
-							$wrappedSubpartArray,
-							$prodVariantRow,
-							$conf,
-							$itemTable->hasAdditional($row, 'isSingle'),
-							!$itemTable->hasAdditional($row, 'noGiftService')
-						);
-					}
+                    if (is_object($itemTableView->getVariant())) {
+                        $itemTableView->getVariant()->removeEmptyMarkerSubpartArray(
+                            $markerArray,
+                            $subpartArray,
+                            $wrappedSubpartArray,
+                            $prodVariantRow,
+                            $conf,
+                            $itemTable->hasAdditional($row, 'isSingle'),
+                            !$itemTable->hasAdditional($row, 'noGiftService')
+                        );
+                    }
 
-					$orderAddressViewObj->getModelObj()->setCondition($row, $funcTablename);
-					$orderAddressViewObj->getWrappedSubpartArray(
-						$viewTagArray,
-						$useBackPid,
-						$subpartArray,
-						$wrappedSubpartArray
-					
-					);
+                    $orderAddressViewObj->getModelObj()->setCondition($row, $funcTablename);
+                    $orderAddressViewObj->getWrappedSubpartArray(
+                        $viewTagArray,
+                        $useBackPid,
+                        $subpartArray,
+                        $wrappedSubpartArray
+                    
+                    );
 
-				// workaround for TYPO3 bug #44270
-					$tempContent = $templateService->substituteMarkerArrayCached(
-						$t['item'],
-						[],
-						$subpartArray,
-						$wrappedSubpartArray
-					);
+                // workaround for TYPO3 bug #44270
+                    $tempContent = $templateService->substituteMarkerArrayCached(
+                        $t['item'],
+                        [],
+                        $subpartArray,
+                        $wrappedSubpartArray
+                    );
 
-					$tempContent = $templateService->substituteMarkerArray(
-						$tempContent,
-						$markerArray
-					);
+                    $tempContent = $templateService->substituteMarkerArray(
+                        $tempContent,
+                        $markerArray
+                    );
 
-					$itemsOut .= $tempContent;
-				}
+                    $itemsOut .= $tempContent;
+                }
 
-				if ($itemsOut) {
-					$tempContent =
-						$templateService->substituteSubpart(
-							$t['itemFrameWork'],
-							'###ITEM_SINGLE###',
-							$itemsOut
-						);
+                if ($itemsOut) {
+                    $tempContent =
+                        $templateService->substituteSubpart(
+                            $t['itemFrameWork'],
+                            '###ITEM_SINGLE###',
+                            $itemsOut
+                        );
 
-					$out .= $tempContent;
-					$itemsOut = '';	// Clear the item-code var
-				}
-			} // end of foreach ($itemArray
+                    $out .= $tempContent;
+                    $itemsOut = '';	// Clear the item-code var
+                }
+            } // end of foreach ($itemArray
 
-			if (isset($damCatMarker)) {
-				$damCatViewObj->setMarker($damCatMarker); // restore original value
-			}
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
-			$shopCountryArray = [];
-			$taxRateArray =
-				$taxObj->getTaxRates(
-					$shopCountryArray,
-					$taxInfoArray,
-					$basketObj->getUidArray(),
-					$basketRecs
-				);
+            if (isset($damCatMarker)) {
+                $damCatViewObj->setMarker($damCatMarker); // restore original value
+            }
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
+            $shopCountryArray = [];
+            $taxRateArray =
+                $taxObj->getTaxRates(
+                    $shopCountryArray,
+                    $taxInfoArray,
+                    $basketObj->getUidArray(),
+                    $basketRecs
+                );
 
-			if (
-				isset($taxRateArray) &&
-				is_array($taxRateArray) &&
-				isset($shopCountryArray) &&
-				is_array($shopCountryArray) &&
-				isset($shopCountryArray['country_code']) &&
-				isset($taxRateArray[$shopCountryArray['country_code']])
-			) {
-				$taxArray = $taxRateArray[$shopCountryArray['country_code']];
-			} else if (
-				isset($taxRateArray) &&
-				is_array($taxRateArray)
-			) {
-				$taxArray = current($taxRateArray);
-			} else {
-				$taxArray = [];
-			}
+            if (
+                isset($taxRateArray) &&
+                is_array($taxRateArray) &&
+                isset($shopCountryArray) &&
+                is_array($shopCountryArray) &&
+                isset($shopCountryArray['country_code']) &&
+                isset($taxRateArray[$shopCountryArray['country_code']])
+            ) {
+                $taxArray = $taxRateArray[$shopCountryArray['country_code']];
+            } else if (
+                isset($taxRateArray) &&
+                is_array($taxRateArray)
+            ) {
+                $taxArray = current($taxRateArray);
+            } else {
+                $taxArray = [];
+            }
 
-			$basketMarkerArray =
-				$this->getMarkerArray(
-					$basketExtra,
-					$calculatedArray,
-					$taxArray
-				);
+            $basketMarkerArray =
+                $this->getMarkerArray(
+                    $basketExtra,
+                    $calculatedArray,
+                    $taxArray
+                );
 
-				// Initializing the markerArray for the rest of the template
-			$markerArray = $mainMarkerArray;
-			$markerArray = array_merge($markerArray, $basketMarkerArray);
-			$activityArray = tx_ttproducts_model_activity::getActivityArray();
+                // Initializing the markerArray for the rest of the template
+            $markerArray = $mainMarkerArray;
+            $markerArray = array_merge($markerArray, $basketMarkerArray);
+            $activityArray = tx_ttproducts_model_activity::getActivityArray();
 
-			if (is_array($activityArray)) {
-				$activity = '';
-				if (!empty($activityArray['products_payment'])) {
-					$activity = 'payment';
-				} else if (!empty($activityArray['products_info'])) {
-					$activity = 'info';
-				}
-				if ($activity) {
-					$bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
-					$hiddenFields .= '<input type="hidden" name="' . TT_PRODUCTS_EXT . '[activity][' . $activity . ']" value="1" ' . ($bUseXHTML ? '/' : '') . '>';
-				}
-			}
-			$markerArray['###HIDDENFIELDS###'] = $hiddenFields;
-			$pid = ($conf['PIDbasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id);
+            if (is_array($activityArray)) {
+                $activity = '';
+                if (!empty($activityArray['products_payment'])) {
+                    $activity = 'payment';
+                } else if (!empty($activityArray['products_info'])) {
+                    $activity = 'info';
+                }
+                if ($activity) {
+                    $bUseXHTML = !empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+                    $hiddenFields .= '<input type="hidden" name="' . TT_PRODUCTS_EXT . '[activity][' . $activity . ']" value="1" ' . ($bUseXHTML ? '/' : '') . '>';
+                }
+            }
+            $markerArray['###HIDDENFIELDS###'] = $hiddenFields;
+            $pid = ($conf['PIDbasket'] ? $conf['PIDbasket'] : $GLOBALS['TSFE']->id);
 
-			$confCache = [];
-			$excludeList = '';
+            $confCache = [];
+            $excludeList = '';
 
-			if (
-				isset($viewParamConf) &&
-				is_array($viewParamConf) &&
-				!empty($viewParamConf['ignore'])
-			){
-				$excludeList = $viewParamConf['ignore'];
-			}
+            if (
+                isset($viewParamConf) &&
+                is_array($viewParamConf) &&
+                !empty($viewParamConf['ignore'])
+            ){
+                $excludeList = $viewParamConf['ignore'];
+            }
 
-			$url = FrontendUtility::getTypoLink_URL(
-				$cObj,
-				$pid,
-				$this->urlObj->getLinkParams(
-					$excludeList,
-					[],
-					true,
-					$useBackPid,
-					0,
-					''
-				),
-				$target = '',
-				$confCache
-			);
+            $url = FrontendUtility::getTypoLink_URL(
+                $cObj,
+                $pid,
+                $this->urlObj->getLinkParams(
+                    $excludeList,
+                    [],
+                    true,
+                    $useBackPid,
+                    0,
+                    ''
+                ),
+                $target = '',
+                $confCache
+            );
 
-			$htmlUrl = htmlspecialchars(
-					$url,
-					ENT_NOQUOTES,
-					'UTF-8'
-				);
+            $htmlUrl = htmlspecialchars(
+                    $url,
+                    ENT_NOQUOTES,
+                    'UTF-8'
+                );
 
-			$wrappedSubpartArray['###LINK_BASKET###'] = ['<a href="' . $htmlUrl . '">', '</a>'];
+            $wrappedSubpartArray['###LINK_BASKET###'] = ['<a href="' . $htmlUrl . '">', '</a>'];
 
-			PaymentShippingHandling::getMarkerArray(
-				$theCode,
-				$markerArray,
-				$pid,
-				$useBackPid,
-				$calculatedArray,
-				$basketExtra
-			);
+            PaymentShippingHandling::getMarkerArray(
+                $theCode,
+                $markerArray,
+                $pid,
+                $useBackPid,
+                $calculatedArray,
+                $basketExtra
+            );
 
-			// for receipt from DIBS script
-			$markerArray['###TRANSACT_CODE###'] = GeneralUtility::_GP('transact');
-			$markerArray['###CUR_SYM###'] = ' ' . ($bHtml ?  htmlentities($conf['currencySymbol'], ENT_QUOTES) : $conf['currencySymbol']);
-			$discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray, true);
+            // for receipt from DIBS script
+            $markerArray['###TRANSACT_CODE###'] = GeneralUtility::_GP('transact');
+            $markerArray['###CUR_SYM###'] = ' ' . ($bHtml ?  htmlentities($conf['currencySymbol'], ENT_QUOTES) : $conf['currencySymbol']);
+            $discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray, true);
 
-			$markerArray['###PRICE_TAX_DISCOUNT###'] = $markerArray['###PRICE_DISCOUNT_TAX###'] = $priceViewObj->priceFormat($discountValue);
+            $markerArray['###PRICE_TAX_DISCOUNT###'] = $markerArray['###PRICE_DISCOUNT_TAX###'] = $priceViewObj->priceFormat($discountValue);
 
-			$discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray, false);
+            $discountValue = tx_ttproducts_basket_calculate::getRealDiscount($calculatedArray, false);
 
-			$markerArray['###PRICE_NO_TAX_DISCOUNT###'] = $priceViewObj->priceFormat($discountValue);
+            $markerArray['###PRICE_NO_TAX_DISCOUNT###'] = $priceViewObj->priceFormat($discountValue);
 
-			self::getDiscountSubpartArray(
-				$subpartArray,
-				$wrappedSubpartArray,
-				$calculatedArray
-			);
+            self::getDiscountSubpartArray(
+                $subpartArray,
+                $wrappedSubpartArray,
+                $calculatedArray
+            );
 
-			$markerArray['###PRICE_VAT###'] =
-				$priceViewObj->priceFormat(
-					$calculatedArray['priceTax']['goodstotal']['ALL'] -
-					$calculatedArray['priceNoTax']['goodstotal']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'] -
-					$calculatedArray['depositnotax']['goodstotal']['ALL']
-				);
+            $markerArray['###PRICE_VAT###'] =
+                $priceViewObj->priceFormat(
+                    $calculatedArray['priceTax']['goodstotal']['ALL'] -
+                    $calculatedArray['priceNoTax']['goodstotal']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'] -
+                    $calculatedArray['depositnotax']['goodstotal']['ALL']
+                );
 
-			$orderViewObj = $tablesObj->get('sys_products_orders', true);
-			$orderViewObj->getBasketRecsMarkerArray($markerArray, $multiOrderArray[0] ?? '');
-			$trackingCode = '';
-			if (isset($multiOrderArray['0']['tracking_code'])) {
-				$trackingCode = $multiOrderArray['0']['tracking_code'];
-			}
-			$billdeliveryObj->getMarkerArray($markerArray, $trackingCode, 'bill');
-			$billdeliveryObj->getMarkerArray($markerArray, $trackingCode, 'delivery');
+            $orderViewObj = $tablesObj->get('sys_products_orders', true);
+            $orderViewObj->getBasketRecsMarkerArray($markerArray, $multiOrderArray[0] ?? '');
+            $trackingCode = '';
+            if (isset($multiOrderArray['0']['tracking_code'])) {
+                $trackingCode = $multiOrderArray['0']['tracking_code'];
+            }
+            $billdeliveryObj->getMarkerArray($markerArray, $trackingCode, 'bill');
+            $billdeliveryObj->getMarkerArray($markerArray, $trackingCode, 'delivery');
 
-				// URL
-			$markerArray = $this->urlObj->addURLMarkers(
-				0,
-				$markerArray,
-				[],
-				'',
-				$useBackPid,
-				0
-			); // Applied it here also...
+                // URL
+            $markerArray = $this->urlObj->addURLMarkers(
+                0,
+                $markerArray,
+                [],
+                '',
+                $useBackPid,
+                0
+            ); // Applied it here also...
 
-			$taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
-			$taxInclExcl = (isset($taxFromShipping) && is_double($taxFromShipping) && $taxFromShipping == 0 ? 'tax_zero' : 'tax_included');
-			$markerArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
+            $taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
+            $taxInclExcl = (isset($taxFromShipping) && is_double($taxFromShipping) && $taxFromShipping == 0 ? 'tax_zero' : 'tax_included');
+            $markerArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
 
-			$pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($conf);
+            $pricefactor = tx_ttproducts_creditpoints_div::getPriceFactor($conf);
 
-	/* Added els6: do not execute the redeeming of the gift certificate if template = OVERVIEW */
-			if ($subpartMarker != 'BASKET_OVERVIEW_TEMPLATE') {
+    /* Added els6: do not execute the redeeming of the gift certificate if template = OVERVIEW */
+            if ($subpartMarker != 'BASKET_OVERVIEW_TEMPLATE') {
 
-	// Added Franz: GIFT CERTIFICATE
-				$markerArray['###GIFT_CERTIFICATE_UNIQUE_NUMBER_NAME###']='recs[tt_products][giftcode]'; // deprecated
-				$markerArray['###FORM_NAME###']='BasketForm';
-				$markerArray['###FORM_NAME_GIFT_CERTIFICATE###']='BasketGiftForm';
+    // Added Franz: GIFT CERTIFICATE
+                $markerArray['###GIFT_CERTIFICATE_UNIQUE_NUMBER_NAME###']='recs[tt_products][giftcode]'; // deprecated
+                $markerArray['###FORM_NAME###']='BasketForm';
+                $markerArray['###FORM_NAME_GIFT_CERTIFICATE###']='BasketGiftForm';
 
-	/* Added els5: markerarrays for gift certificates */
-	/* Added Els6: routine for redeeming the gift certificate (other way then proposed by Franz */
-				$markerArray['###INSERT_GIFTCODE###'] = 'recs[tt_products][giftcode]';
-				$markerArray['###VALUE_GIFTCODE###'] = htmlspecialchars($basketObj->recs['tt_products']['giftcode'] ?? '');
-				$cpArray = tx_ttproducts_control_session::readSession('cp');
+    /* Added els5: markerarrays for gift certificates */
+    /* Added Els6: routine for redeeming the gift certificate (other way then proposed by Franz */
+                $markerArray['###INSERT_GIFTCODE###'] = 'recs[tt_products][giftcode]';
+                $markerArray['###VALUE_GIFTCODE###'] = htmlspecialchars($basketObj->recs['tt_products']['giftcode'] ?? '');
+                $cpArray = tx_ttproducts_control_session::readSession('cp');
 
-				if (
-					isset($cpArray['gift']) &&
-					is_array($cpArray['gift']) &&
-					isset($cpArray['gift']['amount'])
-				) {
-					$creditpointsGifts = $cpArray['gift']['amount'];
-				}
-				$markerArray['###CREDITPOINTS_GIFTS###'] = htmlspecialchars($creditpointsGifts);
+                if (
+                    isset($cpArray['gift']) &&
+                    is_array($cpArray['gift']) &&
+                    isset($cpArray['gift']['amount'])
+                ) {
+                    $creditpointsGifts = $cpArray['gift']['amount'];
+                }
+                $markerArray['###CREDITPOINTS_GIFTS###'] = htmlspecialchars($creditpointsGifts);
 
-				if (empty($basketObj->recs['tt_products']['giftcode'])) {
-					$subpartArray['###SUB_GIFTCODE_DISCOUNT###'] = '';
-					$subpartArray['###SUB_GIFTCODE_DISCOUNTWRONG###'] = '';
-					if ($creditpointsGifts == '') {
-						$subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
-					}
-				} else {
-					$uniqueId = GeneralUtility::trimExplode ('-', $basketObj->recs['tt_products']['giftcode'], true);
-					$query='uid=\'' . intval($uniqueId[0]) . '\' AND crdate=\'' . intval($uniqueId[1]) . '\'';
-					$giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
-					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes);
-					$GLOBALS['TYPO3_DB']->sql_free_result($giftRes);
-					$creditpointsDiscount = intval($creditpointsGifts) * $pricefactor;
-					$markerArray['###GIFT_DISCOUNT###'] = $creditpointsDiscount;
-					$markerArray['###VALUE_GIFTCODE_USED###'] = htmlspecialchars($basketObj->recs['tt_products']['giftcode'] ?? '');
+                if (empty($basketObj->recs['tt_products']['giftcode'])) {
+                    $subpartArray['###SUB_GIFTCODE_DISCOUNT###'] = '';
+                    $subpartArray['###SUB_GIFTCODE_DISCOUNTWRONG###'] = '';
+                    if ($creditpointsGifts == '') {
+                        $subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
+                    }
+                } else {
+                    $uniqueId = GeneralUtility::trimExplode ('-', $basketObj->recs['tt_products']['giftcode'], true);
+                    $query='uid=\'' . intval($uniqueId[0]) . '\' AND crdate=\'' . intval($uniqueId[1]) . '\'';
+                    $giftRes = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products_gifts', $query);
+                    $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($giftRes);
+                    $GLOBALS['TYPO3_DB']->sql_free_result($giftRes);
+                    $creditpointsDiscount = intval($creditpointsGifts) * $pricefactor;
+                    $markerArray['###GIFT_DISCOUNT###'] = $creditpointsDiscount;
+                    $markerArray['###VALUE_GIFTCODE_USED###'] = htmlspecialchars($basketObj->recs['tt_products']['giftcode'] ?? '');
 
-					if ($row && $creditpointsGifts && $pricefactor > 0) {
-						$subpartArray['###SUB_GIFTCODE_DISCOUNTWRONG###']= '';
-						if ($creditpointsGifts == '') {
-							$subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
-						}
-					} else {
-						$markerArray['###VALUE_GIFTCODE_USED###'] = '**********';
-						if (GeneralUtility::_GP('creditpoints_gifts') == '') {
-							$subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
-						}
-					}
-				}
-			}
-			$amountCreditpoints = (            
+                    if ($row && $creditpointsGifts && $pricefactor > 0) {
+                        $subpartArray['###SUB_GIFTCODE_DISCOUNTWRONG###']= '';
+                        if ($creditpointsGifts == '') {
+                            $subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
+                        }
+                    } else {
+                        $markerArray['###VALUE_GIFTCODE_USED###'] = '**********';
+                        if (GeneralUtility::_GP('creditpoints_gifts') == '') {
+                            $subpartArray['###SUB_GIFTCODE_DISCOUNT_true###'] = '';
+                        }
+                    }
+                }
+            }
+            $amountCreditpoints = (            
                 CompatibilityUtility::isLoggedIn()
  ? $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] : 0) + intval($creditpointsGifts);
-			$markerArray['###AMOUNT_CREDITPOINTS###'] = $amountCreditpoints;
-			$autoCreditpointsTotal = (CompatibilityUtility::isLoggedIn() ? $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] : 0);
+            $markerArray['###AMOUNT_CREDITPOINTS###'] = $amountCreditpoints;
+            $autoCreditpointsTotal = (CompatibilityUtility::isLoggedIn() ? $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] : 0);
 
-			$creditpoints = $autoCreditpointsTotal + $sum_pricecreditpoints_total_totunits * tx_ttproducts_creditpoints_div::getCreditPoints($sum_pricecreditpoints_total_totunits, $conf['creditpoints.'] ?? '');
- 			$markerArray['###AUTOCREDITPOINTS_TOTAL###'] = number_format($autoCreditpointsTotal, 0);
- 			$markerArray['###AUTOCREDITPOINTS_PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat($autoCreditpointsTotal * $pricefactor);
-			$remainingCreditpoints = 0;
-			$creditpointsObj->getBasketMissingCreditpoints(0, $tmp, $remainingCreditpoints);
- 			$markerArray['###AUTOCREDITPOINTS_REMAINING###'] = number_format($remainingCreditpoints, 0);
- 			if (CompatibilityUtility::isLoggedIn()) {
+            $creditpoints = $autoCreditpointsTotal + $sum_pricecreditpoints_total_totunits * tx_ttproducts_creditpoints_div::getCreditPoints($sum_pricecreditpoints_total_totunits, $conf['creditpoints.'] ?? '');
+            $markerArray['###AUTOCREDITPOINTS_TOTAL###'] = number_format($autoCreditpointsTotal, 0);
+            $markerArray['###AUTOCREDITPOINTS_PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat($autoCreditpointsTotal * $pricefactor);
+            $remainingCreditpoints = 0;
+            $creditpointsObj->getBasketMissingCreditpoints(0, $tmp, $remainingCreditpoints);
+            $markerArray['###AUTOCREDITPOINTS_REMAINING###'] = number_format($remainingCreditpoints, 0);
+            if (CompatibilityUtility::isLoggedIn()) {
                 $markerArray['###CREDITPOINTS_AVAILABLE###'] = number_format($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'], 0);
-			} else {
+            } else {
                 $markerArray['###CREDITPOINTS_AVAILABLE###'] = 0;
             }
- 			$markerArray['###USERCREDITPOINTS_PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat(($autoCreditpointsTotal < $amountCreditpoints ? $autoCreditpointsTotal : $amountCreditpoints) * $pricefactor);
+            $markerArray['###USERCREDITPOINTS_PRICE_TOTAL_TAX###'] = $priceViewObj->priceFormat(($autoCreditpointsTotal < $amountCreditpoints ? $autoCreditpointsTotal : $amountCreditpoints) * $pricefactor);
 
-			// maximum1 amount of creditpoint to change is amount on account minus amount already spended in the credit-shop
-			$max1_creditpoints = (CompatibilityUtility::isLoggedIn() ? $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] : 0) + intval($creditpointsGifts);
-			// maximum2 amount of creditpoint to change is amount bought multiplied with creditpointfactor
-			$max2_creditpoints = 0;
+            // maximum1 amount of creditpoint to change is amount on account minus amount already spended in the credit-shop
+            $max1_creditpoints = (CompatibilityUtility::isLoggedIn() ? $GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] : 0) + intval($creditpointsGifts);
+            // maximum2 amount of creditpoint to change is amount bought multiplied with creditpointfactor
+            $max2_creditpoints = 0;
 
-			if ($pricefactor > 0) {
-				$max2_creditpoints = intval (($calculatedArray['priceTax']['total']['ALL'] - $calculatedArray['priceTax']['vouchertotal']['ALL']) / $pricefactor );
-			}
-			// real maximum amount of creditpoint to change is minimum of both maximums
-			$markerArray['###AMOUNT_CREDITPOINTS_MAX###'] = number_format(min($max1_creditpoints,$max2_creditpoints), 0);
+            if ($pricefactor > 0) {
+                $max2_creditpoints = intval (($calculatedArray['priceTax']['total']['ALL'] - $calculatedArray['priceTax']['vouchertotal']['ALL']) / $pricefactor );
+            }
+            // real maximum amount of creditpoint to change is minimum of both maximums
+            $markerArray['###AMOUNT_CREDITPOINTS_MAX###'] = number_format(min($max1_creditpoints,$max2_creditpoints), 0);
 
-			// if quantity is 0 than
-			if ($amountCreditpoints == '0') {
-				$subpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
-				$wrappedSubpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
+            // if quantity is 0 than
+            if ($amountCreditpoints == '0') {
+                $subpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
+                $wrappedSubpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
                 $subpartArray['###SUB_CREDITPOINTS_AMOUNT_EMPTY###'] = '';
-				$subpartArray['###SUB_CREDITPOINTS_AMOUNT###'] = '';
-			} else {
-				$wrappedSubpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
-				$subpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
-				$wrappedSubpartArray['###SUB_CREDITPOINTS_AMOUNT_EMPTY###'] = '';
-				$wrappedSubpartArray['###SUB_CREDITPOINTS_AMOUNT###'] = '';
-			}
-			$markerArray['###CHANGE_AMOUNT_CREDITPOINTS###'] = 'recs[tt_products][creditpoints]';
-			if (empty($basketObj->recs['tt_products']['creditpoints'])) {
-				$markerArray['###AMOUNT_CREDITPOINTS_QTY###'] = 0;
-				$subpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
-	/* Added Els8: put credit_discount 0 for plain text email */
-				$markerArray['###CREDIT_DISCOUNT###'] = '0.00';
-			} else {
-				// quantity chosen can not be larger than the maximum amount, above calculated
-				if ($basketObj->recs['tt_products']['creditpoints'] > min ($max1_creditpoints,$max2_creditpoints)) {
-					$basketObj->recs['tt_products']['creditpoints'] = min ($max1_creditpoints, $max2_creditpoints);
-				}
-				$markerArray['###AMOUNT_CREDITPOINTS_QTY###'] = number_format($basketObj->recs['tt_products']['creditpoints'], 0);
-				$subpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
-				$markerArray['###CREDIT_DISCOUNT###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['creditpoints']);
-			}
+                $subpartArray['###SUB_CREDITPOINTS_AMOUNT###'] = '';
+            } else {
+                $wrappedSubpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
+                $subpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
+                $wrappedSubpartArray['###SUB_CREDITPOINTS_AMOUNT_EMPTY###'] = '';
+                $wrappedSubpartArray['###SUB_CREDITPOINTS_AMOUNT###'] = '';
+            }
+            $markerArray['###CHANGE_AMOUNT_CREDITPOINTS###'] = 'recs[tt_products][creditpoints]';
+            if (empty($basketObj->recs['tt_products']['creditpoints'])) {
+                $markerArray['###AMOUNT_CREDITPOINTS_QTY###'] = 0;
+                $subpartArray['###SUB_CREDITPOINTS_DISCOUNT###'] = '';
+    /* Added Els8: put credit_discount 0 for plain text email */
+                $markerArray['###CREDIT_DISCOUNT###'] = '0.00';
+            } else {
+                // quantity chosen can not be larger than the maximum amount, above calculated
+                if ($basketObj->recs['tt_products']['creditpoints'] > min ($max1_creditpoints,$max2_creditpoints)) {
+                    $basketObj->recs['tt_products']['creditpoints'] = min ($max1_creditpoints, $max2_creditpoints);
+                }
+                $markerArray['###AMOUNT_CREDITPOINTS_QTY###'] = number_format($basketObj->recs['tt_products']['creditpoints'], 0);
+                $subpartArray['###SUB_CREDITPOINTS_DISCOUNT_EMPTY###'] = '';
+                $markerArray['###CREDIT_DISCOUNT###'] = $priceViewObj->priceFormat($calculatedArray['priceTax']['creditpoints']);
+            }
 
-	/* Added els5: CREDITPOINTS_SPENDED: creditpoint needed, check if user has this amount of creditpoints on his account (winkelwagen.tmpl), only if user has logged in */
-			$markerArray['###CREDITPOINTS_SPENDED###'] = $sum_pricecredits_total_totunits_no_tax;
-			if ($sum_pricecredits_total_totunits_no_tax <= $amountCreditpoints) {
-				$subpartArray['###SUB_CREDITPOINTS_SPENDED_EMPTY###'] = '';
-				$markerArray['###CREDITPOINTS_SPENDED###'] = $sum_pricecredits_total_totunits_no_tax;
-				// new saldo: creditpoints
-				$markerArray['###AMOUNT_CREDITPOINTS###'] = $amountCreditpoints - $markerArray['###CREDITPOINTS_SPENDED###'];
-			} else {
-				if (!$markerArray['###FE_USER_UID###']) {
-					$subpartArray['###SUB_CREDITPOINTS_SPENDED_EMPTY###'] = '';
-				} else {
-					$markerArray['###CREDITPOINTS_SPENDED_ERROR###'] = 'Wijzig de artikelen in de kurkenshop: onvoldoende kurken op uw saldo (' . $amountCreditpoints . ') . '; // TODO
-					$markerArray['###CREDITPOINTS_SPENDED###'] = '&nbsp;';
-				}
-			}
+    /* Added els5: CREDITPOINTS_SPENDED: creditpoint needed, check if user has this amount of creditpoints on his account (winkelwagen.tmpl), only if user has logged in */
+            $markerArray['###CREDITPOINTS_SPENDED###'] = $sum_pricecredits_total_totunits_no_tax;
+            if ($sum_pricecredits_total_totunits_no_tax <= $amountCreditpoints) {
+                $subpartArray['###SUB_CREDITPOINTS_SPENDED_EMPTY###'] = '';
+                $markerArray['###CREDITPOINTS_SPENDED###'] = $sum_pricecredits_total_totunits_no_tax;
+                // new saldo: creditpoints
+                $markerArray['###AMOUNT_CREDITPOINTS###'] = $amountCreditpoints - $markerArray['###CREDITPOINTS_SPENDED###'];
+            } else {
+                if (!$markerArray['###FE_USER_UID###']) {
+                    $subpartArray['###SUB_CREDITPOINTS_SPENDED_EMPTY###'] = '';
+                } else {
+                    $markerArray['###CREDITPOINTS_SPENDED_ERROR###'] = 'Wijzig de artikelen in de kurkenshop: onvoldoende kurken op uw saldo (' . $amountCreditpoints . ') . '; // TODO
+                    $markerArray['###CREDITPOINTS_SPENDED###'] = '&nbsp;';
+                }
+            }
 
-			foreach ($quantityArray as $k => $subQuantityArray) {
-				switch ($k) {
-					case 'minimum':
-						$markerkey = 'MINQUANTITY';
-						break;
-					case 'maximum':
-						$markerkey = 'MAXQUANTITY';
-						break;
-				}
+            foreach ($quantityArray as $k => $subQuantityArray) {
+                switch ($k) {
+                    case 'minimum':
+                        $markerkey = 'MINQUANTITY';
+                        break;
+                    case 'maximum':
+                        $markerkey = 'MAXQUANTITY';
+                        break;
+                }
 
-				if (is_array($subQuantityArray) && count($subQuantityArray)) {
-					$subpartArray['###MESSAGE_' . $markerkey . '###'] = '';
-					$tmpSubpart =
-						$templateService->getSubpart(
-							$t['basketFrameWork'],
-							'###MESSAGE_' . $markerkey . '_ERROR###'
-						);
-					$quantityCode = [];
-					$quantityCode[0] = 'error_' . strtolower($markerkey);
-					$quantityCode[1] = '';
+                if (is_array($subQuantityArray) && count($subQuantityArray)) {
+                    $subpartArray['###MESSAGE_' . $markerkey . '###'] = '';
+                    $tmpSubpart =
+                        $templateService->getSubpart(
+                            $t['basketFrameWork'],
+                            '###MESSAGE_' . $markerkey . '_ERROR###'
+                        );
+                    $quantityCode = [];
+                    $quantityCode[0] = 'error_' . strtolower($markerkey);
+                    $quantityCode[1] = '';
 
-					foreach ($subQuantityArray as $subQuantityRow) {
-						$quantityCode[1] .= $subQuantityRow['rec']['title'] . ': ' . $subQuantityRow['quantity'] . ' ' . ($k == 'minimum' ? '&lt;' : '&gt;') . ' ' . $subQuantityRow['limitQuantity'];
-					}
+                    foreach ($subQuantityArray as $subQuantityRow) {
+                        $quantityCode[1] .= $subQuantityRow['rec']['title'] . ': ' . $subQuantityRow['quantity'] . ' ' . ($k == 'minimum' ? '&lt;' : '&gt;') . ' ' . $subQuantityRow['limitQuantity'];
+                    }
 
-					$errorOut = ErrorUtility::getMessage($languageObj, $quantityCode);
-					$markerArray['###ERROR_' . $markerkey . '###'] = $errorOut;
-					$subpartArray['###MESSAGE_' . $markerkey . '_ERROR###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
-				} else {
-					$subpartArray['###MESSAGE_' . $markerkey . '_ERROR###'] = '';
-					$tmpSubpart =
-						$templateService->getSubpart(
-							$t['basketFrameWork'],
-							'###MESSAGE_' . $markerkey . '###'
-						);
-					$subpartArray['###MESSAGE_' . $markerkey . '###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
-				}
-			}
+                    $errorOut = ErrorUtility::getMessage($languageObj, $quantityCode);
+                    $markerArray['###ERROR_' . $markerkey . '###'] = $errorOut;
+                    $subpartArray['###MESSAGE_' . $markerkey . '_ERROR###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
+                } else {
+                    $subpartArray['###MESSAGE_' . $markerkey . '_ERROR###'] = '';
+                    $tmpSubpart =
+                        $templateService->getSubpart(
+                            $t['basketFrameWork'],
+                            '###MESSAGE_' . $markerkey . '###'
+                        );
+                    $subpartArray['###MESSAGE_' . $markerkey . '###'] = $templateService->substituteMarkerArray($tmpSubpart, $markerArray);
+                }
+            }
 
-			if (count($quantityArray['minimum']) || count($quantityArray['maximum'])/* || !$minPriceSuccess*/) {
-				$subpartArray['###MESSAGE_NO_ERROR###'] = '';
-			} else {
-				$subpartArray['###MESSAGE_ERROR###'] = '';
-			}
-			$voucherView = $tablesObj->get('voucher', true);
+            if (count($quantityArray['minimum']) || count($quantityArray['maximum'])/* || !$minPriceSuccess*/) {
+                $subpartArray['###MESSAGE_NO_ERROR###'] = '';
+            } else {
+                $subpartArray['###MESSAGE_ERROR###'] = '';
+            }
+            $voucherView = $tablesObj->get('voucher', true);
 
-			if (is_object($voucherView)) {
-				$voucherView->getSubpartMarkerArray(
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-				$voucherView->getMarkerArray($markerArray);
-			}
+            if (is_object($voucherView)) {
+                $voucherView->getSubpartMarkerArray(
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+                $voucherView->getMarkerArray($markerArray);
+            }
 
-			$markerArray['###CREDITPOINTS_SAVED###'] = number_format($creditpoints, '0');
-			$pidagb = intval($conf['PIDagb']);
+            $markerArray['###CREDITPOINTS_SAVED###'] = number_format($creditpoints, '0');
+            $pidagb = intval($conf['PIDagb']);
 
-			$addQueryString = [];
+            $addQueryString = [];
 
-			// $addQueryString['id'] = $pidagb;
-			if ($GLOBALS['TSFE']->type) {
-				$addQueryString['type'] = $GLOBALS['TSFE']->type;
-			}
+            // $addQueryString['id'] = $pidagb;
+            if ($GLOBALS['TSFE']->type) {
+                $addQueryString['type'] = $GLOBALS['TSFE']->type;
+            }
 
-			$pointerExcludeArray = array_keys(tx_ttproducts_model_control::getPointerParamsCodeArray());
-			$singleExcludeList = $this->urlObj->getSingleExcludeList(implode(',', $pointerExcludeArray));
-			$tempUrl =
+            $pointerExcludeArray = array_keys(tx_ttproducts_model_control::getPointerParamsCodeArray());
+            $singleExcludeList = $this->urlObj->getSingleExcludeList(implode(',', $pointerExcludeArray));
+            $tempUrl =
                 FrontendUtility::getTypoLink_URL(
-					$cObj,
-					$pidagb,
-					$this->urlObj->getLinkParams(
-						$singleExcludeList,
-						$addQueryString,
-						true,
-						$useBackPid,
-						0,
-						''
-					)
-				);
+                    $cObj,
+                    $pidagb,
+                    $this->urlObj->getLinkParams(
+                        $singleExcludeList,
+                        $addQueryString,
+                        true,
+                        $useBackPid,
+                        0,
+                        ''
+                    )
+                );
 
-			$wrappedSubpartArray['###LINK_AGB###'] = [
-				'<a href="' . htmlspecialchars($tempUrl) . '" target="' . $conf['AGBtarget'] . '">',
-				'</a>'
-			];
+            $wrappedSubpartArray['###LINK_AGB###'] = [
+                '<a href="' . htmlspecialchars($tempUrl) . '" target="' . $conf['AGBtarget'] . '">',
+                '</a>'
+            ];
 
             $pidPrivacy = intval($conf['PIDprivacy']);
             $tempUrl =
@@ -1450,328 +1450,328 @@ class tx_ttproducts_basket_view implements \TYPO3\CMS\Core\SingletonInterface {
                 '</a>'
             ];
 
-			$pidRevocation = intval($conf['PIDrevocation']);
+            $pidRevocation = intval($conf['PIDrevocation']);
 
-			$tempUrl =
-				FrontendUtility::getTypoLink_URL(
-					$cObj,
-					$pidRevocation,
-					$this->urlObj->getLinkParams(
-						$singleExcludeList,
-						$addQueryString,
-						true,
-						$useBackPid,
-						0,
-						''
-					)
-				);
+            $tempUrl =
+                FrontendUtility::getTypoLink_URL(
+                    $cObj,
+                    $pidRevocation,
+                    $this->urlObj->getLinkParams(
+                        $singleExcludeList,
+                        $addQueryString,
+                        true,
+                        $useBackPid,
+                        0,
+                        ''
+                    )
+                );
 
-			$wrappedSubpartArray['###LINK_REVOCATION###'] = [
-				'<a href="' . htmlspecialchars($tempUrl) . '" target="' . $conf['AGBtarget'] . '">',
-				'</a>'
-			];
+            $wrappedSubpartArray['###LINK_REVOCATION###'] = [
+                '<a href="' . htmlspecialchars($tempUrl) . '" target="' . $conf['AGBtarget'] . '">',
+                '</a>'
+            ];
 
-				// Final substitution:
-			if (!\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {		// Remove section for FE_USERs only, if there are no fe_user
-				$subpartArray['###FE_USER_SECTION###'] = '';
-			}
+                // Final substitution:
+            if (!\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {		// Remove section for FE_USERs only, if there are no fe_user
+                $subpartArray['###FE_USER_SECTION###'] = '';
+            }
 
-			if (is_object($infoViewObj)) {
-				$infoViewObj->getRowMarkerArray(
-					$basketExtra,
-					$markerArray,
-					$bHtml,
-					$bSelectSalutation
-				);
-			}
+            if (is_object($infoViewObj)) {
+                $infoViewObj->getRowMarkerArray(
+                    $basketExtra,
+                    $markerArray,
+                    $bHtml,
+                    $bSelectSalutation
+                );
+            }
 
-			$fieldsTempArray = $markerObj->getMarkerFields(
-				$t['basketFrameWork'],
-				$itemTable->getTableObj()->tableFieldArray,
-				$itemTable->getTableObj()->requiredFieldArray,
-				$markerFieldArray,
-				$itemTableView->getMarker(),
-				$viewTagArray,
-				$parentArray
-			);
+            $fieldsTempArray = $markerObj->getMarkerFields(
+                $t['basketFrameWork'],
+                $itemTable->getTableObj()->tableFieldArray,
+                $itemTable->getTableObj()->requiredFieldArray,
+                $markerFieldArray,
+                $itemTableView->getMarker(),
+                $viewTagArray,
+                $parentArray
+            );
 
-			$priceCalcMarkerArray = [
-				'PRICE_TOTAL_TAX' =>
-					$calculatedArray['priceTax']['total']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'],
-				'PRICE_TOTAL_NO_TAX' =>
-					$calculatedArray['priceNoTax']['total']['ALL'] +
-					$calculatedArray['depositnotax']['goodstotal']['ALL'],
-				'PRICE_TOTAL_0_TAX' =>
-					$calculatedArray['price0Tax']['total']['ALL'] +
-					$calculatedArray['depositnotax']['goodstotal']['ALL'],
-				'PRICE_TOTAL_ONLY_TAX' =>
-					$calculatedArray['priceTax']['total']['ALL'] -
-					$calculatedArray['priceNoTax']['total']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'] -
-					$calculatedArray['depositnotax']['goodstotal']['ALL'],
-				'PRICE_GOODSTOTAL_0_TAX' =>
-					$calculatedArray['price0Tax']['goodstotal']['ALL'],
-				'PRICE_GOODSTOTAL_0_NO_TAX' =>
-					$calculatedArray['price0NoTax']['goodstotal']['ALL'],
-				'PRICE_VOUCHERTOTAL_TAX' =>
-					$calculatedArray['priceTax']['vouchertotal']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'],
-				'PRICE_VOUCHERTOTAL_NO_TAX' =>
-					$calculatedArray['priceNoTax']['vouchertotal']['ALL'] +
-					$calculatedArray['depositnotax']['goodstotal']['ALL'],
-				'PRICE_VOUCHERGOODSTOTAL_TAX' =>
-					$calculatedArray['priceTax']['vouchergoodstotal']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'],
-				'PRICE_VOUCHERGOODSTOTAL_NO_TAX' =>
-					$calculatedArray['priceNoTax']['vouchergoodstotal']['ALL'] +
-					$calculatedArray['depositnotax']['goodstotal']['ALL'],
-				'PRICE_TOTAL_TAX_WITHOUT_PAYMENT' =>
-					$calculatedArray['priceTax']['total']['ALL'] +
-					$calculatedArray['deposittax']['goodstotal']['ALL'] -
-					$calculatedArray['payment']['priceTax'],
-				'PRICE_TOTAL_NO_TAX_WITHOUT_PAYMENT' =>
-					$calculatedArray['priceNoTax']['total']['ALL'] +
-						$calculatedArray['depositnotax']['goodstotal']['ALL'] -
-						$calculatedArray['payment']['priceNoTax'],
-				'PRICE_TOTAL_TAX_CENT' =>
-					intval(round(100 * $calculatedArray['priceTax']['total']['ALL'])),
-				'PRICE_VOUCHERTOTAL_TAX_CENT' =>
-					intval(
-						round(
-							100 * (
-								$calculatedArray['priceTax']['vouchertotal']['ALL'] +
-								$calculatedArray['deposittax']['goodstotal']['ALL']
-							)
-						)
-					)
-			];
+            $priceCalcMarkerArray = [
+                'PRICE_TOTAL_TAX' =>
+                    $calculatedArray['priceTax']['total']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'],
+                'PRICE_TOTAL_NO_TAX' =>
+                    $calculatedArray['priceNoTax']['total']['ALL'] +
+                    $calculatedArray['depositnotax']['goodstotal']['ALL'],
+                'PRICE_TOTAL_0_TAX' =>
+                    $calculatedArray['price0Tax']['total']['ALL'] +
+                    $calculatedArray['depositnotax']['goodstotal']['ALL'],
+                'PRICE_TOTAL_ONLY_TAX' =>
+                    $calculatedArray['priceTax']['total']['ALL'] -
+                    $calculatedArray['priceNoTax']['total']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'] -
+                    $calculatedArray['depositnotax']['goodstotal']['ALL'],
+                'PRICE_GOODSTOTAL_0_TAX' =>
+                    $calculatedArray['price0Tax']['goodstotal']['ALL'],
+                'PRICE_GOODSTOTAL_0_NO_TAX' =>
+                    $calculatedArray['price0NoTax']['goodstotal']['ALL'],
+                'PRICE_VOUCHERTOTAL_TAX' =>
+                    $calculatedArray['priceTax']['vouchertotal']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'],
+                'PRICE_VOUCHERTOTAL_NO_TAX' =>
+                    $calculatedArray['priceNoTax']['vouchertotal']['ALL'] +
+                    $calculatedArray['depositnotax']['goodstotal']['ALL'],
+                'PRICE_VOUCHERGOODSTOTAL_TAX' =>
+                    $calculatedArray['priceTax']['vouchergoodstotal']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'],
+                'PRICE_VOUCHERGOODSTOTAL_NO_TAX' =>
+                    $calculatedArray['priceNoTax']['vouchergoodstotal']['ALL'] +
+                    $calculatedArray['depositnotax']['goodstotal']['ALL'],
+                'PRICE_TOTAL_TAX_WITHOUT_PAYMENT' =>
+                    $calculatedArray['priceTax']['total']['ALL'] +
+                    $calculatedArray['deposittax']['goodstotal']['ALL'] -
+                    $calculatedArray['payment']['priceTax'],
+                'PRICE_TOTAL_NO_TAX_WITHOUT_PAYMENT' =>
+                    $calculatedArray['priceNoTax']['total']['ALL'] +
+                        $calculatedArray['depositnotax']['goodstotal']['ALL'] -
+                        $calculatedArray['payment']['priceNoTax'],
+                'PRICE_TOTAL_TAX_CENT' =>
+                    intval(round(100 * $calculatedArray['priceTax']['total']['ALL'])),
+                'PRICE_VOUCHERTOTAL_TAX_CENT' =>
+                    intval(
+                        round(
+                            100 * (
+                                $calculatedArray['priceTax']['vouchertotal']['ALL'] +
+                                $calculatedArray['deposittax']['goodstotal']['ALL']
+                            )
+                        )
+                    )
+            ];
 
-			foreach ($priceCalcMarkerArray as $markerKey => $value) {
-				$markerArray['###' . $markerKey . '###'] = (is_int($value) ? $value : $priceViewObj->priceFormat($value));
-			}
+            foreach ($priceCalcMarkerArray as $markerKey => $value) {
+                $markerArray['###' . $markerKey . '###'] = (is_int($value) ? $value : $priceViewObj->priceFormat($value));
+            }
 
-			$variantFieldArray = [];
-			$variantMarkerArray = [];
-			$taxContent = '';
+            $variantFieldArray = [];
+            $variantMarkerArray = [];
+            $taxContent = '';
 
-			if (tx_ttproducts_static_tax::isInstalled()) {
-				$staticTaxViewObj = $tablesObj->get('static_taxes', true);
-				if (is_object($staticTaxViewObj)) {
-					$staticTaxObj = $staticTaxViewObj->getModelObj();
+            if (tx_ttproducts_static_tax::isInstalled()) {
+                $staticTaxViewObj = $tablesObj->get('static_taxes', true);
+                if (is_object($staticTaxViewObj)) {
+                    $staticTaxObj = $staticTaxViewObj->getModelObj();
 
-					$bUseTaxArray = false;
-					$viewTaxTagArray = [];
-					$parentArray = [];
-					$markerFieldArray = [];
+                    $bUseTaxArray = false;
+                    $viewTaxTagArray = [];
+                    $parentArray = [];
+                    $markerFieldArray = [];
 
-					$fieldsArray = $markerObj->getMarkerFields(
-						$t['basketFrameWork'],
-						$staticTaxObj->getTableObj()->tableFieldArray,
-						$staticTaxObj->getTableObj()->requiredFieldArray,
-						$markerFieldArray,
-						$staticTaxViewObj->getMarker(),
-						$viewTaxTagArray,
-						$parentArray
-					);
+                    $fieldsArray = $markerObj->getMarkerFields(
+                        $t['basketFrameWork'],
+                        $staticTaxObj->getTableObj()->tableFieldArray,
+                        $staticTaxObj->getTableObj()->requiredFieldArray,
+                        $markerFieldArray,
+                        $staticTaxViewObj->getMarker(),
+                        $viewTaxTagArray,
+                        $parentArray
+                    );
 
-					if (
-						isset($taxInfoArray) &&
-						is_array($taxInfoArray) &&
-						!empty($taxInfoArray)
-					) {
-						$bUseTaxArray = true;
-						$bEnableTaxZero = false;
-						foreach ($taxInfoArray as $countryCode => $taxArray) {
-							foreach ($taxArray as $k => $taxRow) {
-								$theTax = $taxRow['tx_rate'] * 0.01;
-								$markerKey = 'STATICTAX_' . ($taxId) . '_' . ($k + 1);
-								$staticTaxMarkerArray = [];
+                    if (
+                        isset($taxInfoArray) &&
+                        is_array($taxInfoArray) &&
+                        !empty($taxInfoArray)
+                    ) {
+                        $bUseTaxArray = true;
+                        $bEnableTaxZero = false;
+                        foreach ($taxInfoArray as $countryCode => $taxArray) {
+                            foreach ($taxArray as $k => $taxRow) {
+                                $theTax = $taxRow['tx_rate'] * 0.01;
+                                $markerKey = 'STATICTAX_' . ($taxId) . '_' . ($k + 1);
+                                $staticTaxMarkerArray = [];
 
-								$staticTaxViewObj->getRowMarkerArray(
-									'static_tax_rates',
-									$taxRow,
-									$markerKey,
-									$staticTaxMarkerArray,
-									$variantFieldArray,
-									$variantMarkerArray,
-									$viewTagArray,
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									$bHtml,
-									$charset,
-									0,
-									'',
-									$id,
-									$prefix, // if false, then no table marker will be added
-									$suffix,
-									'',
-									$bEnableTaxZero
-								);
+                                $staticTaxViewObj->getRowMarkerArray(
+                                    'static_tax_rates',
+                                    $taxRow,
+                                    $markerKey,
+                                    $staticTaxMarkerArray,
+                                    $variantFieldArray,
+                                    $variantMarkerArray,
+                                    $viewTagArray,
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $bHtml,
+                                    $charset,
+                                    0,
+                                    '',
+                                    $id,
+                                    $prefix, // if false, then no table marker will be added
+                                    $suffix,
+                                    '',
+                                    $bEnableTaxZero
+                                );
 
-								$markerArray = array_merge($markerArray, $staticTaxMarkerArray);
-								$countryMarkerArray = [];
-								$countrySubpartArray = [];
-								$countryWrappedSubpartArray = [];
-								foreach ($staticTaxMarkerArray as $key => $value) {
-									$countryMarkerKey =  str_replace($markerKey, 'STATICTAX', $key);
-									$countryMarkerArray[$countryMarkerKey] = $value;
-								}
+                                $markerArray = array_merge($markerArray, $staticTaxMarkerArray);
+                                $countryMarkerArray = [];
+                                $countrySubpartArray = [];
+                                $countryWrappedSubpartArray = [];
+                                foreach ($staticTaxMarkerArray as $key => $value) {
+                                    $countryMarkerKey =  str_replace($markerKey, 'STATICTAX', $key);
+                                    $countryMarkerArray[$countryMarkerKey] = $value;
+                                }
 
-								$priceArray = [];
+                                $priceArray = [];
 
-								$value = 0;
-								if (
-									isset($calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode]) &&
-									isset($calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$taxRow['tx_rate']])
-								) {
-									$value = $calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$taxRow['tx_rate']];
-								}
-								$priceArray['priceNoTax'] = $value;
-								$priceArray['priceTax'] = $priceArray['priceNoTax'] * (1 + $theTax);
-								$priceArray['onlyTax'] = $priceArray['priceTax'] - $priceArray['priceNoTax'];
-								$priceCalcMarkerArray2 = [
-									'PRICE_TOTAL_ONLY_TAX' => $priceArray['onlyTax']
-								];
+                                $value = 0;
+                                if (
+                                    isset($calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode]) &&
+                                    isset($calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$taxRow['tx_rate']])
+                                ) {
+                                    $value = $calculatedArray['priceNoTax']['goodssametaxtotal'][$countryCode][$taxRow['tx_rate']];
+                                }
+                                $priceArray['priceNoTax'] = $value;
+                                $priceArray['priceTax'] = $priceArray['priceNoTax'] * (1 + $theTax);
+                                $priceArray['onlyTax'] = $priceArray['priceTax'] - $priceArray['priceNoTax'];
+                                $priceCalcMarkerArray2 = [
+                                    'PRICE_TOTAL_ONLY_TAX' => $priceArray['onlyTax']
+                                ];
 
-								foreach ($priceCalcMarkerArray2 as $markerKey => $value) {
-									$markerArray['###STATICTAX_' . ($taxId) . '_' . ($k + 1) . '_' . $markerKey . '###'] = $countryMarkerArray['###' . $markerKey . '###'] = $priceViewObj->priceFormat($value);
-								}
+                                foreach ($priceCalcMarkerArray2 as $markerKey => $value) {
+                                    $markerArray['###STATICTAX_' . ($taxId) . '_' . ($k + 1) . '_' . $markerKey . '###'] = $countryMarkerArray['###' . $markerKey . '###'] = $priceViewObj->priceFormat($value);
+                                }
 
-								$countryMarkerArray['###COUNTRY_CODE###'] = $countryCode;
-								$tempContent = $templateService->substituteMarkerArrayCached(
-									$t['taxes'],
-									$countryMarkerArray,
-									$countrySubpartArray,
-									$countryWrappedSubpartArray
-								);
-								$taxContent .= $tempContent;
-							}
-						}
-					} // $t['taxes']
+                                $countryMarkerArray['###COUNTRY_CODE###'] = $countryCode;
+                                $tempContent = $templateService->substituteMarkerArrayCached(
+                                    $t['taxes'],
+                                    $countryMarkerArray,
+                                    $countrySubpartArray,
+                                    $countryWrappedSubpartArray
+                                );
+                                $taxContent .= $tempContent;
+                            }
+                        }
+                    } // $t['taxes']
 
 
-					foreach ($viewTaxTagArray as $theTag => $v1) {
-						if (!isset($markerArray['###' . $theTag . '###'])) {
-							foreach ($priceCalcMarkerArray as $markerKey => $value) {
-								if (strpos($theTag, $markerKey) !== false) {
-									$markerArray['###' . $theTag . '###'] = '';
-								}
-							}
-							if (strpos($theTag, 'STATICTAX_') === 0) {
-								$markerArray['###' . $theTag . '###'] = '';
-							}
-						}
-					}
-				}
-			}
+                    foreach ($viewTaxTagArray as $theTag => $v1) {
+                        if (!isset($markerArray['###' . $theTag . '###'])) {
+                            foreach ($priceCalcMarkerArray as $markerKey => $value) {
+                                if (strpos($theTag, $markerKey) !== false) {
+                                    $markerArray['###' . $theTag . '###'] = '';
+                                }
+                            }
+                            if (strpos($theTag, 'STATICTAX_') === 0) {
+                                $markerArray['###' . $theTag . '###'] = '';
+                            }
+                        }
+                    }
+                }
+            }
 
-			$subpartArray['###COUNTRY_TAXRATES###'] = $taxContent;
+            $subpartArray['###COUNTRY_TAXRATES###'] = $taxContent;
 
-			$this->getBoundaryMarkerArray(
-				$t['basketFrameWork'],
-				$cObj,
-				$cnf,
-				$calculatedArray,
-				$checkPriceArray,
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            $this->getBoundaryMarkerArray(
+                $t['basketFrameWork'],
+                $cObj,
+                $cnf,
+                $calculatedArray,
+                $checkPriceArray,
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-				// Call all getBasketView hooks at the end of this method
+                // Call all getBasketView hooks at the end of this method
             if (
                 isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getBasketView']) &&
                 is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getBasketView'])
             ) {
-				foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getBasketView'] as $classRef) {
-					$hookObj= GeneralUtility::makeInstance($classRef);
-					if (method_exists($hookObj, 'getMarkerArrays')) {
-						$hookObj->getMarkerArrays(
-							$this,
-							$templateCode,
-							$theCode,
-							$markerArray,
-							$subpartArray,
-							$wrappedSubpartArray,
-							$mainMarkerArray,
-							$count
-						);
-					}
-				}
-			}
+                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getBasketView'] as $classRef) {
+                    $hookObj= GeneralUtility::makeInstance($classRef);
+                    if (method_exists($hookObj, 'getMarkerArrays')) {
+                        $hookObj->getMarkerArrays(
+                            $this,
+                            $templateCode,
+                            $theCode,
+                            $markerArray,
+                            $subpartArray,
+                            $wrappedSubpartArray,
+                            $mainMarkerArray,
+                            $count
+                        );
+                    }
+                }
+            }
 
-			$pidListObj = tx_ttproducts_control_basket::getPidListObj();
-			$relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
-			$relatedListView->init(
-				$pidListObj->getPidlist(),
-				$pidListObj->getRecursive()
-			);
-			$relatedMarkerArray = $relatedListView->getListMarkerArray(
-				$theCode,
-				$templateCode,
-				$viewTagArray,
-				$funcTablename,
-				$basketObj->getUidArray(),
-				[],
-				[],
-				false,
+            $pidListObj = tx_ttproducts_control_basket::getPidListObj();
+            $relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
+            $relatedListView->init(
+                $pidListObj->getPidlist(),
+                $pidListObj->getRecursive()
+            );
+            $relatedMarkerArray = $relatedListView->getListMarkerArray(
+                $theCode,
+                $templateCode,
+                $viewTagArray,
+                $funcTablename,
+                $basketObj->getUidArray(),
+                [],
+                [],
+                false,
                 $multiOrderArray,
-				$this->useArticles,
-				$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
-				$GLOBALS['TSFE']->id,
-				$errorCode
-			);
+                $this->useArticles,
+                $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
+                $GLOBALS['TSFE']->id,
+                $errorCode
+            );
 
-			if ($relatedMarkerArray && is_array($relatedMarkerArray)) {
-				$markerArray = array_merge($markerArray, $relatedMarkerArray);
-			}
+            if ($relatedMarkerArray && is_array($relatedMarkerArray)) {
+                $markerArray = array_merge($markerArray, $relatedMarkerArray);
+            }
 
-			$frameWork =
-				$templateService->substituteSubpart(
-					$t['basketFrameWork'],
-					'###ITEM_CATEGORY_AND_ITEMS###',
-					$out
-				);
+            $frameWork =
+                $templateService->substituteSubpart(
+                    $t['basketFrameWork'],
+                    '###ITEM_CATEGORY_AND_ITEMS###',
+                    $out
+                );
 
-			PaymentShippingHandling::getSubpartArrays(
-				$basketExtra,
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray,
-				$frameWork
-			);
-			$orderAddressViewObj->getWrappedSubpartArray(
-				$viewTagArray,
-				$useBackPid,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            PaymentShippingHandling::getSubpartArrays(
+                $basketExtra,
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray,
+                $frameWork
+            );
+            $orderAddressViewObj->getWrappedSubpartArray(
+                $viewTagArray,
+                $useBackPid,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-				// This cObject may be used to call a function which manipulates the shopping basket based on settings in an external order system. The output is included in the top of the order (HTML) on the basket-page.
-			$externalCObject =  \JambageCom\Div2007\Utility\ObsoleteUtility::getExternalCObject($this, 'externalProcessing');
+                // This cObject may be used to call a function which manipulates the shopping basket based on settings in an external order system. The output is included in the top of the order (HTML) on the basket-page.
+            $externalCObject =  \JambageCom\Div2007\Utility\ObsoleteUtility::getExternalCObject($this, 'externalProcessing');
 
-			$markerArray['###EXTERNAL_COBJECT###'] = $externalCObject . '';  // adding extra preprocessing CObject
+            $markerArray['###EXTERNAL_COBJECT###'] = $externalCObject . '';  // adding extra preprocessing CObject
 
  // workaround for TYPO3 bug #44270
-				// substitute the main subpart with the rendered content.
-			$frameWork =
-				$templateService->substituteMarkerArrayCached(
-					$frameWork,
-					[],
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-			$out =
-				$templateService->substituteMarkerArray(
-					$frameWork,
-					$markerArray
-				); // workaround for TYPO3 bug
+                // substitute the main subpart with the rendered content.
+            $frameWork =
+                $templateService->substituteMarkerArrayCached(
+                    $frameWork,
+                    [],
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+            $out =
+                $templateService->substituteMarkerArray(
+                    $frameWork,
+                    $markerArray
+                ); // workaround for TYPO3 bug
 
-		} // if ($t['basketFrameWork'])
+        } // if ($t['basketFrameWork'])
 
-		return $out;
-	} // getView
+        return $out;
+    } // getView
 }
 

--- a/view/class.tx_ttproducts_basketitem_view.php
+++ b/view/class.tx_ttproducts_basketitem_view.php
@@ -43,340 +43,340 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_basketitem_view implements \TYPO3\CMS\Core\SingletonInterface {
 
-	public function getQuantityName (
-		$uid,
-		$functablename,
-		$externalRow,
-		$parentFuncTablename,
-		$parentRow,
-		$callFunctableArray // deprecated parameter
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$basketVar = tx_ttproducts_model_control::getBasketVar();
-		$externalQuantity = '';
+    public function getQuantityName (
+        $uid,
+        $functablename,
+        $externalRow,
+        $parentFuncTablename,
+        $parentRow,
+        $callFunctableArray // deprecated parameter
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $basketVar = tx_ttproducts_model_control::getBasketVar();
+        $externalQuantity = '';
 
-		if (
-			$functablename != 'tt_products' &&
-			is_array($externalRow) &&
-			isset($externalRow['uid'])
-		) {
-			if (
-				isset($parentRow) &&
-				is_array($parentRow) &&
-				isset($parentRow['uid'])
-			) {
-				$piVar = tx_ttproducts_model_control::getPiVar($parentFuncTablename);
-				if ($piVar !== false) {
-					$externalQuantity = $piVar . '=' . intval($parentRow['uid']) .
-						tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR;
-				}
-			}
+        if (
+            $functablename != 'tt_products' &&
+            is_array($externalRow) &&
+            isset($externalRow['uid'])
+        ) {
+            if (
+                isset($parentRow) &&
+                is_array($parentRow) &&
+                isset($parentRow['uid'])
+            ) {
+                $piVar = tx_ttproducts_model_control::getPiVar($parentFuncTablename);
+                if ($piVar !== false) {
+                    $externalQuantity = $piVar . '=' . intval($parentRow['uid']) .
+                        tx_ttproducts_variant_int::EXTERNAL_QUANTITY_SEPARATOR;
+                }
+            }
 
-			$piVar = tx_ttproducts_model_control::getPiVar($functablename);
+            $piVar = tx_ttproducts_model_control::getPiVar($functablename);
 
-			if ($piVar !== false) {
-				$externalQuantity = '[' . $externalQuantity . $piVar . '=' . intval($externalRow['uid']) . ']';
-			}
-		} else if (isset($callFunctableArray) && is_array($callFunctableArray)) {
-			foreach ($callFunctableArray as $callFunctablename) {
-				$funcMarker = $tablesObj->get($callFunctablename, true)->getMarker();
-				$externalQuantity .= '[###' . $funcMarker . '_UID###]';
-			}
-		}
+            if ($piVar !== false) {
+                $externalQuantity = '[' . $externalQuantity . $piVar . '=' . intval($externalRow['uid']) . ']';
+            }
+        } else if (isset($callFunctableArray) && is_array($callFunctableArray)) {
+            foreach ($callFunctableArray as $callFunctablename) {
+                $funcMarker = $tablesObj->get($callFunctablename, true)->getMarker();
+                $externalQuantity .= '[###' . $funcMarker . '_UID###]';
+            }
+        }
 
-		$basketQuantityName = $basketVar . '[' . $uid . ']' . $externalQuantity . '[quantity]';
-		return $basketQuantityName;
-	}
+        $basketQuantityName = $basketVar . '[' . $uid . ']' . $externalQuantity . '[quantity]';
+        return $basketQuantityName;
+    }
 
-	public function getItemMarkerSubpartArrays (
-		$templateCode,
-		$functablename,
-		$row,
-		$theCode,
-		$tagArray,
-		$bEditable,
-		$productRowArray,
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
-		$productFuncTablename = 'tt_products';
+    public function getItemMarkerSubpartArrays (
+        $templateCode,
+        $functablename,
+        $row,
+        $theCode,
+        $tagArray,
+        $bEditable,
+        $productRowArray,
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
+        $productFuncTablename = 'tt_products';
 
-		if (isset($productRowArray) && is_array($productRowArray)) {
-			foreach ($productRowArray as $productRow) {
-				if ($row['uid'] == $productRow['uid']) {
-					$row = array_merge($row, $productRow);
-					break;
-				}
-			}
-		}
+        if (isset($productRowArray) && is_array($productRowArray)) {
+            foreach ($productRowArray as $productRow) {
+                if ($row['uid'] == $productRow['uid']) {
+                    $row = array_merge($row, $productRow);
+                    break;
+                }
+            }
+        }
 
         $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewTableView = $tablesObj->get($productFuncTablename, true);
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-		$viewTableView->editVariant->getSubpartMarkerArray(
-			$templateCode,
-			$productFuncTablename,
-			$row,
-			$theCode,
-			$bEditable,
-			$tagArray,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewTableView = $tablesObj->get($productFuncTablename, true);
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $viewTableView->editVariant->getSubpartMarkerArray(
+            $templateCode,
+            $productFuncTablename,
+            $row,
+            $theCode,
+            $bEditable,
+            $tagArray,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
 
-		$addQueryString = [];
-		$uid = $row['uid'];
-		$pid = $GLOBALS['TSFE']->id;
-		$cmdArray = tx_ttproducts_control_basket::getCmdArray();
-		$css_current = '';
+        $addQueryString = [];
+        $uid = $row['uid'];
+        $pid = $GLOBALS['TSFE']->id;
+        $cmdArray = tx_ttproducts_control_basket::getCmdArray();
+        $css_current = '';
 
-		foreach ($cmdArray as $cmd) {
+        foreach ($cmdArray as $cmd) {
 
-			$upperCmd = strtoupper($cmd);
+            $upperCmd = strtoupper($cmd);
 
-			if (isset($tagArray['LINK_BASKET_' . $upperCmd])) {
+            if (isset($tagArray['LINK_BASKET_' . $upperCmd])) {
 
-				$addQueryString[$cmd] = $uid;
-				$basketVar = tx_ttproducts_model_control::getBasketParamVar();
-				if (isset($row['ext'])) {
-					$extArray = $row['ext'];
-				}
+                $addQueryString[$cmd] = $uid;
+                $basketVar = tx_ttproducts_model_control::getBasketParamVar();
+                if (isset($row['ext'])) {
+                    $extArray = $row['ext'];
+                }
 
-				if (
-					isset($extArray)
-					&& is_array($extArray)
-					&& isset($extArray['extVarLine'])
-				) {
-					$addQueryString[$basketVar] = md5($extArray['extVarLine']);
+                if (
+                    isset($extArray)
+                    && is_array($extArray)
+                    && isset($extArray['extVarLine'])
+                ) {
+                    $addQueryString[$basketVar] = md5($extArray['extVarLine']);
 
-					$pageLink = FrontendUtility::getTypoLink_URL(
-						$cObj,
-						$pid,
-						$urlObj->getLinkParams(
-							'',
-							$addQueryString,
-							true,
-							false
-						)
-					);
+                    $pageLink = FrontendUtility::getTypoLink_URL(
+                        $cObj,
+                        $pid,
+                        $urlObj->getLinkParams(
+                            '',
+                            $addQueryString,
+                            true,
+                            false
+                        )
+                    );
 
-					$wrappedSubpartArray['###LINK_BASKET_' . $upperCmd . '###'] =
-						[
-							'<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>',
-							'</a>'
-						];
-					unset($addQueryString[$basketVar]);
-				} else {
-					$subpartArray['###LINK_BASKET_' . $upperCmd . '###'] = '';
-				}
-				unset($addQueryString[$cmd]);
-			}
-		}
-	}
+                    $wrappedSubpartArray['###LINK_BASKET_' . $upperCmd . '###'] =
+                        [
+                            '<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>',
+                            '</a>'
+                        ];
+                    unset($addQueryString[$basketVar]);
+                } else {
+                    $subpartArray['###LINK_BASKET_' . $upperCmd . '###'] = '';
+                }
+                unset($addQueryString[$cmd]);
+            }
+        }
+    }
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getItemMarkerArray (
-		$functablename,
-		$useCache,
-		$item,
-		&$markerArray,
-		$tagArray,
-		&$hiddenText,
-		$theCode = '',
-		$bInputDisabled = false,
-		$id = '1',
-		$bSelect = true,
-		$charset = '',
-		$externalRow = [],
-		$parentFuncTablename = '',
-		$parentRow = [],
-		$callFunctableArray = [],  // deprecated
-		$filterRowArray = []
-	) {
-		$productFuncTablename = 'tt_products';
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getItemMarkerArray (
+        $functablename,
+        $useCache,
+        $item,
+        &$markerArray,
+        $tagArray,
+        &$hiddenText,
+        $theCode = '',
+        $bInputDisabled = false,
+        $id = '1',
+        $bSelect = true,
+        $charset = '',
+        $externalRow = [],
+        $parentFuncTablename = '',
+        $parentRow = [],
+        $callFunctableArray = [],  // deprecated
+        $filterRowArray = []
+    ) {
+        $productFuncTablename = 'tt_products';
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
 
-		$conf = $cnfObj->getConf();
-		$basketVar = tx_ttproducts_model_control::getBasketVar();
-		$viewTableView = $tablesObj->get($productFuncTablename, true);
-		$viewTable = $viewTableView->getModelObj();
-		$fieldArray = $viewTable->variant->getFieldArray();
-		$keyAdditional = $viewTable->variant->getAdditionalKey();
-		$selectableArray = $viewTable->variant->getSelectableArray();
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-		$bUseXHTML = empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
+        $conf = $cnfObj->getConf();
+        $basketVar = tx_ttproducts_model_control::getBasketVar();
+        $viewTableView = $tablesObj->get($productFuncTablename, true);
+        $viewTable = $viewTableView->getModelObj();
+        $fieldArray = $viewTable->variant->getFieldArray();
+        $keyAdditional = $viewTable->variant->getAdditionalKey();
+        $selectableArray = $viewTable->variant->getSelectableArray();
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $bUseXHTML = empty($GLOBALS['TSFE']->config['config']['xhtmlDoctype']);
         $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
 
-		$variantSeparator = $viewTable->getVariant()->getSplitSeparator();
-		$row = $item['rec'];
-		$uid = $row['uid'];
-		$presetVariantArray =
-			tx_ttproducts_control_product::getPresetVariantArray(
-				$viewTable,
-				$row,
-				$cnfObj->getUseArticles()
-			);
+        $variantSeparator = $viewTable->getVariant()->getSplitSeparator();
+        $row = $item['rec'];
+        $uid = $row['uid'];
+        $presetVariantArray =
+            tx_ttproducts_control_product::getPresetVariantArray(
+                $viewTable,
+                $row,
+                $cnfObj->getUseArticles()
+            );
 
-		if (
-			$theCode == 'SINGLE' &&
-			empty($presetVariantArray) &&
-			$bSelect &&
-			$functablename == 'tt_products'
-		) {
-			$articleNo = tx_ttproducts_control_product::getActiveArticleNo();
+        if (
+            $theCode == 'SINGLE' &&
+            empty($presetVariantArray) &&
+            $bSelect &&
+            $functablename == 'tt_products'
+        ) {
+            $articleNo = tx_ttproducts_control_product::getActiveArticleNo();
 
-			if ($articleNo !== false) {
-				$articleObj = $tablesObj->get('tt_products_articles');
-				$articleRow = $articleObj->get($articleNo);
+            if ($articleNo !== false) {
+                $articleObj = $tablesObj->get('tt_products_articles');
+                $articleRow = $articleObj->get($articleNo);
 
-				if (isset($fieldArray) && is_array($fieldArray)) {
+                if (isset($fieldArray) && is_array($fieldArray)) {
 
-					foreach($fieldArray as $k => $field) {
-						$variantValue = $row[$field] ?? '';
-						$prodTmpRow =
-							preg_split(
-								'/[\h]*' . $variantSeparator . '[\h]*/',
-								$variantValue,
-								-1,
-								PREG_SPLIT_NO_EMPTY
-							);
+                    foreach($fieldArray as $k => $field) {
+                        $variantValue = $row[$field] ?? '';
+                        $prodTmpRow =
+                            preg_split(
+                                '/[\h]*' . $variantSeparator . '[\h]*/',
+                                $variantValue,
+                                -1,
+                                PREG_SPLIT_NO_EMPTY
+                            );
 
-						$imageFileArray = '';
+                        $imageFileArray = '';
 
-						if ($variantValue && $prodTmpRow[0]) {
-							$key = array_search(trim($articleRow[$field]), $prodTmpRow, true);
-							if ($key !== false) {
-								$presetVariantArray[$field] = $key;
-							}
-						}
-					}
-				}
-			}
-		}
+                        if ($variantValue && $prodTmpRow[0]) {
+                            $key = array_search(trim($articleRow[$field]), $prodTmpRow, true);
+                            if ($key !== false) {
+                                $presetVariantArray[$field] = $key;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-			// Returns a markerArray ready for substitution with information for the tt_producst record, $row
+            // Returns a markerArray ready for substitution with information for the tt_producst record, $row
 
-		$extArray = '';
-		if (isset($row['ext'])) {
-			$extArray = $row['ext'];
-		}
-		$variant = '';
+        $extArray = '';
+        if (isset($row['ext'])) {
+            $extArray = $row['ext'];
+        }
+        $variant = '';
 
-		if (is_array($extArray)) {
-			if (isset($extArray['extVarLine'])) {
-				$variant = $extArray['extVarLine'];
-			} else if (
+        if (is_array($extArray)) {
+            if (isset($extArray['extVarLine'])) {
+                $variant = $extArray['extVarLine'];
+            } else if (
                 isset($extArray['tt_products']) &&
                 is_array($extArray['tt_products'])
             ) {
-				$variant = $viewTable->variant->getVariantFromRow($row);
-			} else if (isset($extArray['tx_dam'])) {
-				$variant = $extArray['tx_dam'][0]['vars'];
-			}
-		}
-		$hiddenText = '';
-		$quantity = $item['count'];
-		$showAmount = ($theCode == 'BASKET' ? 'basket' : $cnfObj->getBasketConf('view', 'showAmount'));
-		$quantity = $itemObj->getQuantity($item, $showAmount);
-		$radioInputArray = $basketObj->getRadioInputArray($row);
-		$bUseRadioBox =
-			is_array($radioInputArray) &&
-			count($radioInputArray) > 0 &&
-			!empty($radioInputArray['name']);
+                $variant = $viewTable->variant->getVariantFromRow($row);
+            } else if (isset($extArray['tx_dam'])) {
+                $variant = $extArray['tx_dam'][0]['vars'];
+            }
+        }
+        $hiddenText = '';
+        $quantity = $item['count'];
+        $showAmount = ($theCode == 'BASKET' ? 'basket' : $cnfObj->getBasketConf('view', 'showAmount'));
+        $quantity = $itemObj->getQuantity($item, $showAmount);
+        $radioInputArray = $basketObj->getRadioInputArray($row);
+        $bUseRadioBox =
+            is_array($radioInputArray) &&
+            count($radioInputArray) > 0 &&
+            !empty($radioInputArray['name']);
 
-		$jsTableName = str_replace('_', '-', $productFuncTablename);
-		$basketQuantityName =
-			$this->getQuantityName(
-				$row['uid'],
-				$functablename,
-				$externalRow,
-				$parentFuncTablename,
-				$parentRow,
-				$callFunctableArray
-			);
+        $jsTableName = str_replace('_', '-', $productFuncTablename);
+        $basketQuantityName =
+            $this->getQuantityName(
+                $row['uid'],
+                $functablename,
+                $externalRow,
+                $parentFuncTablename,
+                $parentRow,
+                $callFunctableArray
+            );
 
-		$attributeFieldName = ($bUseRadioBox && !empty($radioInputArray['name']) ? $radioInputArray['name'] : $basketQuantityName);
-		$markerArray['###FIELD_NAME###'] = htmlspecialchars($attributeFieldName);
+        $attributeFieldName = ($bUseRadioBox && !empty($radioInputArray['name']) ? $radioInputArray['name'] : $basketQuantityName);
+        $markerArray['###FIELD_NAME###'] = htmlspecialchars($attributeFieldName);
 
-			// check need for comments
-		if (
-			$useCache &&
-			$showAmount == 'basket' &&
-			isset($conf['BASKETQTY']) &&
-			isset($conf['BASKETQTY.']) &&
-			isset($conf['BASKETQTY.']['userFunc'])
-		) {
-			$cObjectType = $conf['BASKETQTY'];
-			$basketConf = [];
-			$basketConf['ref'] = $uid;
-			$basketConf['row'] = $row;
-			$basketConf['variant'] = $variant;
-			$basketConf['userFunc'] = $conf['BASKETQTY.']['userFunc'];
-			$cObjectType = $conf['BASKETQTY'];
+            // check need for comments
+        if (
+            $useCache &&
+            $showAmount == 'basket' &&
+            isset($conf['BASKETQTY']) &&
+            isset($conf['BASKETQTY.']) &&
+            isset($conf['BASKETQTY.']['userFunc'])
+        ) {
+            $cObjectType = $conf['BASKETQTY'];
+            $basketConf = [];
+            $basketConf['ref'] = $uid;
+            $basketConf['row'] = $row;
+            $basketConf['variant'] = $variant;
+            $basketConf['userFunc'] = $conf['BASKETQTY.']['userFunc'];
+            $cObjectType = $conf['BASKETQTY'];
 
-			$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-			$cObj->start([]);
-			$markerArray['###FIELD_QTY###'] = $cObj->cObjGetSingle($cObjectType, $basketConf);
-		} else {
-			if (
-				isset($callFunctableArray) &&
-				is_array($callFunctableArray) &&
-				count($callFunctableArray)
-			) {
-				$quantityMarker = '###';
-				foreach ($callFunctableArray as $marker => $callFunctablename) {
-					$quantityMarker .=
-						tx_ttproducts_control_basketquantity::getQuantityMarker($marker, $uid, '###' . $marker . '_UID###');
-				}
-				$quantityMarker .= '###';
-			} else if (
-				isset($filterRowArray) &&
-				is_array($filterRowArray) &&
-				count($filterRowArray)
-			) {
-				$filterQuantity = 0;
-				foreach ($filterRowArray as $filterRow) {
-					if ($filterRow['product_uid'] == $uid && isset($filterRow['quantity'])) {
-						$filterQuantity += $filterRow['quantity'];
-					}
-				}
-				$quantityMarker = $filterQuantity;
-			} else {
-				$quantityMarker = $quantity ? $quantity : '';
-			}
+            $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+            $cObj->start([]);
+            $markerArray['###FIELD_QTY###'] = $cObj->cObjGetSingle($cObjectType, $basketConf);
+        } else {
+            if (
+                isset($callFunctableArray) &&
+                is_array($callFunctableArray) &&
+                count($callFunctableArray)
+            ) {
+                $quantityMarker = '###';
+                foreach ($callFunctableArray as $marker => $callFunctablename) {
+                    $quantityMarker .=
+                        tx_ttproducts_control_basketquantity::getQuantityMarker($marker, $uid, '###' . $marker . '_UID###');
+                }
+                $quantityMarker .= '###';
+            } else if (
+                isset($filterRowArray) &&
+                is_array($filterRowArray) &&
+                count($filterRowArray)
+            ) {
+                $filterQuantity = 0;
+                foreach ($filterRowArray as $filterRow) {
+                    if ($filterRow['product_uid'] == $uid && isset($filterRow['quantity'])) {
+                        $filterQuantity += $filterRow['quantity'];
+                    }
+                }
+                $quantityMarker = $filterQuantity;
+            } else {
+                $quantityMarker = $quantity ? $quantity : '';
+            }
 
-			$markerArray['###FIELD_QTY###'] = $quantityMarker;
-		}
+            $markerArray['###FIELD_QTY###'] = $quantityMarker;
+        }
 
-		$markerArray['###FIELD_ID###'] = $jsTableName . '-' . strtolower($theCode) . '-id-' . $id;
+        $markerArray['###FIELD_ID###'] = $jsTableName . '-' . strtolower($theCode) . '-id-' . $id;
 
-		$markerArray['###BASKET_ID###'] = $id;
-		$markerArray['###BASKET_INPUT###'] = '';
-		$markerArray['###BASKET_INTO_ID###'] = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $row['uid'];
-		$markerArray['###BASKET_INPUT_ERROR_ID###'] = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $row['uid'];
+        $markerArray['###BASKET_ID###'] = $id;
+        $markerArray['###BASKET_INPUT###'] = '';
+        $markerArray['###BASKET_INTO_ID###'] = tx_ttproducts_model_control::getBasketIntoIdPrefix() . '-' . $row['uid'];
+        $markerArray['###BASKET_INPUT_ERROR_ID###'] = tx_ttproducts_model_control::getBasketInputErrorIdPrefix() . '-' . $row['uid'];
 
-		$markerArray['###DISABLED###'] = ($bInputDisabled ? ($bUseXHTML ? 'disabled="disabled"' : 'disabled') : '');
+        $markerArray['###DISABLED###'] = ($bInputDisabled ? ($bUseXHTML ? 'disabled="disabled"' : 'disabled') : '');
 
-		$markerArray['###IN_STOCK_ID###'] = 'in-stock-id-' . $row['uid'];
+        $markerArray['###IN_STOCK_ID###'] = 'in-stock-id-' . $row['uid'];
 
-		$markerArray['###BASKET_IN_STOCK###'] = $languageObj->getLabel(($row['inStock'] > 0 ? 'in_stock' : 'not_in_stock'));
+        $markerArray['###BASKET_IN_STOCK###'] = $languageObj->getLabel(($row['inStock'] > 0 ? 'in_stock' : 'not_in_stock'));
 
         $fileName = $conf['basketPic'];
         $basketFile = '';
@@ -384,229 +384,229 @@ class tx_ttproducts_basketitem_view implements \TYPO3\CMS\Core\SingletonInterfac
         $basketFile = $sanitizer->sanitize($fileName);
 
         $markerArray['###IMAGE_BASKET_SRC###'] = $basketFile;
-		$fileresource =  FrontendUtility::fileResource($basketFile);
-		$markerArray['###IMAGE_BASKET###'] = $fileresource;
+        $fileresource =  FrontendUtility::fileResource($basketFile);
+        $markerArray['###IMAGE_BASKET###'] = $fileresource;
 
-		if (isset($fieldArray) && is_array($fieldArray)) {
-			$formConf = $cnfObj->getFormConf($theCode);
-			$tablename = $viewTable->getTablename();
+        if (isset($fieldArray) && is_array($fieldArray)) {
+            $formConf = $cnfObj->getFormConf($theCode);
+            $tablename = $viewTable->getTablename();
 
-			foreach($fieldArray as $k => $field) {
+            foreach($fieldArray as $k => $field) {
                 if (!isset($selectableArray[$k])) { // additional
                     continue;
                 }
-				$fieldConf = $GLOBALS['TCA'][$tablename]['columns'][$field];
-				$fieldMarker = strtoupper($field);
+                $fieldConf = $GLOBALS['TCA'][$tablename]['columns'][$field];
+                $fieldMarker = strtoupper($field);
 
-				if (isset($fieldConf) && is_array($fieldConf)) {
-					$text = '';
-					$variantValue = $row[$field] ?? '';
-					$prodTmpRow = preg_split('/[\h]*' . $variantSeparator . '[\h]*/', $variantValue, -1, PREG_SPLIT_NO_EMPTY);
+                if (isset($fieldConf) && is_array($fieldConf)) {
+                    $text = '';
+                    $variantValue = $row[$field] ?? '';
+                    $prodTmpRow = preg_split('/[\h]*' . $variantSeparator . '[\h]*/', $variantValue, -1, PREG_SPLIT_NO_EMPTY);
 
-					$imageFileArray = '';
+                    $imageFileArray = '';
 
-					if ($bSelect && $variantValue && $prodTmpRow[0]) {
-						$selectConfKey = $viewTable->variant->getSelectConfKey($field);
+                    if ($bSelect && $variantValue && $prodTmpRow[0]) {
+                        $selectConfKey = $viewTable->variant->getSelectConfKey($field);
 
-						if (
-							is_array($formConf) &&
-							isset($formConf[$selectConfKey . '.'])
-						) {
-							$theFormConf = $formConf[$selectConfKey . '.'];
+                        if (
+                            is_array($formConf) &&
+                            isset($formConf[$selectConfKey . '.'])
+                        ) {
+                            $theFormConf = $formConf[$selectConfKey . '.'];
 
-							if (
-								isset($theFormConf['image.']) &&
-								is_array($theFormConf['image.']) &&
-								isset($theFormConf['imageImport.']) &&
-								is_array($theFormConf['imageImport.']) &&
-								isset($theFormConf['layout'])
-							) {
-								$imageConf = $theFormConf['image.'];
-								$imageFileArray = [];
-								foreach ($prodTmpRow as $k2 => $variantVal) {
-									$tmpImgCode = '';
-									foreach ($theFormConf['imageImport.'] as $k3 => $imageImport) {
+                            if (
+                                isset($theFormConf['image.']) &&
+                                is_array($theFormConf['image.']) &&
+                                isset($theFormConf['imageImport.']) &&
+                                is_array($theFormConf['imageImport.']) &&
+                                isset($theFormConf['layout'])
+                            ) {
+                                $imageConf = $theFormConf['image.'];
+                                $imageFileArray = [];
+                                foreach ($prodTmpRow as $k2 => $variantVal) {
+                                    $tmpImgCode = '';
+                                    foreach ($theFormConf['imageImport.'] as $k3 => $imageImport) {
 
-										if (is_array($imageImport['prod.'])) {
-											if (isset($imageImport['sql.'])) {
-												$bIsValid =
-													tx_ttproducts_sql::isValid(
-														$row,
-														$imageImport['sql.']['where']
-													);
-												if (!$bIsValid) {
-													continue;
-												}
-											}
-											$imageFile = $imageImport['prod.'][$k2];
-											$imagePath = $imageImport['path'];
+                                        if (is_array($imageImport['prod.'])) {
+                                            if (isset($imageImport['sql.'])) {
+                                                $bIsValid =
+                                                    tx_ttproducts_sql::isValid(
+                                                        $row,
+                                                        $imageImport['sql.']['where']
+                                                    );
+                                                if (!$bIsValid) {
+                                                    continue;
+                                                }
+                                            }
+                                            $imageFile = $imageImport['prod.'][$k2];
+                                            $imagePath = $imageImport['path'];
 
-											if ($imageFile != '') {
-												$imageConf['file'] = $imagePath . $imageFile;
+                                            if ($imageFile != '') {
+                                                $imageConf['file'] = $imagePath . $imageFile;
                                                 $tmpImgCode =
                                                     $imageObj->getImageCode(
                                                         $imageConf,
                                                         $theCode
                                                     );
-											}
-										}
-									}
-									$imageFileArray[] = $tmpImgCode;
-								}
-							}
-						} else {
-							$theFormConf = '';
-						}
-						$prodTranslatedRow = $prodTmpRow;
-						$type = '';
-						$selectedKey = '0';
-						switch($selectableArray[$k]) {
-							case 1:
-								$type = 'select';
-								break;
-							case 2:
-								$type = 'radio';
-								break;
-							case 3:
-								$type = 'checkbox';
-								$selectedKey = '';
-								if ($quantity > 0) {
-									$selectedKey = $variant;
-								}
-								break;
-						}
+                                            }
+                                        }
+                                    }
+                                    $imageFileArray[] = $tmpImgCode;
+                                }
+                            }
+                        } else {
+                            $theFormConf = '';
+                        }
+                        $prodTranslatedRow = $prodTmpRow;
+                        $type = '';
+                        $selectedKey = '0';
+                        switch($selectableArray[$k]) {
+                            case 1:
+                                $type = 'select';
+                                break;
+                            case 2:
+                                $type = 'radio';
+                                break;
+                            case 3:
+                                $type = 'checkbox';
+                                $selectedKey = '';
+                                if ($quantity > 0) {
+                                    $selectedKey = $variant;
+                                }
+                                break;
+                        }
 
-						if (isset($presetVariantArray[$field])) {
-							$selectedKey = $presetVariantArray[$field];
-						}
-						$viewTable->getTableObj()->substituteMarkerArray($prodTranslatedRow);
-						$dataArray = [];
-						$layout = '';
-						$header = '';
+                        if (isset($presetVariantArray[$field])) {
+                            $selectedKey = $presetVariantArray[$field];
+                        }
+                        $viewTable->getTableObj()->substituteMarkerArray($prodTranslatedRow);
+                        $dataArray = [];
+                        $layout = '';
+                        $header = '';
 
-						if (isset($theFormConf) && is_array($theFormConf)) {
-							if (isset($theFormConf['header.'])) {
-								$header = $theFormConf['header.']['label'];
-							}
-							if (isset($theFormConf['layout'])) {
-								$layout = $theFormConf['layout'];
-							}
-							if (isset($theFormConf['dataArray.'])) {
-								$dataArray = $theFormConf['dataArray.'];
-							}
-						}
+                        if (isset($theFormConf) && is_array($theFormConf)) {
+                            if (isset($theFormConf['header.'])) {
+                                $header = $theFormConf['header.']['label'];
+                            }
+                            if (isset($theFormConf['layout'])) {
+                                $layout = $theFormConf['layout'];
+                            }
+                            if (isset($theFormConf['dataArray.'])) {
+                                $dataArray = $theFormConf['dataArray.'];
+                            }
+                        }
 
-						if ($type != '') {
-							$text = tx_ttproducts_form_div::createSelect(
-								$languageObj,
-								$prodTranslatedRow,
-					 			tx_ttproducts_control_basket::getTagName($row['uid'], $field),
-								$selectedKey,
-								false,
-								false,
-								[],
-								$type,
-								$dataArray,
-								$header,
-								$layout,
-								$imageFileArray
-							);
-						} else {
-							$text = $variantValue;
-						}
-					} else {
-						$prodTmpRow = $row;
-						$viewTable->variant->modifyRowFromVariant($prodTmpRow, $variant);
-						$text = $prodTmpRow[$field] ?? ''; // $prodTmpRow[0];
-					}
+                        if ($type != '') {
+                            $text = tx_ttproducts_form_div::createSelect(
+                                $languageObj,
+                                $prodTranslatedRow,
+                                tx_ttproducts_control_basket::getTagName($row['uid'], $field),
+                                $selectedKey,
+                                false,
+                                false,
+                                [],
+                                $type,
+                                $dataArray,
+                                $header,
+                                $layout,
+                                $imageFileArray
+                            );
+                        } else {
+                            $text = $variantValue;
+                        }
+                    } else {
+                        $prodTmpRow = $row;
+                        $viewTable->variant->modifyRowFromVariant($prodTmpRow, $variant);
+                        $text = $prodTmpRow[$field] ?? ''; // $prodTmpRow[0];
+                    }
 
-					$markerArray['###FIELD_' . $fieldMarker . '_NAME###'] = $basketVar . '[' . $row['uid'] . '][' . $field . ']';
-					$markerArray['###FIELD_' . $fieldMarker . '_VALUE###'] = $row[$field] ?? '';
-					$markerArray['###FIELD_' . $fieldMarker . '_ONCHANGE'] = ''; // TODO:  use $forminfoArray['###FORM_NAME###' in something like onChange="Go(this.form.Auswahl.options[this.form.Auswahl.options.selectedIndex].value)"
+                    $markerArray['###FIELD_' . $fieldMarker . '_NAME###'] = $basketVar . '[' . $row['uid'] . '][' . $field . ']';
+                    $markerArray['###FIELD_' . $fieldMarker . '_VALUE###'] = $row[$field] ?? '';
+                    $markerArray['###FIELD_' . $fieldMarker . '_ONCHANGE'] = ''; // TODO:  use $forminfoArray['###FORM_NAME###' in something like onChange="Go(this.form.Auswahl.options[this.form.Auswahl.options.selectedIndex].value)"
 
-					$markerKey = '###' . $viewTableView->getMarker() . '_' . $fieldMarker . '###';
-					$markerArray[$markerKey] = $text;
-					$markerKey = '###' . $viewTableView->getMarker() . '_' . $fieldMarker . '_FUNCTION1###';
+                    $markerKey = '###' . $viewTableView->getMarker() . '_' . $fieldMarker . '###';
+                    $markerArray[$markerKey] = $text;
+                    $markerKey = '###' . $viewTableView->getMarker() . '_' . $fieldMarker . '_FUNCTION1###';
 
-					$markerArray[$markerKey] = tx_ttproducts_control_basket::getAjaxVariantFunction($row, $productFuncTablename, $theCode);
-				}
-			}
-		}
+                    $markerArray[$markerKey] = tx_ttproducts_control_basket::getAjaxVariantFunction($row, $productFuncTablename, $theCode);
+                }
+            }
+        }
 
-		$prodAdditionalText['single'] = '';
+        $prodAdditionalText['single'] = '';
 
-		if ($bUseRadioBox) {
+        if ($bUseRadioBox) {
 
-			$params = 'type="' . $radioInputArray['type'] . '"';
-			$params .= (!empty($radioInputArray['params']) ? ' ' . $radioInputArray['params'] : '');
-			if ($radioInputArray['checked'] == $uid) {
-				$params .= ' ' . ($bUseXHTML ? 'checked="checked"' : 'checked');
-			}
-			$markerArray['###BASKET_INPUT###'] = tx_ttproducts_form_div::createTag('input', $radioInputArray['name'], $uid, $params);
-		}
+            $params = 'type="' . $radioInputArray['type'] . '"';
+            $params .= (!empty($radioInputArray['params']) ? ' ' . $radioInputArray['params'] : '');
+            if ($radioInputArray['checked'] == $uid) {
+                $params .= ' ' . ($bUseXHTML ? 'checked="checked"' : 'checked');
+            }
+            $markerArray['###BASKET_INPUT###'] = tx_ttproducts_form_div::createTag('input', $radioInputArray['name'], $uid, $params);
+        }
 
-		if ($keyAdditional !== false) {
-			$isSingleProduct = $viewTable->hasAdditional($row, 'isSingle');
-			if ($isSingleProduct) {
-				$message = $languageObj->getLabel('additional_single');
-				$prodAdditionalText['single'] = $message . '<input type="checkbox" name="' . $basketQuantityName . '" ' . ($quantity ? 'checked="checked"' : '') . 'onchange = "this.form[this.name+\'[1]\'].value=(this.checked ? 1 : 0);"' . ' value="1">';
-				$hiddenText .= '<input type="hidden" name="' . $basketQuantityName . '[1]" value="' . ($quantity ? '1' : '0') . '">';
-			}
+        if ($keyAdditional !== false) {
+            $isSingleProduct = $viewTable->hasAdditional($row, 'isSingle');
+            if ($isSingleProduct) {
+                $message = $languageObj->getLabel('additional_single');
+                $prodAdditionalText['single'] = $message . '<input type="checkbox" name="' . $basketQuantityName . '" ' . ($quantity ? 'checked="checked"' : '') . 'onchange = "this.form[this.name+\'[1]\'].value=(this.checked ? 1 : 0);"' . ' value="1">';
+                $hiddenText .= '<input type="hidden" name="' . $basketQuantityName . '[1]" value="' . ($quantity ? '1' : '0') . '">';
+            }
 
-			$isImageProduct = $viewTable->hasAdditional($row, 'isImage');
-			$damParam = tx_ttproducts_model_control::getPiVarValue('tx_dam');
+            $isImageProduct = $viewTable->hasAdditional($row, 'isImage');
+            $damParam = tx_ttproducts_model_control::getPiVarValue('tx_dam');
 
-			if (
-				$functablename == 'tt_products' &&
-				is_array($extArray) &&
-				isset($extArray['tx_dam'])
-			) {
-				reset($extArray['tx_dam']);
-				$damext = current($extArray['tx_dam']);
-				$damUid = $damext['uid'];
-			} else if (
-				$isImageProduct &&
-				isset($damParam)
-			) {
-				$damUid = tx_ttproducts_model_control::getPiVarValue('tx_dam');
-			}
+            if (
+                $functablename == 'tt_products' &&
+                is_array($extArray) &&
+                isset($extArray['tx_dam'])
+            ) {
+                reset($extArray['tx_dam']);
+                $damext = current($extArray['tx_dam']);
+                $damUid = $damext['uid'];
+            } else if (
+                $isImageProduct &&
+                isset($damParam)
+            ) {
+                $damUid = tx_ttproducts_model_control::getPiVarValue('tx_dam');
+            }
 
-			if (isset($damUid)) {
-				$tableVariant = $viewTable->variant->getTableUid('tx_dam', $damUid);
-				$variant .= $tableVariant;
-				$markerArray['###DAM_UID###'] = $damUid;
-			}
-			$giftService = !$viewTable->hasAdditional($row, 'noGiftService');
- 		}
+            if (isset($damUid)) {
+                $tableVariant = $viewTable->variant->getTableUid('tx_dam', $damUid);
+                $variant .= $tableVariant;
+                $markerArray['###DAM_UID###'] = $damUid;
+            }
+            $giftService = !$viewTable->hasAdditional($row, 'noGiftService');
+        }
 
-		if ($giftService) {
-			$basketAdditionalName = $basketVar . '[' . $row['uid'] . '][additional][' . md5($variant) . ']';
-			$bGiftService = false;
-			if (
-				isset($basketExt[$row['uid']]) &&
-				isset($basketExt[$row['uid']][$variant . '.']) &&
-				isset($basketExt[$row['uid']][$variant . '.']['additional']) &&
-				is_array($basketExt[$row['uid']][$variant . '.']['additional'])
-			) {
-				$bGiftService = $basketExt[$row['uid']][$variant . '.']['additional']['giftservice'];
-			}
-			$giftServicePostfix = '[giftservice]';
-			$message = $languageObj->getLabel('additional_gift_service');
-			$value = ($bGiftService ? '1' : '0');
-			$prodAdditionalText['giftService'] = $message . '<input type="checkbox" name="' . $basketAdditionalName . $giftServicePostfix . '" ' . ($value ? 'checked="checked"' : '') . 'onchange = "this.form[this.name+\'[1]\'].value=(this.checked ? 1 : 0);"' . ' value="' . $value . '">';
-			$hiddenText .= '<input type="hidden" name="' . $basketAdditionalName . $giftServicePostfix . '[1]" value="' . $value . '">';
-		} else {
-			$prodAdditionalText['giftService'] = '';
-		}
+        if ($giftService) {
+            $basketAdditionalName = $basketVar . '[' . $row['uid'] . '][additional][' . md5($variant) . ']';
+            $bGiftService = false;
+            if (
+                isset($basketExt[$row['uid']]) &&
+                isset($basketExt[$row['uid']][$variant . '.']) &&
+                isset($basketExt[$row['uid']][$variant . '.']['additional']) &&
+                is_array($basketExt[$row['uid']][$variant . '.']['additional'])
+            ) {
+                $bGiftService = $basketExt[$row['uid']][$variant . '.']['additional']['giftservice'];
+            }
+            $giftServicePostfix = '[giftservice]';
+            $message = $languageObj->getLabel('additional_gift_service');
+            $value = ($bGiftService ? '1' : '0');
+            $prodAdditionalText['giftService'] = $message . '<input type="checkbox" name="' . $basketAdditionalName . $giftServicePostfix . '" ' . ($value ? 'checked="checked"' : '') . 'onchange = "this.form[this.name+\'[1]\'].value=(this.checked ? 1 : 0);"' . ' value="' . $value . '">';
+            $hiddenText .= '<input type="hidden" name="' . $basketAdditionalName . $giftServicePostfix . '[1]" value="' . $value . '">';
+        } else {
+            $prodAdditionalText['giftService'] = '';
+        }
 
-		$markerArray['###FIELD_NAME_BASKET###'] = $basketVar . '[' . $row['uid'] . '][' . md5($variant) . ']';
-		$markerArray['###PRODUCT_ADDITIONAL_SINGLE###'] = $prodAdditionalText['single'];
-		$markerArray['###PRODUCT_ADDITIONAL_GIFT_SERVICE###'] = $prodAdditionalText['giftService'];
-		$markerArray['###PRODUCT_ADDITIONAL_GIFT_SERVICE_DISPLAY###'] = ($value ? '1' : '');
-		if (isset($tagArray['PRODUCT_HIDDEN_TEXT'])) {
-			$markerArray['###PRODUCT_HIDDEN_TEXT###'] = $hiddenText;
-			$hiddenText = '';
-		}
-	} // getItemMarkerArray
+        $markerArray['###FIELD_NAME_BASKET###'] = $basketVar . '[' . $row['uid'] . '][' . md5($variant) . ']';
+        $markerArray['###PRODUCT_ADDITIONAL_SINGLE###'] = $prodAdditionalText['single'];
+        $markerArray['###PRODUCT_ADDITIONAL_GIFT_SERVICE###'] = $prodAdditionalText['giftService'];
+        $markerArray['###PRODUCT_ADDITIONAL_GIFT_SERVICE_DISPLAY###'] = ($value ? '1' : '');
+        if (isset($tagArray['PRODUCT_HIDDEN_TEXT'])) {
+            $markerArray['###PRODUCT_HIDDEN_TEXT###'] = $hiddenText;
+            $hiddenText = '';
+        }
+    } // getItemMarkerArray
 }
 

--- a/view/class.tx_ttproducts_card_view.php
+++ b/view/class.tx_ttproducts_card_view.php
@@ -43,124 +43,124 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_card_view extends tx_ttproducts_table_base_view {
-	public $marker = 'CARD';
+    public $marker = 'CARD';
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getMarkerArray ($row, &$markerArray, array $allowedArray, $tablename = 'sys_products_cards') {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getMarkerArray ($row, &$markerArray, array $allowedArray, $tablename = 'sys_products_cards') {
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
         $cObj = FrontendUtility::getContentObjectRenderer();
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$ccNumberArray = [];
-		$ccTypeTextSelected = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $ccNumberArray = [];
+        $ccTypeTextSelected = '';
 
-		if (count($allowedArray)) {
-			$ccTypeText =
-				tx_ttproducts_form_div::createSelect(
-					$languageObj,
-					$GLOBALS['TCA'][$tablename]['columns']['cc_type']['config']['items'],
-					'recs[creditcard][cc_type]',
-					$row['cc_type'] ?? '',
-					true,
-					true,
-					$allowedArray
-				);
-		} else {
-			$ccTypeText = '';
-		}
+        if (count($allowedArray)) {
+            $ccTypeText =
+                tx_ttproducts_form_div::createSelect(
+                    $languageObj,
+                    $GLOBALS['TCA'][$tablename]['columns']['cc_type']['config']['items'],
+                    'recs[creditcard][cc_type]',
+                    $row['cc_type'] ?? '',
+                    true,
+                    true,
+                    $allowedArray
+                );
+        } else {
+            $ccTypeText = '';
+        }
 
-		if (is_array($row)) {
-			for ($i = 1; $i <= 4; ++$i) {
-				$value = '';
-				if (isset($row['cc_number_' . $i])) {
-					$value = $row['cc_number_' . $i];
-				} else if (isset($row['cc_number'])) {
-					$value = substr($row['cc_number'], ($i - 1) * 4, 4);
-				}
-				$ccNumberArray[$i - 1] = $value;
-			}
-		}
-		$ccOwnerName = $row['owner_name'] ?? '';
+        if (is_array($row)) {
+            for ($i = 1; $i <= 4; ++$i) {
+                $value = '';
+                if (isset($row['cc_number_' . $i])) {
+                    $value = $row['cc_number_' . $i];
+                } else if (isset($row['cc_number'])) {
+                    $value = substr($row['cc_number'], ($i - 1) * 4, 4);
+                }
+                $ccNumberArray[$i - 1] = $value;
+            }
+        }
+        $ccOwnerName = $row['owner_name'] ?? '';
 
-		$markerArray['###PERSON_CARDS_OWNER_NAME###'] = htmlentities($ccOwnerName, ENT_QUOTES, 'UTF-8');
-		$markerArray['###PERSON_CARDS_CC_TYPE###'] = $ccTypeText;
-		$markerArray['###PERSON_CARDS_CC_TYPE_SELECTED###'] = $row['cc_type'] ?? '';
-		if (isset($row['cc_type'])) { //
-			$tmp = $GLOBALS['TCA'][$tablename]['columns']['cc_type']['config']['items'][$row['cc_type']]['0'];
-			$tmp = $languageObj->splitLabel($tmp);
-			$ccTypeTextSelected = $languageObj->getLabel($tmp);
-		}
-		$markerArray['###PERSON_CARDS_CC_TYPE_SELECTED###'] = $ccTypeTextSelected;
-		for ($i = 1; $i <= 4; ++$i)	{
-			$markerArray['###PERSON_CARDS_CC_NUMBER_'.$i.'###'] = $ccNumberArray[$i - 1];
-		}
-		$markerArray['###PERSON_CARDS_CC_NUMBER###'] = $row['cc_number'] ?? '';
-		$markerArray['###PERSON_CARDS_CVV2###'] = $row['cvv2'] ?? '';
+        $markerArray['###PERSON_CARDS_OWNER_NAME###'] = htmlentities($ccOwnerName, ENT_QUOTES, 'UTF-8');
+        $markerArray['###PERSON_CARDS_CC_TYPE###'] = $ccTypeText;
+        $markerArray['###PERSON_CARDS_CC_TYPE_SELECTED###'] = $row['cc_type'] ?? '';
+        if (isset($row['cc_type'])) { //
+            $tmp = $GLOBALS['TCA'][$tablename]['columns']['cc_type']['config']['items'][$row['cc_type']]['0'];
+            $tmp = $languageObj->splitLabel($tmp);
+            $ccTypeTextSelected = $languageObj->getLabel($tmp);
+        }
+        $markerArray['###PERSON_CARDS_CC_TYPE_SELECTED###'] = $ccTypeTextSelected;
+        for ($i = 1; $i <= 4; ++$i)	{
+            $markerArray['###PERSON_CARDS_CC_NUMBER_'.$i.'###'] = $ccNumberArray[$i - 1];
+        }
+        $markerArray['###PERSON_CARDS_CC_NUMBER###'] = $row['cc_number'] ?? '';
+        $markerArray['###PERSON_CARDS_CVV2###'] = $row['cvv2'] ?? '';
 
-		$month = '';
-		$year = '';
+        $month = '';
+        $year = '';
 
-		if (isset($row['endtime'])) {
-			$dateArray = explode('-', strftime('%d-%m-%Y', $row['endtime']));
-			if (isset($row['endtime_mm'])) {
-				$month = $row['endtime_mm'];
-			} else {
-				$month = $dateArray['1'];
-			}
+        if (isset($row['endtime'])) {
+            $dateArray = explode('-', strftime('%d-%m-%Y', $row['endtime']));
+            if (isset($row['endtime_mm'])) {
+                $month = $row['endtime_mm'];
+            } else {
+                $month = $dateArray['1'];
+            }
 
-			if (isset($row['endtime_yy'])) {
-				$year = $row['endtime_yy'];
-			} else {
-				$year = substr($dateArray['2'], 2, 2);
-			}
-		}
+            if (isset($row['endtime_yy'])) {
+                $year = $row['endtime_yy'];
+            } else {
+                $year = substr($dateArray['2'], 2, 2);
+            }
+        }
 
 
-		$markerArray['###PERSON_CARDS_ENDTIME_MM###'] = $month;
-		$markerArray['###PERSON_CARDS_ENDTIME_YY###'] = $year;
-		$markerArray['###PERSON_CARDS_ENDTIME_YY_SELECT###'] = '';
-		$markerArray['###PERSON_CARDS_ENDTIME_MM_SELECT###'] = '';
-		$markerArray['###PERSON_CARDS_ENDTIME###'] = isset($row['endtime']) ? $cObj->stdWrap($row['endtime'], $conf['cardEndDate_stdWrap.']) : '';
+        $markerArray['###PERSON_CARDS_ENDTIME_MM###'] = $month;
+        $markerArray['###PERSON_CARDS_ENDTIME_YY###'] = $year;
+        $markerArray['###PERSON_CARDS_ENDTIME_YY_SELECT###'] = '';
+        $markerArray['###PERSON_CARDS_ENDTIME_MM_SELECT###'] = '';
+        $markerArray['###PERSON_CARDS_ENDTIME###'] = isset($row['endtime']) ? $cObj->stdWrap($row['endtime'], $conf['cardEndDate_stdWrap.']) : '';
 
-		if (isset($conf['payment.']['creditcardSelect.'])) {
-			$mmArray = $conf['payment.']['creditcardSelect.']['mm.'];
-			if (is_array($mmArray)) {
-				$valueArray = tx_ttproducts_form_div::fetchValueArray($mmArray['valueArray.']);
-				$markerArray['###PERSON_CARDS_ENDTIME_MM_SELECT###'] =
-					tx_ttproducts_form_div::createSelect(
-						$languageObj,
-						$valueArray,
-						'recs[creditcard][endtime_mm]',
-						$month,
-						true,
-						true
-					);
-			}
-			$yyArray = $conf['payment.']['creditcardSelect.']['yy.'];
-			if (is_array($yyArray)) {
-				$valueArray = tx_ttproducts_form_div::fetchValueArray($yyArray['valueArray.']);
-				$markerArray['###PERSON_CARDS_ENDTIME_YY_SELECT###'] =
-					tx_ttproducts_form_div::createSelect (
-						$languageObj,
-						$valueArray,
-						'recs[creditcard][endtime_yy]',
-						$year,
-						true,
-						true
-					);
-			}
-		}
-	} // getMarkerArray
+        if (isset($conf['payment.']['creditcardSelect.'])) {
+            $mmArray = $conf['payment.']['creditcardSelect.']['mm.'];
+            if (is_array($mmArray)) {
+                $valueArray = tx_ttproducts_form_div::fetchValueArray($mmArray['valueArray.']);
+                $markerArray['###PERSON_CARDS_ENDTIME_MM_SELECT###'] =
+                    tx_ttproducts_form_div::createSelect(
+                        $languageObj,
+                        $valueArray,
+                        'recs[creditcard][endtime_mm]',
+                        $month,
+                        true,
+                        true
+                    );
+            }
+            $yyArray = $conf['payment.']['creditcardSelect.']['yy.'];
+            if (is_array($yyArray)) {
+                $valueArray = tx_ttproducts_form_div::fetchValueArray($yyArray['valueArray.']);
+                $markerArray['###PERSON_CARDS_ENDTIME_YY_SELECT###'] =
+                    tx_ttproducts_form_div::createSelect (
+                        $languageObj,
+                        $valueArray,
+                        'recs[creditcard][endtime_yy]',
+                        $year,
+                        true,
+                        true
+                    );
+            }
+        }
+    } // getMarkerArray
 }
 

--- a/view/class.tx_ttproducts_cat_view.php
+++ b/view/class.tx_ttproducts_cat_view.php
@@ -43,375 +43,375 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_cat_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pibase; // reference to object of pibase
-	public $conf;
-	public $config;
+    public $pibase; // reference to object of pibase
+    public $conf;
+    public $config;
 
-	public $urlObj; // url functions
-	public $pid; // PID where to go
-	public $pidListObj;
-	public $cOjb;
+    public $urlObj; // url functions
+    public $pid; // PID where to go
+    public $pidListObj;
+    public $cOjb;
 
-	public function init(
-		&$pibase,
-		$pid,
-		$pid_list,
-		$recursive
-	) {
-		$this->pibase = $pibase;
-		$this->cObj = $pibase->cObj;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
+    public function init(
+        &$pibase,
+        $pid,
+        $pid_list,
+        $recursive
+    ) {
+        $this->pibase = $pibase;
+        $this->cObj = $pibase->cObj;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
 
-		$this->pid = $pid;
-		$this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $this->pid = $pid;
+        $this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
 
-		$this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$this->pidListObj->applyRecursive($recursive, $pid_list, true);
-		$this->pidListObj->setPageArray();
-	}
+        $this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $this->pidListObj->applyRecursive($recursive, $pid_list, true);
+        $this->pidListObj->setPageArray();
+    }
 
 
-	// returns the single view
-	public function printView (
-		$templateCode,
-		$functablename,
-		$uid,
-		$theCode,
-		&$error_code,
-		$templateSuffix = ''
-	) {
+    // returns the single view
+    public function printView (
+        $templateCode,
+        $functablename,
+        $uid,
+        $theCode,
+        &$error_code,
+        $templateSuffix = ''
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$tableViewObj = $tablesObj->get($functablename, true);
-		$tableObj = $tableViewObj->getModelObj();
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$variantFieldArray = [];
-		$piVars = tx_ttproducts_model_control::getPiVars();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $tableViewObj = $tablesObj->get($functablename, true);
+        $tableObj = $tableViewObj->getModelObj();
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $variantFieldArray = [];
+        $piVars = tx_ttproducts_model_control::getPiVars();
 
-		if ($this->config['displayCurrentRecord']) {
-			$row = $this->cObj->data;
-		} else if ($uid) {
-			$pidField = ($functablename == 'pages' ? 'uid' : 'pid');
-			$where = $pidField . ' IN (' . $this->pidListObj->getPidlist() . ')';
-			$row = $tableObj->get($uid, 0, true, $where);
-			$row = $tableObj->get($uid, 0, true, $where);
-			$tableConf = $cnf->getTableConf($functablename, $theCode);
-			$tableObj->clear();
-			$tableObj->initCodeConf($theCode,$tableConf);
-			$tableLangFields = $cnf->getTranslationFields($tableConf);
-		}
+        if ($this->config['displayCurrentRecord']) {
+            $row = $this->cObj->data;
+        } else if ($uid) {
+            $pidField = ($functablename == 'pages' ? 'uid' : 'pid');
+            $where = $pidField . ' IN (' . $this->pidListObj->getPidlist() . ')';
+            $row = $tableObj->get($uid, 0, true, $where);
+            $row = $tableObj->get($uid, 0, true, $where);
+            $tableConf = $cnf->getTableConf($functablename, $theCode);
+            $tableObj->clear();
+            $tableObj->initCodeConf($theCode,$tableConf);
+            $tableLangFields = $cnf->getTranslationFields($tableConf);
+        }
 
-		foreach ($tableLangFields as $type => $fieldArray) {
-			if (is_array($fieldArray)) {
-				foreach ($fieldArray as $field => $langfield) {
-					$row[$field] = $row[$langfield];
-				}
-			}
-		}
+        foreach ($tableLangFields as $type => $fieldArray) {
+            if (is_array($fieldArray)) {
+                foreach ($fieldArray as $field => $langfield) {
+                    $row[$field] = $row[$langfield];
+                }
+            }
+        }
 
-		if ($row) {
-			// $this->uid = intval ($row['uid']); // store the uid for later usage here
+        if ($row) {
+            // $this->uid = intval ($row['uid']); // store the uid for later usage here
 
-			$markerArray = [];
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
-			$pageObj = $tablesObj->get('pages');
+            $markerArray = [];
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
+            $pageObj = $tablesObj->get('pages');
 
-			if ($this->config['displayCurrentRecord']) {
-				$subPartMarker = '###' . $tableViewObj->getMarker() . '_SINGLE_DISPLAY_RECORDINSERT###';
-			} else {
-				$subPartMarker = '###' . $tableViewObj->getMarker() . '_SINGLE_DISPLAY###';
-			}
+            if ($this->config['displayCurrentRecord']) {
+                $subPartMarker = '###' . $tableViewObj->getMarker() . '_SINGLE_DISPLAY_RECORDINSERT###';
+            } else {
+                $subPartMarker = '###' . $tableViewObj->getMarker() . '_SINGLE_DISPLAY###';
+            }
 
-			// Add the template suffix
-			$subPartMarker = substr($subPartMarker, 0, -3) . $templateSuffix . '###';
-			$itemFrameWork = $templateService->getSubpart($templateCode, $subpartmarkerObj->spMarker($subPartMarker));
-			if (!$itemFrameWork) {
-				$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-				$error_code[0] = 'no_subtemplate';
-				$error_code[1] = '###' . $subPartMarker . '###';
-				$error_code[2] = $templateObj->getTemplateFile();
-				return '';
-			}
+            // Add the template suffix
+            $subPartMarker = substr($subPartMarker, 0, -3) . $templateSuffix . '###';
+            $itemFrameWork = $templateService->getSubpart($templateCode, $subpartmarkerObj->spMarker($subPartMarker));
+            if (!$itemFrameWork) {
+                $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+                $error_code[0] = 'no_subtemplate';
+                $error_code[1] = '###' . $subPartMarker . '###';
+                $error_code[2] = $templateObj->getTemplateFile();
+                return '';
+            }
 
-			$viewTagArray = $markerObj->getAllMarkers($itemFrameWork);
-			$tablesObj->get('fe_users', true)->getWrappedSubpartArray(
-				$viewTagArray,
-				$useBackPid,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            $viewTagArray = $markerObj->getAllMarkers($itemFrameWork);
+            $tablesObj->get('fe_users', true)->getWrappedSubpartArray(
+                $viewTagArray,
+                $useBackPid,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-			$itemFrameWork = $templateService->substituteMarkerArrayCached($itemFrameWork, $markerArray, $subpartArray, $wrappedSubpartArray);
-			$markerFieldArray = [];
-			$viewTagArray = [];
-			$parentArray = [];
-			$fieldsArray = $markerObj->getMarkerFields(
-				$itemFrameWork,
-				$tableObj->getTableObj()->tableFieldArray,
-				$tableObj->getTableObj()->requiredFieldArray,
-				$markerFieldArray,
-				$tableViewObj->getMarker(),
-				$viewTagArray,
-				$parentArray
-			);
+            $itemFrameWork = $templateService->substituteMarkerArrayCached($itemFrameWork, $markerArray, $subpartArray, $wrappedSubpartArray);
+            $markerFieldArray = [];
+            $viewTagArray = [];
+            $parentArray = [];
+            $fieldsArray = $markerObj->getMarkerFields(
+                $itemFrameWork,
+                $tableObj->getTableObj()->tableFieldArray,
+                $tableObj->getTableObj()->requiredFieldArray,
+                $markerFieldArray,
+                $tableViewObj->getMarker(),
+                $viewTagArray,
+                $parentArray
+            );
 
-				// Fill marker arrays
-			$backPID = $piVars['backPID'] ?? '';
-			$backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
-			$basketPID = $this->conf['PIDbasket'];
-			$pid = $backPID;
+                // Fill marker arrays
+            $backPID = $piVars['backPID'] ?? '';
+            $backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
+            $basketPID = $this->conf['PIDbasket'];
+            $pid = $backPID;
 
-			$useBackPid = true;
+            $useBackPid = true;
 
-			$addQueryString = [];
-			$linkPid = $pid;
-			if ($useBackPid && $backPID) {
-				$linkPid = $backPID;
-			}
+            $addQueryString = [];
+            $linkPid = $pid;
+            if ($useBackPid && $backPID) {
+                $linkPid = $backPID;
+            }
 
-			if (isset($viewTagArray['LINK_ITEM'])) {
-				$queryString =
-					$this->urlObj->getLinkParams(
-						'',
-						$addQueryString,
-						true,
-						$useBackPid,
-						0,
-						'product',
-						$tableViewObj->piVar
-					);
-				$linkUrl = FrontendUtility::getTypoLink_URL(
-					$this->cObj,
-					$linkPid,
-					$queryString,
-					'',
-					[]
-				);
-				$wrappedSubpartArray['###LINK_ITEM###'] = [
-					'<a class="listlink" href="' . htmlspecialchars($linkUrl) . '">',
-					'</a>'
-				];
-			}
-			if (isset($viewCatTagArray['LINK_CATEGORY'])) {
-				$catListPid = $pageObj->getPID(
-					$this->conf['PIDlistDisplay'] ?? '',
-					$this->conf['PIDlistDisplay.'] ?? '',
-					$row
-				);
-				$tableViewObj->getSubpartArrays(
-					$this->urlObj,
-					$row,
-					$subpartArray,
-					$wrappedSubpartArray,
-					$viewTagArray,
-					$catListPid,
-					'LINK_CATEGORY'
-				);
-			}
+            if (isset($viewTagArray['LINK_ITEM'])) {
+                $queryString =
+                    $this->urlObj->getLinkParams(
+                        '',
+                        $addQueryString,
+                        true,
+                        $useBackPid,
+                        0,
+                        'product',
+                        $tableViewObj->piVar
+                    );
+                $linkUrl = FrontendUtility::getTypoLink_URL(
+                    $this->cObj,
+                    $linkPid,
+                    $queryString,
+                    '',
+                    []
+                );
+                $wrappedSubpartArray['###LINK_ITEM###'] = [
+                    '<a class="listlink" href="' . htmlspecialchars($linkUrl) . '">',
+                    '</a>'
+                ];
+            }
+            if (isset($viewCatTagArray['LINK_CATEGORY'])) {
+                $catListPid = $pageObj->getPID(
+                    $this->conf['PIDlistDisplay'] ?? '',
+                    $this->conf['PIDlistDisplay.'] ?? '',
+                    $row
+                );
+                $tableViewObj->getSubpartArrays(
+                    $this->urlObj,
+                    $row,
+                    $subpartArray,
+                    $wrappedSubpartArray,
+                    $viewTagArray,
+                    $catListPid,
+                    'LINK_CATEGORY'
+                );
+            }
 
-			$viewParentCatTagArray = [];
-			$tableViewObj->getParentMarkerArray (
-				$parentArray,
-				$row,
-				$catParentArray,
-				$uid,
-				$row['pid'],
-				$this->config['limitImage'],
-				'listcatImage',
-				$viewParentCatTagArray,
-				[],
-				($functablename == 'pages'),
-				$theCode,
-				tx_ttproducts_control_basket::getBasketExtra(),
-				tx_ttproducts_control_basket::getRecs(),
-				1,
-				''
-			);
+            $viewParentCatTagArray = [];
+            $tableViewObj->getParentMarkerArray (
+                $parentArray,
+                $row,
+                $catParentArray,
+                $uid,
+                $row['pid'],
+                $this->config['limitImage'],
+                'listcatImage',
+                $viewParentCatTagArray,
+                [],
+                ($functablename == 'pages'),
+                $theCode,
+                tx_ttproducts_control_basket::getBasketExtra(),
+                tx_ttproducts_control_basket::getRecs(),
+                1,
+                ''
+            );
 
-			if (isset($viewCatTagArray['LINK_PARENT1_CATEGORY'])) {
-				$catRow = $tableObj->getParent($cat);
-				$catListPid =
-					$pageObj->getPID(
-						$this->conf['PIDlistDisplay'],
-						$this->conf['PIDlistDisplay.'],
-						$catRow
-					);
-				$viewCatTable->getSubpartArrays(
-					$this->urlObj,
-					$catRow,
-					$subpartArray,
-					$wrappedSubpartArray,
-					$viewTagArray,
-					$catListPid,
-					'LINK_PARENT1_CATEGORY'
-				);
-			}
+            if (isset($viewCatTagArray['LINK_PARENT1_CATEGORY'])) {
+                $catRow = $tableObj->getParent($cat);
+                $catListPid =
+                    $pageObj->getPID(
+                        $this->conf['PIDlistDisplay'],
+                        $this->conf['PIDlistDisplay.'],
+                        $catRow
+                    );
+                $viewCatTable->getSubpartArrays(
+                    $this->urlObj,
+                    $catRow,
+                    $subpartArray,
+                    $wrappedSubpartArray,
+                    $viewTagArray,
+                    $catListPid,
+                    'LINK_PARENT1_CATEGORY'
+                );
+            }
 
-			$pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
+            $pageAsCategory = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'];
 
-			$tableViewObj->getMarkerArray(
-				$markerArray,
-				'',
-				$uid,
-				$row['pid'],
-				10,
-				'image',
-				$viewTagArray,
-				[],
-				$pageAsCategory,
-				$theCode,
-				tx_ttproducts_control_basket::getBasketExtra(),
-				tx_ttproducts_control_basket::getRecs(),
-				'',
-				'',
-				''
-			);
+            $tableViewObj->getMarkerArray(
+                $markerArray,
+                '',
+                $uid,
+                $row['pid'],
+                10,
+                'image',
+                $viewTagArray,
+                [],
+                $pageAsCategory,
+                $theCode,
+                tx_ttproducts_control_basket::getBasketExtra(),
+                tx_ttproducts_control_basket::getRecs(),
+                '',
+                '',
+                ''
+            );
 
-			$subpartArray = [];
-			$markerArray['###FORM_NAME###'] = $forminfoArray['###FORM_NAME###'];
-			$addQueryString = [];
-			if ($pid == $GLOBALS['TSFE']->id) {
-				$addQueryString[$tableViewObj->getPivar()] = $uid;
-			}
+            $subpartArray = [];
+            $markerArray['###FORM_NAME###'] = $forminfoArray['###FORM_NAME###'];
+            $addQueryString = [];
+            if ($pid == $GLOBALS['TSFE']->id) {
+                $addQueryString[$tableViewObj->getPivar()] = $uid;
+            }
 
-			$markerArray =
-				$this->urlObj->addURLMarkers(
-					$pid,
-					$markerArray,
-					$addQueryString
-				); // Applied it here also...
+            $markerArray =
+                $this->urlObj->addURLMarkers(
+                    $pid,
+                    $markerArray,
+                    $addQueryString
+                ); // Applied it here also...
 
-			$queryPrevPrefix = '';
-			$queryNextPrefix = '';
-			$prevOrderby = '';
-			$nextOrderby = '';
+            $queryPrevPrefix = '';
+            $queryNextPrefix = '';
+            $prevOrderby = '';
+            $nextOrderby = '';
 
-			if(is_array($tableConf) && isset($tableConf['orderBy']) && strpos($itemTableConf['orderBy'],',') === false) {
-				$orderByField = $tableConf['orderBy'];
-				$queryPrevPrefix = $orderByField . ' < ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$orderByField], $tableObj->getTableObj()->name);
-				$queryNextPrefix = $orderByField . ' > ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$orderByField], $tableObj->getTableObj()->name);
-				$prevOrderby = $orderByField . ' DESC';
-				$nextOrderby = $orderByField . ' ASC';
-			} else {
-				$queryPrevPrefix = 'uid < ' . intval($uid);
-				$queryNextPrefix = 'uid > ' . intval($uid);
-				$prevOrderby = 'uid DESC';
-				$nextOrderby = 'uid ASC';
-			}
+            if(is_array($tableConf) && isset($tableConf['orderBy']) && strpos($itemTableConf['orderBy'],',') === false) {
+                $orderByField = $tableConf['orderBy'];
+                $queryPrevPrefix = $orderByField . ' < ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$orderByField], $tableObj->getTableObj()->name);
+                $queryNextPrefix = $orderByField . ' > ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($row[$orderByField], $tableObj->getTableObj()->name);
+                $prevOrderby = $orderByField . ' DESC';
+                $nextOrderby = $orderByField . ' ASC';
+            } else {
+                $queryPrevPrefix = 'uid < ' . intval($uid);
+                $queryNextPrefix = 'uid > ' . intval($uid);
+                $prevOrderby = 'uid DESC';
+                $nextOrderby = 'uid ASC';
+            }
 
-			$prevOrderby = $tableObj->getTableObj()->transformOrderby($prevOrderby);
-			$nextOrderby = $tableObj->getTableObj()->transformOrderby($nextOrderby);
+            $prevOrderby = $tableObj->getTableObj()->transformOrderby($prevOrderby);
+            $nextOrderby = $tableObj->getTableObj()->transformOrderby($nextOrderby);
 
-			$whereFilter = '';
-			if (
+            $whereFilter = '';
+            if (
                 isset($tableConf['filter.']['regexp.'])
             ) {
-				if (isset($tableConf['filter.']['regexp.']['field.'])) {
-					foreach ($tableConf['filter.']['field.'] as $field => $value) {
-						$whereFilter .= ' AND ' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value), $tableObj->getTableObj()->name);
-					}
-				}
-			}
+                if (isset($tableConf['filter.']['regexp.']['field.'])) {
+                    foreach ($tableConf['filter.']['field.'] as $field => $value) {
+                        $whereFilter .= ' AND ' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value), $tableObj->getTableObj()->name);
+                    }
+                }
+            }
 
-			$queryprev = '';
-			$queryprev = $queryPrevPrefix . ' AND pid IN (' . $this->pidListObj->getPidlist() . ')' .  $tableObj->getTableObj()->enableFields();
-			// $resprev = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $queryprev,'', $prevOrderby);
-			$resprev = $tableObj->getTableObj()->exec_SELECTquery('*', $queryprev, '', $GLOBALS['TYPO3_DB']->stripOrderBy($prevOrderby));
+            $queryprev = '';
+            $queryprev = $queryPrevPrefix . ' AND pid IN (' . $this->pidListObj->getPidlist() . ')' .  $tableObj->getTableObj()->enableFields();
+            // $resprev = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $queryprev,'', $prevOrderby);
+            $resprev = $tableObj->getTableObj()->exec_SELECTquery('*', $queryprev, '', $GLOBALS['TYPO3_DB']->stripOrderBy($prevOrderby));
 
-			if ($rowprev = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resprev) ) {
-				$addQueryString = [];
-				$addQueryString[$tableViewObj->getPivar()] = $rowprev['uid'];
+            if ($rowprev = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resprev) ) {
+                $addQueryString = [];
+                $addQueryString[$tableViewObj->getPivar()] = $rowprev['uid'];
 
-				if ($useBackPid) {
-					$addQueryString['backPID'] = $backPID;
-				}
-				$queryString =
-					$this->urlObj->getLinkParams(
-						'',
-						$addQueryString,
-						true,
-						$useBackPid,
-						0,
-						'product',
-						''
-					);
-				$linkUrl = FrontendUtility::getTypoLink_URL(
-					$this->cObj,
-					$GLOBALS['TSFE']->id,
-					$queryString,
-					'',
-					[]
-				);
-				$wrappedSubpartArray['###LINK_PREV_SINGLE###'] = [
-					'<a href="' . htmlspecialchars($linkUrl) . '">',
-					'</a>'
-				];
-			} else	{
-				$subpartArray['###LINK_PREV_SINGLE###']='';
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($resprev);
+                if ($useBackPid) {
+                    $addQueryString['backPID'] = $backPID;
+                }
+                $queryString =
+                    $this->urlObj->getLinkParams(
+                        '',
+                        $addQueryString,
+                        true,
+                        $useBackPid,
+                        0,
+                        'product',
+                        ''
+                    );
+                $linkUrl = FrontendUtility::getTypoLink_URL(
+                    $this->cObj,
+                    $GLOBALS['TSFE']->id,
+                    $queryString,
+                    '',
+                    []
+                );
+                $wrappedSubpartArray['###LINK_PREV_SINGLE###'] = [
+                    '<a href="' . htmlspecialchars($linkUrl) . '">',
+                    '</a>'
+                ];
+            } else	{
+                $subpartArray['###LINK_PREV_SINGLE###']='';
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($resprev);
 
-			$querynext = $queryNextPrefix.' AND pid IN (' . $this->pidListObj->getPidlist() . ')' .  $wherestock . $tableObj->getTableObj()->enableFields();
-			// $resnext = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $querynext, $nextOrderby);
-			$resnext = $tableObj->getTableObj()->exec_SELECTquery('*', $querynext, '', $GLOBALS['TYPO3_DB']->stripOrderBy($nextOrderby));
+            $querynext = $queryNextPrefix.' AND pid IN (' . $this->pidListObj->getPidlist() . ')' .  $wherestock . $tableObj->getTableObj()->enableFields();
+            // $resnext = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $querynext, $nextOrderby);
+            $resnext = $tableObj->getTableObj()->exec_SELECTquery('*', $querynext, '', $GLOBALS['TYPO3_DB']->stripOrderBy($nextOrderby));
 
-			if ($rownext = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resnext)) {
-				$addQueryString=[];
-				$addQueryString[$this->type] = $rownext['uid'];
-				$addQueryString['backPID'] = $backPID;
-				if ($useBackPid) {
-					$addQueryString['backPID'] = $backPID;
-				} else if ($cat) {
-					$addQueryString[$viewCatTable->getPivar()] = $linkCat;
-				}
+            if ($rownext = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resnext)) {
+                $addQueryString=[];
+                $addQueryString[$this->type] = $rownext['uid'];
+                $addQueryString['backPID'] = $backPID;
+                if ($useBackPid) {
+                    $addQueryString['backPID'] = $backPID;
+                } else if ($cat) {
+                    $addQueryString[$viewCatTable->getPivar()] = $linkCat;
+                }
 
-				$queryString =
-					$this->urlObj->getLinkParams(
-						'',
-						$addQueryString,
-						true,
-						$useBackPid,
-						0,
-						'product',
-						''
-					);
-				$linkUrl = FrontendUtility::getTypoLink_URL(
-					$this->cObj,
-					$GLOBALS['TSFE']->id,
-					$queryString,
-					'',
-					[]
-				);
-				$wrappedSubpartArray['###LINK_NEXT_SINGLE###'] = [
-					'<a href="' . htmlspecialchars($linkUrl) . '">',
-					'</a>'
-				];
-			} else {
-				$subpartArray['###LINK_NEXT_SINGLE###'] = '';
-			}
-			$GLOBALS['TYPO3_DB']->sql_free_result($resnext);
+                $queryString =
+                    $this->urlObj->getLinkParams(
+                        '',
+                        $addQueryString,
+                        true,
+                        $useBackPid,
+                        0,
+                        'product',
+                        ''
+                    );
+                $linkUrl = FrontendUtility::getTypoLink_URL(
+                    $this->cObj,
+                    $GLOBALS['TSFE']->id,
+                    $queryString,
+                    '',
+                    []
+                );
+                $wrappedSubpartArray['###LINK_NEXT_SINGLE###'] = [
+                    '<a href="' . htmlspecialchars($linkUrl) . '">',
+                    '</a>'
+                ];
+            } else {
+                $subpartArray['###LINK_NEXT_SINGLE###'] = '';
+            }
+            $GLOBALS['TYPO3_DB']->sql_free_result($resnext);
 
-				// Substitute
-			$content =
-				$templateService->substituteMarkerArrayCached(
-					$itemFrameWork,
-					$markerArray,
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-		} else {
-			$error_code[0] = 'wrong_parameter';
-			$error_code[1] = (($functablename == 'pages') ? 'page' : 'cat');
-			$error_code[2] = intval($uid);
-			$error_code[3] = $this->pidListObj->getPidlist();
-		}
-		return $content;
-	} // print
+                // Substitute
+            $content =
+                $templateService->substituteMarkerArrayCached(
+                    $itemFrameWork,
+                    $markerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+        } else {
+            $error_code[0] = 'wrong_parameter';
+            $error_code[1] = (($functablename == 'pages') ? 'page' : 'cat');
+            $error_code[2] = intval($uid);
+            $error_code[3] = $this->pidListObj->getPidlist();
+        }
+        return $content;
+    } // print
 }
 

--- a/view/class.tx_ttproducts_category_base_view.php
+++ b/view/class.tx_ttproducts_category_base_view.php
@@ -44,179 +44,179 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 abstract class tx_ttproducts_category_base_view extends tx_ttproducts_table_base_view {
-	public $dataArray;  // array of read in categories
-	public $marker = 'CATEGORY';
-	public $markerObj;
-	public $mm_table = ''; // only set if a mm table is used
-	public $parentField; // reference field name for parent
+    public $dataArray;  // array of read in categories
+    public $marker = 'CATEGORY';
+    public $markerObj;
+    public $mm_table = ''; // only set if a mm table is used
+    public $parentField; // reference field name for parent
 
 
-	public function setMarkerArrayCatTitle (
-		&$markerArray,
-		$catTitle,
-		$prefix
-	) {
+    public function setMarkerArrayCatTitle (
+        &$markerArray,
+        $catTitle,
+        $prefix
+    ) {
         $cObj = FrontendUtility::getContentObjectRenderer();
-		$cObj->setCurrentVal($catTitle);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+        $cObj->setCurrentVal($catTitle);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		$title = $cObj->cObjGetSingle($conf['categoryHeader'] ?? '', $conf['categoryHeader.'] ?? '', 'categoryHeader');
-		$markerArray['###' . $prefix . $this->getMarker() . '_TITLE###'] = $title;
-	}
-
-
-	public function getMarkerArrayCatTitle (
-		$markerArray,
-		$prefix = ''
-	) {
-		$markerKey = '###' . $prefix . $this->getMarker() . '_TITLE###';
-		$result = $markerArray[$markerKey];
-		return $result;
-	}
+        $title = $cObj->cObjGetSingle($conf['categoryHeader'] ?? '', $conf['categoryHeader.'] ?? '', 'categoryHeader');
+        $markerArray['###' . $prefix . $this->getMarker() . '_TITLE###'] = $title;
+    }
 
 
-	public function &getSubpartArrays (
-		&$urlmarkerObj,
-		$row,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		&$tagArray,
-		$pid,
-		$linkMarker
-	) {
+    public function getMarkerArrayCatTitle (
+        $markerArray,
+        $prefix = ''
+    ) {
+        $markerKey = '###' . $prefix . $this->getMarker() . '_TITLE###';
+        $result = $markerArray[$markerKey];
+        return $result;
+    }
+
+
+    public function &getSubpartArrays (
+        &$urlmarkerObj,
+        $row,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        &$tagArray,
+        $pid,
+        $linkMarker
+    ) {
         $cObj = FrontendUtility::getContentObjectRenderer();
-		$addQueryString = [];
-		$addQueryString[$this->piVar] = $row['uid'];
-		$wrappedSubpartArray['###' . $linkMarker . '###'] =
-			[
-				'<a href="' .
-					htmlspecialchars(
-						FrontendUtility::getTypoLink_URL(
-							$cObj,
-							$pid,
-							$urlmarkerObj->getLinkParams(
-								'',
-								$addQueryString,
-								true,
-								false,
-								0,
-								'product',
-								$this->piVar
-							),
-							'',
-							[]
-						)
-					)
-			. '">',
-				'</a>'
+        $addQueryString = [];
+        $addQueryString[$this->piVar] = $row['uid'];
+        $wrappedSubpartArray['###' . $linkMarker . '###'] =
+            [
+                '<a href="' .
+                    htmlspecialchars(
+                        FrontendUtility::getTypoLink_URL(
+                            $cObj,
+                            $pid,
+                            $urlmarkerObj->getLinkParams(
+                                '',
+                                $addQueryString,
+                                true,
+                                false,
+                                0,
+                                'product',
+                                $this->piVar
+                            ),
+                            '',
+                            []
+                        )
+                    )
+            . '">',
+                '</a>'
             ];
-	}
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 			 			for the tt_producst record, $row
-	 * @access private
-	 */
-	abstract function getMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$category,
-		$pid,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		&$viewCatTagArray,
-		$forminfoArray = [],
-		$pageAsCategory = 0,
-		$theCode,
-		$basketExtra,
-		$basketRecs, 
-		$id,
-		$prefix,
-		$linkWrap = ''
-	);
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 			 			for the tt_producst record, $row
+     * @access private
+     */
+    abstract function getMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $category,
+        $pid,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        &$viewCatTagArray,
+        $forminfoArray = [],
+        $pageAsCategory = 0,
+        $theCode,
+        $basketExtra,
+        $basketRecs, 
+        $id,
+        $prefix,
+        $linkWrap = ''
+    );
 
-	public function getParentMarkerArray (
-		$parentArray,
-		$row,
-		&$markerArray,
-		$category,
-		$pid,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		&$viewCatTagArray,
-		$forminfoArray = [],
-		$pageAsCategory = 0,
-		$code,
-		$basketExtra,
-		$basketRecs,
-		$id,
-		$prefix
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$config = $cnf->getConfig();
+    public function getParentMarkerArray (
+        $parentArray,
+        $row,
+        &$markerArray,
+        $category,
+        $pid,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        &$viewCatTagArray,
+        $forminfoArray = [],
+        $pageAsCategory = 0,
+        $code,
+        $basketExtra,
+        $basketRecs,
+        $id,
+        $prefix
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $config = $cnf->getConfig();
 
-		if (is_array($parentArray) && count($parentArray)) {
-			$currentRow = $row;
-			$count = 0;
-			$currentCategory = $this->getModelObj()->getRowCategory($row);
-			$parentCategory = '';
+        if (is_array($parentArray) && count($parentArray)) {
+            $currentRow = $row;
+            $count = 0;
+            $currentCategory = $this->getModelObj()->getRowCategory($row);
+            $parentCategory = '';
 
-			foreach ($parentArray as $parent) {
-				do {
-					$parentRow = $this->getModelObj()->getParent($currentCategory);
-					$parentCategory = $parentRow['uid'];
-					$parentPid = $this->getModelObj()->getRowPid($parentRow);
-					$count++;
-					if ($count < $parent) {
-						$currentCategory = $parentCategory;
-					}
-				} while ($count < $parent && is_array($currentRow) && count($currentRow));
-				$currentCategory = $parentCategory;
+            foreach ($parentArray as $parent) {
+                do {
+                    $parentRow = $this->getModelObj()->getParent($currentCategory);
+                    $parentCategory = $parentRow['uid'];
+                    $parentPid = $this->getModelObj()->getRowPid($parentRow);
+                    $count++;
+                    if ($count < $parent) {
+                        $currentCategory = $parentCategory;
+                    }
+                } while ($count < $parent && is_array($currentRow) && count($currentRow));
+                $currentCategory = $parentCategory;
 
-				if (is_array($currentRow) && count($currentRow)) {
+                if (is_array($currentRow) && count($currentRow)) {
                     $tmp = [];
-					$this->getMarkerArray(
-						$markerArray,
-						'',
-						$parentCategory,
-						$parentPid,
-						$config['limitImage'],
-						'listcatImage',
-						$viewCatTagArray,
-						$tmp,
-						$pageAsCategory,
-						'SINGLE',
-						$basketExtra,
-						$basketRecs,
-						1,
-						'PARENT' . $parent . '_',
-						$prefix
-					);
-				}
-			}
-		}
-	}
+                    $this->getMarkerArray(
+                        $markerArray,
+                        '',
+                        $parentCategory,
+                        $parentPid,
+                        $config['limitImage'],
+                        'listcatImage',
+                        $viewCatTagArray,
+                        $tmp,
+                        $pageAsCategory,
+                        'SINGLE',
+                        $basketExtra,
+                        $basketRecs,
+                        1,
+                        'PARENT' . $parent . '_',
+                        $prefix
+                    );
+                }
+            }
+        }
+    }
 
 
-	public function addAllCatTagsMarker (&$markerArray, $tagArray, $prefix) {
-		$outArray = [];
+    public function addAllCatTagsMarker (&$markerArray, $tagArray, $prefix) {
+        $outArray = [];
 
-		if (isset($tagArray) && is_array($tagArray)) {
-			foreach ($tagArray as $tag) {
-				$outArray[] = $prefix . $tag;
-			}
-		}
+        if (isset($tagArray) && is_array($tagArray)) {
+            foreach ($tagArray as $tag) {
+                $outArray[] = $prefix . $tag;
+            }
+        }
 
-		$markerArray['###ALLCATTAGS###'] = implode(' ', $outArray);
-	}
+        $markerArray['###ALLCATTAGS###'] = implode(' ', $outArray);
+    }
 }
 

--- a/view/class.tx_ttproducts_category_view.php
+++ b/view/class.tx_ttproducts_category_view.php
@@ -42,41 +42,41 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_category_view extends tx_ttproducts_category_base_view {
-	public $piVar = 'cat';
+    public $piVar = 'cat';
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 	 			for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$category,
-		$pid,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		&$viewCatTagArray,
-		$forminfoArray = [],
-		$pageAsCategory = 0,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$id,
-		$prefix,
-		$linkWrap = ''
-	) {
-		$modelObj = $this->getModelObj();
-		$row = ($category ? $modelObj->get($category) : array ('title' => '', 'pid' => $pid));
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$functablename = $modelObj->getFuncTablename();
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 	 			for the tt_producst record, $row
+     * @access private
+     */
+    public function getMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $category,
+        $pid,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        &$viewCatTagArray,
+        $forminfoArray = [],
+        $pageAsCategory = 0,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $id,
+        $prefix,
+        $linkWrap = ''
+    ) {
+        $modelObj = $this->getModelObj();
+        $row = ($category ? $modelObj->get($category) : array ('title' => '', 'pid' => $pid));
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $functablename = $modelObj->getFuncTablename();
 
 // 		$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
 //
@@ -96,39 +96,39 @@ class tx_ttproducts_category_view extends tx_ttproducts_category_base_view {
 // 			$linkWrap
 // 		);
 
-		$pageCatTitle = '';
-		if ($pageAsCategory == 1) {
-			$pageObj = $tablesObj->get('pages');
-			$pageTmp = $pageObj->get($pid);
-			$pageCatTitle = $pageTmp['title'];
-		}
+        $pageCatTitle = '';
+        if ($pageAsCategory == 1) {
+            $pageObj = $tablesObj->get('pages');
+            $pageTmp = $pageObj->get($pid);
+            $pageCatTitle = $pageTmp['title'];
+        }
 
-		$catTitle = $pageCatTitle;
+        $catTitle = $pageCatTitle;
         if (($row['title'])) {
             $tableconf = $modelObj->getTableConf($theCode);
             $catTitle .= (($tableconf['separator'] ?? '') . $row['title']);
         }
-		$this->setMarkerArrayCatTitle($markerArray, $catTitle, $prefix);
-		parent::getRowMarkerArray(
-			$functablename,
-			$row,
-			$markerKey,
-			$markerArray,
-			$variantFieldArray,
-			$variantMarkerArray,
-			$viewCatTagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			true,
-			'UTF-8',
-			$imageNum,
-			$imageRenderObj,
-			$id,
-			$prefix,
-			'',
-			$linkWrap
-		);
-	}
+        $this->setMarkerArrayCatTitle($markerArray, $catTitle, $prefix);
+        parent::getRowMarkerArray(
+            $functablename,
+            $row,
+            $markerKey,
+            $markerArray,
+            $variantFieldArray,
+            $variantMarkerArray,
+            $viewCatTagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            true,
+            'UTF-8',
+            $imageNum,
+            $imageRenderObj,
+            $id,
+            $prefix,
+            '',
+            $linkWrap
+        );
+    }
 }
 

--- a/view/class.tx_ttproducts_catlist_view.php
+++ b/view/class.tx_ttproducts_catlist_view.php
@@ -44,23 +44,23 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_catlist_view extends tx_ttproducts_catlist_view_base {
 
-	public function getChildsContent (
-		$theCode,
-		$t,
-		$functablename,
-		$categoryArray,
-		array $catArray,
-		array $childArray,
-		$ctrlArray,
-		$linkOutArray,
+    public function getChildsContent (
+        $theCode,
+        $t,
+        $functablename,
+        $categoryArray,
+        array $catArray,
+        array $childArray,
+        $ctrlArray,
+        $linkOutArray,
         $depth,
         $maxDepth,
-		$viewCatTagArray,
-		$currentCat,
-		$pageAsCategory,
-		$childRow,
-		$subCategoryMarkerArray
-	) {
+        $viewCatTagArray,
+        $currentCat,
+        $pageAsCategory,
+        $childRow,
+        $subCategoryMarkerArray
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
 
         $subCategoryMarker = '';
@@ -74,49 +74,49 @@ class tx_ttproducts_catlist_view extends tx_ttproducts_catlist_view_base {
                 }
             }
         }
-		$icCount = 0;
-		$childsOut = '';
-		$childStart = 0;
-		$childEnd = $childEndMax = count($childArray) - 1;
+        $icCount = 0;
+        $childsOut = '';
+        $childStart = 0;
+        $childEnd = $childEndMax = count($childArray) - 1;
 
-		if ($ctrlArray['bUseBrowser'] && !empty($ctrlArray['limit'])) {
-			$piVars = tx_ttproducts_model_control::getPiVars();
-			$childStart = ($piVars['pointer'] ?? 0) * $ctrlArray['limit'];
-			$childEnd = $childStart + $ctrlArray['limit'] - 1;
+        if ($ctrlArray['bUseBrowser'] && !empty($ctrlArray['limit'])) {
+            $piVars = tx_ttproducts_model_control::getPiVars();
+            $childStart = ($piVars['pointer'] ?? 0) * $ctrlArray['limit'];
+            $childEnd = $childStart + $ctrlArray['limit'] - 1;
 
-			if ($childEnd > $childEndMax) {
-				$childEnd = $childEndMax;
-			}
-		}
+            if ($childEnd > $childEndMax) {
+                $childEnd = $childEndMax;
+            }
+        }
 
-		for ($k = $childStart; $k <= $childEnd; ++$k) {
+        for ($k = $childStart; $k <= $childEnd; ++$k) {
             $childLinkOut = '';
-			$child = $childArray[$k];
-			$childRow = $categoryArray[$child];
-			$markerArray = [];
-			$icCount++;
+            $child = $childArray[$k];
+            $childRow = $categoryArray[$child];
+            $markerArray = [];
+            $icCount++;
 
-			if ($ctrlArray['bUseBrowser']) {
-				if ($icCount > $ctrlArray['limit']) {
-					break;
-				}
-			}
-			$this->getMarkerArray(
-				$functablename,
-				$markerArray,
-				$linkOutArray,
-				$depth + 1,
-				$maxDepth,
-				$icCount,
-				$child,
-				$viewCatTagArray,
-				$currentCat,
-				$pageAsCategory,
-				$childRow,
-				$theCode,
-				tx_ttproducts_control_basket::getBasketExtra(),
-				tx_ttproducts_control_basket::getRecs()
-			);
+            if ($ctrlArray['bUseBrowser']) {
+                if ($icCount > $ctrlArray['limit']) {
+                    break;
+                }
+            }
+            $this->getMarkerArray(
+                $functablename,
+                $markerArray,
+                $linkOutArray,
+                $depth + 1,
+                $maxDepth,
+                $icCount,
+                $child,
+                $viewCatTagArray,
+                $currentCat,
+                $pageAsCategory,
+                $childRow,
+                $theCode,
+                tx_ttproducts_control_basket::getBasketExtra(),
+                tx_ttproducts_control_basket::getRecs()
+            );
 
             $grandChildArray = $childRow['child_category'];
 
@@ -144,40 +144,40 @@ class tx_ttproducts_catlist_view extends tx_ttproducts_catlist_view_base {
                     );
             }
 
-			if ($t[$subCategoryMarker]['linkCategoryFrameWork']) {
-				$newOut =
-					$templateService->substituteMarkerArray(
-						$t[$subCategoryMarker]['linkCategoryFrameWork'],
-						$markerArray
-					);
-				$childLinkOut = $linkOutArray['0'] . $newOut . $linkOutArray['1'];
-			}
-			$wrappedSubpartArray = [];
-			$this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
-			$subpartArray = [];
-			$subpartArray['###CATEGORY_SINGLE###'] = $childLinkOut;
-			$childsOut .=
-				$templateService->substituteMarkerArrayCached(
-					$t[$subCategoryMarker]['categoryFrameWork'],
-					$markerArray,
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-		}
-		$subpartArray = [];
-		$wrappedSubpartArray = [];
-		$this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
-		$subpartArray['###CATEGORY_SINGLE###'] = $childsOut;
-		$childsOut =
-			$templateService->substituteMarkerArrayCached(
-				$t[$subCategoryMarker]['listFrameWork'],
-				[],
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            if ($t[$subCategoryMarker]['linkCategoryFrameWork']) {
+                $newOut =
+                    $templateService->substituteMarkerArray(
+                        $t[$subCategoryMarker]['linkCategoryFrameWork'],
+                        $markerArray
+                    );
+                $childLinkOut = $linkOutArray['0'] . $newOut . $linkOutArray['1'];
+            }
+            $wrappedSubpartArray = [];
+            $this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
+            $subpartArray = [];
+            $subpartArray['###CATEGORY_SINGLE###'] = $childLinkOut;
+            $childsOut .=
+                $templateService->substituteMarkerArrayCached(
+                    $t[$subCategoryMarker]['categoryFrameWork'],
+                    $markerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+        }
+        $subpartArray = [];
+        $wrappedSubpartArray = [];
+        $this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
+        $subpartArray['###CATEGORY_SINGLE###'] = $childsOut;
+        $childsOut =
+            $templateService->substituteMarkerArrayCached(
+                $t[$subCategoryMarker]['listFrameWork'],
+                [],
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-		return $childsOut;
-	}
+        return $childsOut;
+    }
 
 
     protected function renderChilds(
@@ -223,97 +223,97 @@ class tx_ttproducts_catlist_view extends tx_ttproducts_catlist_view_base {
         return $childsOut;
     }
 
-	// returns the category list view
-	public function printView (
-		$functablename,
-		&$templateCode,
-		$theCode,
-		&$error_code,
-		$templateArea = 'ITEM_CATLIST_TEMPLATE',
-		$pageAsCategory,
-		$templateSuffix = '',
-		$basketExtra,
-		$basketRecs
-	) {
+    // returns the category list view
+    public function printView (
+        $functablename,
+        &$templateCode,
+        $theCode,
+        &$error_code,
+        $templateArea = 'ITEM_CATLIST_TEMPLATE',
+        $pageAsCategory,
+        $templateSuffix = '',
+        $basketExtra,
+        $basketRecs
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$t = [];
-		$ctrlArray = [];
-		parent::getPrintViewArrays(
-			$functablename,
-			$templateCode,
-			$t,
-			$htmlParts,
-			$theCode,
-			$error_code,
-			$templateArea,
-			$pageAsCategory,
-			$templateSuffix,
-			$basketExtra,
-			$basketRecs,
-			$currentCat,
-			$categoryArray,
-			$catArray,
-			$activeRootline,
-			$rootpathArray,
-			$subCategoryMarkerArray,
-			$ctrlArray
-		);
-		$content = '';
-		$out = '';
-		$where = '';
-		$bFinished = false;
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$catView = $tablesObj->get($functablename, true);
-		$catTableObj = $catView->getModelObj();
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $t = [];
+        $ctrlArray = [];
+        parent::getPrintViewArrays(
+            $functablename,
+            $templateCode,
+            $t,
+            $htmlParts,
+            $theCode,
+            $error_code,
+            $templateArea,
+            $pageAsCategory,
+            $templateSuffix,
+            $basketExtra,
+            $basketRecs,
+            $currentCat,
+            $categoryArray,
+            $catArray,
+            $activeRootline,
+            $rootpathArray,
+            $subCategoryMarkerArray,
+            $ctrlArray
+        );
+        $content = '';
+        $out = '';
+        $where = '';
+        $bFinished = false;
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $catView = $tablesObj->get($functablename, true);
+        $catTableObj = $catView->getModelObj();
 
-		if (!empty($error_code)) {
-			// nothing
-		} else if (count($categoryArray)) {
-			$count = 0;
-			$countArray = [];
-			$countArray[0] = 0;
-			$countArray[1] = 0;
-			$count = 0;
-			$out = '';
-			$parentArray = [];
-			$viewCatTagArray = [];
-			$currentMarkerArray = [];
+        if (!empty($error_code)) {
+            // nothing
+        } else if (count($categoryArray)) {
+            $count = 0;
+            $countArray = [];
+            $countArray[0] = 0;
+            $countArray[1] = 0;
+            $count = 0;
+            $out = '';
+            $parentArray = [];
+            $viewCatTagArray = [];
+            $currentMarkerArray = [];
 
-			$maxDepth = $catTableObj->getDepth($theCode);
-			$tmp = [];
-			$catfieldsArray = $markerObj->getMarkerFields(
-				$t['categoryFrameWork'],
-				$catTableObj->getTableObj()->tableFieldArray,
-				$catTableObj->getTableObj()->requiredFieldArray,
-				$tmp,
-				$catView->getMarker(),
-				$viewCatTagArray,
-				$parentArray
-			);
-			$iCount = 0;
-			$tSubParts =
-				$subpartmarkerObj->getTemplateSubParts(
-					$templateCode,
-					$subCategoryMarkerArray
-				);
+            $maxDepth = $catTableObj->getDepth($theCode);
+            $tmp = [];
+            $catfieldsArray = $markerObj->getMarkerFields(
+                $t['categoryFrameWork'],
+                $catTableObj->getTableObj()->tableFieldArray,
+                $catTableObj->getTableObj()->requiredFieldArray,
+                $tmp,
+                $catView->getMarker(),
+                $viewCatTagArray,
+                $parentArray
+            );
+            $iCount = 0;
+            $tSubParts =
+                $subpartmarkerObj->getTemplateSubParts(
+                    $templateCode,
+                    $subCategoryMarkerArray
+                );
 
-			foreach ($tSubParts as $marker => $area) {
-				$this->getFrameWork(
-					$t[$marker],
-					$templateCode,
-					$area . $templateSuffix
-				);
-			}
-			$iCount++;
-			$currentMarkerArray = [];
+            foreach ($tSubParts as $marker => $area) {
+                $this->getFrameWork(
+                    $t[$marker],
+                    $templateCode,
+                    $area . $templateSuffix
+                );
+            }
+            $iCount++;
+            $currentMarkerArray = [];
 
-			if ($currentCat) {
-			} else {
-				$currentCat = array_key_first($categoryArray);
-			}    
+            if ($currentCat) {
+            } else {
+                $currentCat = array_key_first($categoryArray);
+            }    
 
             if (
                 isset($catArray['1']) &&
@@ -416,196 +416,196 @@ class tx_ttproducts_catlist_view extends tx_ttproducts_catlist_view_base {
                 }
             }
 
-			$markerArray = $currentMarkerArray;
-			$markerArray[$this->htmlPartsMarkers[0]] = '';
-			$markerArray[$this->htmlPartsMarkers[1]] = '';
-			$out = $templateService->substituteMarkerArrayCached($out, $markerArray);
+            $markerArray = $currentMarkerArray;
+            $markerArray[$this->htmlPartsMarkers[0]] = '';
+            $markerArray[$this->htmlPartsMarkers[1]] = '';
+            $out = $templateService->substituteMarkerArrayCached($out, $markerArray);
 
-			$markerArray = [];
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
-			$this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
-			$subpartArray['###CATEGORY_SINGLE###'] = $out;
-			$viewConfArray = $this->getViewConfArray();
+            $markerArray = [];
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
+            $this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
+            $subpartArray['###CATEGORY_SINGLE###'] = $out;
+            $viewConfArray = $this->getViewConfArray();
 
-			if (is_array($viewConfArray) && count($viewConfArray)) {
-				$allMarkers = $this->getTemplateMarkers($t);
-				$addQueryString = [];
-				$markerArray =
-					$this->urlObj->addURLMarkers(
-						$GLOBALS['TSFE']->id,
-						$markerArray,
-						$addQueryString,
-						false
-					);
+            if (is_array($viewConfArray) && count($viewConfArray)) {
+                $allMarkers = $this->getTemplateMarkers($t);
+                $addQueryString = [];
+                $markerArray =
+                    $this->urlObj->addURLMarkers(
+                        $GLOBALS['TSFE']->id,
+                        $markerArray,
+                        $addQueryString,
+                        false
+                    );
 
-				$controlViewObj = GeneralUtility::makeInstance('tx_ttproducts_control_view');
-				$controlViewObj->getMarkerArray(
-					$markerArray,
-					$allMarkers,
-					$this->getTableConfArray()
-				);
-			}
+                $controlViewObj = GeneralUtility::makeInstance('tx_ttproducts_control_view');
+                $controlViewObj->getMarkerArray(
+                    $markerArray,
+                    $allMarkers,
+                    $this->getTableConfArray()
+                );
+            }
 
-			$out =
-				$templateService->substituteMarkerArrayCached(
-					$t['listFrameWork'],
-					$markerArray,
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-			$content = $out;
-		} else {
-			$contentEmpty =
-				$subpartmarkerObj->getSubpart(
-					$templateCode,
-					$subpartmarkerObj->spMarker(
-						'###' . $templateArea . $templateSuffix . '_EMPTY###'
-					),
-					$error_code
-				);
-		}
+            $out =
+                $templateService->substituteMarkerArrayCached(
+                    $t['listFrameWork'],
+                    $markerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+            $content = $out;
+        } else {
+            $contentEmpty =
+                $subpartmarkerObj->getSubpart(
+                    $templateCode,
+                    $subpartmarkerObj->spMarker(
+                        '###' . $templateArea . $templateSuffix . '_EMPTY###'
+                    ),
+                    $error_code
+                );
+        }
 
-		if ($contentEmpty != '') {
+        if ($contentEmpty != '') {
 
-			$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-			$content =
-				$templateService->substituteMarkerArray(
-					$contentEmpty,
-					$globalMarkerArray
-				);
-		}
+            $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+            $content =
+                $templateService->substituteMarkerArray(
+                    $contentEmpty,
+                    $globalMarkerArray
+                );
+        }
 
-		return $content;
-	}
-
-
-	public function getItemSubpartArrays (
-		$templateCode,
-		$functablename,
-		$row,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$tagArray,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$id
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$categoryTableView = $tablesObj->get($functablename, true);
-
-		$categoryTableView->getItemSubpartArrays(
-			$templateCode,
-			$functablename,
-			$row,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$tagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$id
-		);
-	}
+        return $content;
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a category
-	 *
-	 */
-	public function getMarkerArray (
-		$functablename,
-		&$markerArray,
-		&$linkOutArray,
-		$depth,
-		$maxDepth,
-		$iCount,
-		$actCategory,
-		$viewCatTagArray,
-		$currentCat,
-		$pageAsCategory,
-		$row,
-		$theCode,
-		$basketExtra,
-		$basketRecs
-	) {
-		$pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
-		$config = $cnfObj->getConfig();
-		$css = 'class="w' . $iCount . '"';
-		$css = ($actCategory == $currentCat ? 'class="act"' : $css);
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
+    public function getItemSubpartArrays (
+        $templateCode,
+        $functablename,
+        $row,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $tagArray,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $id
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $categoryTableView = $tablesObj->get($functablename, true);
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$pageObj = $tablesObj->get('pages');
-		$categoryTableView = $tablesObj->get($functablename, true);
-		$categoryTable = $categoryTableView->getModelObj();
+        $categoryTableView->getItemSubpartArrays(
+            $templateCode,
+            $functablename,
+            $row,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $tagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $id
+        );
+    }
 
-		$cssConf =
-			$cnfObj->getCSSConf(
-				$functablename,
-				$theCode
-			);
 
-		if (isset($cssConf) && is_array($cssConf)) {
-			$rowEven = $cssConf['row.']['even'] ?? '';
-			$rowUneven = $cssConf['row.']['uneven'] ?? '';
-			$evenUneven = (($iCount & 1) == 0 ? $rowEven : $rowUneven);
-		} else {
-			$evenUneven = '';
-		}
-		$markerArray['###UNEVEN###'] = $evenUneven;
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a category
+     *
+     */
+    public function getMarkerArray (
+        $functablename,
+        &$markerArray,
+        &$linkOutArray,
+        $depth,
+        $maxDepth,
+        $iCount,
+        $actCategory,
+        $viewCatTagArray,
+        $currentCat,
+        $pageAsCategory,
+        $row,
+        $theCode,
+        $basketExtra,
+        $basketRecs
+    ) {
+        $pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
+        $config = $cnfObj->getConfig();
+        $css = 'class="w' . $iCount . '"';
+        $css = ($actCategory == $currentCat ? 'class="act"' : $css);
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
 
-		$pid =
-			$pageObj->getPID(
-				$conf['PIDlistDisplay'] ?? 0,
-				$conf['PIDlistDisplay.'] ?? [],
-				$row
-			);
-		$addQueryString = [$categoryTableView->getPivar() => $actCategory];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $pageObj = $tablesObj->get('pages');
+        $categoryTableView = $tablesObj->get($functablename, true);
+        $categoryTable = $categoryTableView->getModelObj();
 
-		$urlParameters = [$prefixId => $addQueryString];
+        $cssConf =
+            $cnfObj->getCSSConf(
+                $functablename,
+                $theCode
+            );
 
-		$linkConf = [];
-		$linkConf['parameter'] = $pid;
-		$linkConf['additionalParams'] = GeneralUtility::implodeArrayForUrl('', $urlParameters);
+        if (isset($cssConf) && is_array($cssConf)) {
+            $rowEven = $cssConf['row.']['even'] ?? '';
+            $rowUneven = $cssConf['row.']['uneven'] ?? '';
+            $evenUneven = (($iCount & 1) == 0 ? $rowEven : $rowUneven);
+        } else {
+            $evenUneven = '';
+        }
+        $markerArray['###UNEVEN###'] = $evenUneven;
 
-		$pibaseObj->cObj->typolink('', $linkConf);
-		$linkUrl = $pibaseObj->cObj->lastTypoLinkUrl;
-		$linkOutArray = ['<a href="' . htmlspecialchars($linkUrl) . '" ' . $css . '>', '</a>'];
+        $pid =
+            $pageObj->getPID(
+                $conf['PIDlistDisplay'] ?? 0,
+                $conf['PIDlistDisplay.'] ?? [],
+                $row
+            );
+        $addQueryString = [$categoryTableView->getPivar() => $actCategory];
 
-		$linkOut =
-			$linkOutArray[0] .
-			htmlentities(
-				$row[$categoryTable->getLabelFieldname()],
-				ENT_QUOTES,
-				'UTF-8'
-			) .
-			$linkOutArray[1];
+        $urlParameters = [$prefixId => $addQueryString];
 
-		$categoryTableView->getMarkerArray(
-			$markerArray,
-			'',
-			$actCategory,
-			$row['pid'],
-			$config['limitImage'],
-			'listcatImage',
-			$viewCatTagArray,
-			[],
-			$pageAsCategory,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$iCount,
-			''
-		);
+        $linkConf = [];
+        $linkConf['parameter'] = $pid;
+        $linkConf['additionalParams'] = GeneralUtility::implodeArrayForUrl('', $urlParameters);
 
-		$markerArray['###LIST_LINK###'] = $linkOut;
-		$markerArray['###LIST_LINK_CSS###'] = $css;
-		$markerArray['###LIST_LINK_URL###'] = htmlspecialchars($linkUrl);
-	}
+        $pibaseObj->cObj->typolink('', $linkConf);
+        $linkUrl = $pibaseObj->cObj->lastTypoLinkUrl;
+        $linkOutArray = ['<a href="' . htmlspecialchars($linkUrl) . '" ' . $css . '>', '</a>'];
+
+        $linkOut =
+            $linkOutArray[0] .
+            htmlentities(
+                $row[$categoryTable->getLabelFieldname()],
+                ENT_QUOTES,
+                'UTF-8'
+            ) .
+            $linkOutArray[1];
+
+        $categoryTableView->getMarkerArray(
+            $markerArray,
+            '',
+            $actCategory,
+            $row['pid'],
+            $config['limitImage'],
+            'listcatImage',
+            $viewCatTagArray,
+            [],
+            $pageAsCategory,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $iCount,
+            ''
+        );
+
+        $markerArray['###LIST_LINK###'] = $linkOut;
+        $markerArray['###LIST_LINK_CSS###'] = $css;
+        $markerArray['###LIST_LINK_URL###'] = htmlspecialchars($linkUrl);
+    }
 }
 

--- a/view/class.tx_ttproducts_catlist_view_base.php
+++ b/view/class.tx_ttproducts_catlist_view_base.php
@@ -44,116 +44,116 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 abstract class tx_ttproducts_catlist_view_base implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pibaseClass;
-	public $cObj;
-	public $conf;
-	public $config;
-	public $pidListObj; // pid where to go
-	public $urlObj; // url functions
-	protected $htmlTagMain = '';	// main HTML tag
-	protected $htmlTagElement = ''; // HTML tag element
-	public $htmlPartsMarkers = ['###ITEM_SINGLE_PRE_HTML###', '###ITEM_SINGLE_POST_HTML###'];
-	public $tableConfArray = [];
-	public $viewConfArray = [];
-	private $tMarkers;	// all markers which are found in the template subpart for the whole view $t['listFrameWork']
+    public $pibaseClass;
+    public $cObj;
+    public $conf;
+    public $config;
+    public $pidListObj; // pid where to go
+    public $urlObj; // url functions
+    protected $htmlTagMain = '';	// main HTML tag
+    protected $htmlTagElement = ''; // HTML tag element
+    public $htmlPartsMarkers = ['###ITEM_SINGLE_PRE_HTML###', '###ITEM_SINGLE_POST_HTML###'];
+    public $tableConfArray = [];
+    public $viewConfArray = [];
+    private $tMarkers;	// all markers which are found in the template subpart for the whole view $t['listFrameWork']
 
 
-	public function init (
+    public function init (
         $cObj,
-		$pibaseClass,
-		$pid_list,
-		$recursive,
-		$pid
-	) {
-		$this->pibaseClass = $pibaseClass;
-		$this->pibase = GeneralUtility::makeInstance('' . $pibaseClass);
+        $pibaseClass,
+        $pid_list,
+        $recursive,
+        $pid
+    ) {
+        $this->pibaseClass = $pibaseClass;
+        $this->pibase = GeneralUtility::makeInstance('' . $pibaseClass);
         $this->cObj = $cObj;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
-		$this->pid = $pid;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
+        $this->pid = $pid;
 
-		$this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-		$this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$this->pidListObj->applyRecursive($recursive, $pid_list, true);
-		$this->pidListObj->setPageArray();
+        $this->urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $this->pidListObj->applyRecursive($recursive, $pid_list, true);
+        $this->pidListObj->setPageArray();
 
-		$this->htmlTagMain = ($this->htmlTagMain ? $this->htmlTagMain : $this->conf['displayCatListType']);
+        $this->htmlTagMain = ($this->htmlTagMain ? $this->htmlTagMain : $this->conf['displayCatListType']);
 
-		if (!$this->htmlTagElement) {
-			switch ($this->htmlTagMain) {
-				case 'ul':
-					$this->htmlTagElement = 'li';
-					break;
-				case 'div':
-					$this->htmlTagElement = 'div';
-					break;
-				case 'tr':
-					$this->htmlTagElement = 'td';
-					break;
-			}
-		}
-	}
-
-
-	public function getTabs ($depth) {
-		$result = '';
-		for ($i = 0; $i < $depth; $i++) {
-			$result .= chr(9);
-		}
-		return $result;
-	}
+        if (!$this->htmlTagElement) {
+            switch ($this->htmlTagMain) {
+                case 'ul':
+                    $this->htmlTagElement = 'li';
+                    break;
+                case 'div':
+                    $this->htmlTagElement = 'div';
+                    break;
+                case 'tr':
+                    $this->htmlTagElement = 'td';
+                    break;
+            }
+        }
+    }
 
 
-	public function getActiveRootline (
-		$cat,
-		$categoryArray
-	) {
-		$result = [];
-
-		if ($cat) {
-			$uid = $cat;
-			$result[$uid] = true;
-			// get all forefathers
-			while ($uid = $categoryArray[$uid]['parent_category']) {
-				$result[$uid] = true;
-			}
-		}
-		return $result;
-	}
+    public function getTabs ($depth) {
+        $result = '';
+        for ($i = 0; $i < $depth; $i++) {
+            $result .= chr(9);
+        }
+        return $result;
+    }
 
 
-	// sets the 'depth' field
-	public function setDepths (
-		&$categoryArray,
-		&$catArray,
-		$categoryRootArray
-	) {
-		$depth = 1;
-		$childlessArray = [];
-		foreach($categoryArray as $category => $row) {
-				// is it a leaf in a tree ?
-			if (
+    public function getActiveRootline (
+        $cat,
+        $categoryArray
+    ) {
+        $result = [];
+
+        if ($cat) {
+            $uid = $cat;
+            $result[$uid] = true;
+            // get all forefathers
+            while ($uid = $categoryArray[$uid]['parent_category']) {
+                $result[$uid] = true;
+            }
+        }
+        return $result;
+    }
+
+
+    // sets the 'depth' field
+    public function setDepths (
+        &$categoryArray,
+        &$catArray,
+        $categoryRootArray
+    ) {
+        $depth = 1;
+        $childlessArray = [];
+        foreach($categoryArray as $category => $row) {
+                // is it a leaf in a tree ?
+            if (
                 empty($row['child_category'])
             ) {
-				$childlessArray[] = (int) $category;
-			}
-		}
+                $childlessArray[] = (int) $category;
+            }
+        }
 
-		foreach($childlessArray as $k => $category) {
-			$count = 0;
-			$lastCategory = $actCategory = (int) $category;
+        foreach($childlessArray as $k => $category) {
+            $count = 0;
+            $lastCategory = $actCategory = (int) $category;
             $lastDepth = 0;
 
-			// determine the highest parent
-			while(
-				$lastCategory &&
-				empty($categoryArray[$lastCategory]['depth']) &&
-				$count < 20
-			) {
-				$count++;
-				$lastCategory = (int) $categoryArray[$lastCategory]['parent_category'];
-			}
+            // determine the highest parent
+            while(
+                $lastCategory &&
+                empty($categoryArray[$lastCategory]['depth']) &&
+                $count < 20
+            ) {
+                $count++;
+                $lastCategory = (int) $categoryArray[$lastCategory]['parent_category'];
+            }
 
             if ($lastCategory > 0) {
                 if (!isset($categoryArray[$lastCategory]['depth'])) {
@@ -161,122 +161,122 @@ abstract class tx_ttproducts_catlist_view_base implements \TYPO3\CMS\Core\Single
                 }
                 $lastDepth = $categoryArray[$lastCategory]['depth'];
             }
-			$depth = $lastDepth + $count;
-			// now write the calculated count into the fields
-			$lastCategory = $actCategory;
+            $depth = $lastDepth + $count;
+            // now write the calculated count into the fields
+            $lastCategory = $actCategory;
 
-			while(
-				$lastCategory &&
-				isset($categoryArray[$lastCategory]) &&
-				empty($categoryArray[$lastCategory]['depth'])
-			) {
-				$categoryArray[$lastCategory]['depth'] = $depth--;
-				$lastCategory = (int) $categoryArray[$lastCategory]['parent_category'];
-			}
-		}
+            while(
+                $lastCategory &&
+                isset($categoryArray[$lastCategory]) &&
+                empty($categoryArray[$lastCategory]['depth'])
+            ) {
+                $categoryArray[$lastCategory]['depth'] = $depth--;
+                $lastCategory = (int) $categoryArray[$lastCategory]['parent_category'];
+            }
+        }
 
-		foreach ($categoryArray as $uid => $row) {
+        foreach ($categoryArray as $uid => $row) {
             $depth = intval($row['depth']);
             if (!isset($catArray[$depth])) {
                 $catArray[$depth] = [];
             }
             $catArray[$depth][] = $uid;
-		}
-		ksort($catArray);
-	}
+        }
+        ksort($catArray);
+    }
 
 
-	public function getTableConfArray () {
-		return $this->tableConfArray;
-	}
+    public function getTableConfArray () {
+        return $this->tableConfArray;
+    }
 
 
-	public function setTableConfArray ($tableConfArray) {
-		$this->tableConfArray = $tableConfArray;
-	}
+    public function setTableConfArray ($tableConfArray) {
+        $this->tableConfArray = $tableConfArray;
+    }
 
 
-	public function getViewConfArray () {
-		return $this->viewConfArray;
-	}
+    public function getViewConfArray () {
+        return $this->viewConfArray;
+    }
 
 
-	public function setViewConfArray ($viewConfArray) {
-		$this->viewConfArray = $viewConfArray;
-	}
+    public function setViewConfArray ($viewConfArray) {
+        $this->viewConfArray = $viewConfArray;
+    }
 
 
-	public function getTemplateMarkers (&$t) {
-		if (is_array($this->tMarkers)) {
-			$rc = $this->tMarkers;
-		} else {
-			$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-			$rc = $markerObj->getAllMarkers($t['listFrameWork']);
-			$this->setTemplateMarkers($rc);
-		}
-		return $rc;
-	}
+    public function getTemplateMarkers (&$t) {
+        if (is_array($this->tMarkers)) {
+            $rc = $this->tMarkers;
+        } else {
+            $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+            $rc = $markerObj->getAllMarkers($t['listFrameWork']);
+            $this->setTemplateMarkers($rc);
+        }
+        return $rc;
+    }
 
 
-	protected function setTemplateMarkers (&$tMarkers) {
-		$this->tMarkers = $tMarkers;
-	}
+    protected function setTemplateMarkers (&$tMarkers) {
+        $this->tMarkers = $tMarkers;
+    }
 
 
-	public function getFrameWork (
-		&$t,
-		&$templateCode,
-		$area
-	) {
+    public function getFrameWork (
+        &$t,
+        &$templateCode,
+        $area
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$subpart = $subpartmarkerObj->spMarker('###' . $area . '###');
-		$t['listFrameWork'] = $templateService->getSubpart($templateCode,$subpart);
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $subpart = $subpartmarkerObj->spMarker('###' . $area . '###');
+        $t['listFrameWork'] = $templateService->getSubpart($templateCode,$subpart);
 
-				// add Global Marker Array
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-		$t['listFrameWork'] = $templateService->substituteMarkerArrayCached($t['listFrameWork'], $globalMarkerArray);
+                // add Global Marker Array
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $t['listFrameWork'] = $templateService->substituteMarkerArrayCached($t['listFrameWork'], $globalMarkerArray);
 
-		if ($t['listFrameWork']) {
-			$t['categoryFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###CATEGORY_SINGLE###');
+        if ($t['listFrameWork']) {
+            $t['categoryFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###CATEGORY_SINGLE###');
 
 //		###SUBCATEGORY_A_1###
-			$t['linkCategoryFrameWork'] = $templateService->getSubpart($t['categoryFrameWork'], '###LINK_CATEGORY###');
-		}
-	}
+            $t['linkCategoryFrameWork'] = $templateService->getSubpart($t['categoryFrameWork'], '###LINK_CATEGORY###');
+        }
+    }
 
 
-	public function getBrowserMarkerArray (
-		&$markerArray,
-		&$t,
-		$resCount,
-		$limit,
-		$maxPages,
-		$imageArray,
-		$imageActiveArray
-	) {
+    public function getBrowserMarkerArray (
+        &$markerArray,
+        &$t,
+        $resCount,
+        $limit,
+        $maxPages,
+        $imageArray,
+        $imageActiveArray
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class); 
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
         $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
 
-		$t['browseFrameWork'] = $templateService->getSubpart($t['listFrameWork'], $subpartmarkerObj->spMarker('###LINK_BROWSE###'));
-		$markerArray['###BROWSE_LINKS###']='';
+        $t['browseFrameWork'] = $templateService->getSubpart($t['listFrameWork'], $subpartmarkerObj->spMarker('###LINK_BROWSE###'));
+        $markerArray['###BROWSE_LINKS###']='';
 
-		if (!empty($t['browseFrameWork'])) {
-			$pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
-			$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-			$tableConfArray = $this->getTableConfArray();
-			$piVars = tx_ttproducts_model_control::getPiVars();
-			$browserConf = [];
-			if (
-				isset($tableConfArray['view.']) && $tableConfArray['view.']['browser'] == 'div2007' && isset($tableConfArray['view.']['browser.'])
-			) {
-				$browserConf = $tableConfArray['view.']['browser.'];
-			}
-			
+        if (!empty($t['browseFrameWork'])) {
+            $pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
+            $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+            $tableConfArray = $this->getTableConfArray();
+            $piVars = tx_ttproducts_model_control::getPiVars();
+            $browserConf = [];
+            if (
+                isset($tableConfArray['view.']) && $tableConfArray['view.']['browser'] == 'div2007' && isset($tableConfArray['view.']['browser.'])
+            ) {
+                $browserConf = $tableConfArray['view.']['browser.'];
+            }
+            
             if (
                 isset($browserConf) &&
                 is_array($browserConf)
@@ -289,115 +289,115 @@ abstract class tx_ttproducts_catlist_view_base implements \TYPO3\CMS\Core\Single
                 }
             }
 
-			$pagefloat = 0;
-			$browseObj = GeneralUtility::makeInstance(\JambageCom\Div2007\Base\BrowserBase::class);
-			$browseObj->init(
-				$conf,
-				$piVars,
-				[],
-				false,	// no autocache used yet
-				tx_ttproducts_control_pibase::$pi_USER_INT_obj,
-				$resCount,
-				$limit,
-				10000,
-				$bShowFirstLast,
-				false,
-				$pagefloat,
-				$imageArray,
-				$imageActiveArray,
-				$dontLinkActivePage
-			);
-			$markerArray['###BROWSE_LINKS###'] =
-				BrowserUtility::render(
-					$browseObj,
-					$languageObj,
-					$pibaseObj->cObj,
-					$parameterApi->getPrefixId(),
-					true,
-					1,
-					'',
-					$browserConf
-				);
-			$wrappedSubpartArray['###LINK_BROWSE###'] = ['', ''];
-		}
-	}
+            $pagefloat = 0;
+            $browseObj = GeneralUtility::makeInstance(\JambageCom\Div2007\Base\BrowserBase::class);
+            $browseObj->init(
+                $conf,
+                $piVars,
+                [],
+                false,	// no autocache used yet
+                tx_ttproducts_control_pibase::$pi_USER_INT_obj,
+                $resCount,
+                $limit,
+                10000,
+                $bShowFirstLast,
+                false,
+                $pagefloat,
+                $imageArray,
+                $imageActiveArray,
+                $dontLinkActivePage
+            );
+            $markerArray['###BROWSE_LINKS###'] =
+                BrowserUtility::render(
+                    $browseObj,
+                    $languageObj,
+                    $pibaseObj->cObj,
+                    $parameterApi->getPrefixId(),
+                    true,
+                    1,
+                    '',
+                    $browserConf
+                );
+            $wrappedSubpartArray['###LINK_BROWSE###'] = ['', ''];
+        }
+    }
 
 
-	// returns the category view arrays
-	protected function getPrintViewArrays (
-		$functablename,
-		&$templateCode,
-		&$t,
-		&$htmlParts,
-		$theCode,
-		&$error_code,
-		$templateArea,
-		$pageAsCategory,
-		$templateSuffix,
-		$basketExtra,
-		$basketRecs,
-		&$currentCat,
-		&$categoryArray,
-		&$catArray,
-		&$activeRootline,
-		&$rootpathArray,
-		&$subCategoryMarkerArray,
-		&$ctrlArray
-	 ) {
-		$pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$rc = true;
-		$mode = '';
-		$allowedCats = '';
+    // returns the category view arrays
+    protected function getPrintViewArrays (
+        $functablename,
+        &$templateCode,
+        &$t,
+        &$htmlParts,
+        $theCode,
+        &$error_code,
+        $templateArea,
+        $pageAsCategory,
+        $templateSuffix,
+        $basketExtra,
+        $basketRecs,
+        &$currentCat,
+        &$categoryArray,
+        &$catArray,
+        &$activeRootline,
+        &$rootpathArray,
+        &$subCategoryMarkerArray,
+        &$ctrlArray
+     ) {
+        $pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $rc = true;
+        $mode = '';
+        $allowedCats = '';
 
-		$this->getFrameWork($t, $templateCode, $templateArea . $templateSuffix);
-		$checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
-		$piVars = tx_ttproducts_model_control::getPiVars();
+        $this->getFrameWork($t, $templateCode, $templateArea . $templateSuffix);
+        $checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
+        $piVars = tx_ttproducts_model_control::getPiVars();
 
-		if (!empty($checkExpression)) {
-			$wrongPounds = preg_match_all($checkExpression, $t['listFrameWork'], $matches);
+        if (!empty($checkExpression)) {
+            $wrongPounds = preg_match_all($checkExpression, $t['listFrameWork'], $matches);
 
-			if ($wrongPounds) {
-				$error_code[0] = 'template_invalid_marker_border';
-				$error_code[1] = '###' . $templateArea . $templateSuffix . '###';
-				$error_code[2] = htmlspecialchars(implode('|', $matches['0']));
+            if ($wrongPounds) {
+                $error_code[0] = 'template_invalid_marker_border';
+                $error_code[1] = '###' . $templateArea . $templateSuffix . '###';
+                $error_code[2] = htmlspecialchars(implode('|', $matches['0']));
 
-				return false;
-			}
-		}
+                return false;
+            }
+        }
 
-		$bUseFilter = false;
-		$ctrlArray['bUseBrowser'] = false;
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $bUseFilter = false;
+        $ctrlArray['bUseBrowser'] = false;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		$functableArray = [$functablename];
-		$tableConfArray = [];
-		$viewConfArray = [];
-		$searchVars = $piVars[tx_ttproducts_model_control::getSearchboxVar()] ?? '';
-		tx_ttproducts_model_control::getTableConfArrays(
-			$pibaseObj->cObj,
-			$functableArray,
-			$theCode,
-			$tableConfArray,
-			$viewConfArray
-		);
+        $functableArray = [$functablename];
+        $tableConfArray = [];
+        $viewConfArray = [];
+        $searchVars = $piVars[tx_ttproducts_model_control::getSearchboxVar()] ?? '';
+        tx_ttproducts_model_control::getTableConfArrays(
+            $pibaseObj->cObj,
+            $functableArray,
+            $theCode,
+            $tableConfArray,
+            $viewConfArray
+        );
 
-		$categoryTable = $tablesObj->get($functablename, 0);
-		$tablename = $categoryTable->getTablename();
-		$aliasPostfix = '';
-		$alias = $categoryTable->getAlias() . $aliasPostfix;
-		$categoryTable->clear();
-		$tableConf = $tableConfArray[$functablename];
-		$categoryTable->initCodeConf($theCode, $tableConf);
-		$this->setTableConfArray($tableConfArray);
-		$this->setViewConfArray($viewConfArray);
+        $categoryTable = $tablesObj->get($functablename, 0);
+        $tablename = $categoryTable->getTablename();
+        $aliasPostfix = '';
+        $alias = $categoryTable->getAlias() . $aliasPostfix;
+        $categoryTable->clear();
+        $tableConf = $tableConfArray[$functablename];
+        $categoryTable->initCodeConf($theCode, $tableConf);
+        $this->setTableConfArray($tableConfArray);
+        $this->setViewConfArray($viewConfArray);
 
-		$searchboxWhere = '';
-		$bUseSearchboxArray = [];
-		$sqlTableArray = [];
-		$sqlTableIndex = 0;
-		$latest = '';
-		if (!empty($searchVars)) {
+        $searchboxWhere = '';
+        $bUseSearchboxArray = [];
+        $sqlTableArray = [];
+        $sqlTableIndex = 0;
+        $latest = '';
+        if (!empty($searchVars)) {
             tx_ttproducts_model_control::getSearchInfo(
                 $this->cObj,
                 $searchVars,
@@ -409,304 +409,304 @@ abstract class tx_ttproducts_catlist_view_base implements \TYPO3\CMS\Core\Single
                 $sqlTableIndex,
                 $latest
             );
-		}
-		$orderBy = $GLOBALS['TYPO3_DB']->stripOrderBy($tableConf['orderBy']);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        }
+        $orderBy = $GLOBALS['TYPO3_DB']->stripOrderBy($tableConf['orderBy']);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		if (empty($error_code) && $t['listFrameWork'] && is_object($categoryTable)) {
+        if (empty($error_code) && $t['listFrameWork'] && is_object($categoryTable)) {
 //		###SUBCATEGORY_A_1###
-			$subCategoryMarkerArray = [];
-			$catArray = [];
-			$dataArray = '';
-			$offset = 0;
-			$depth = 0;
-			$allMarkers = $this->getTemplateMarkers($t);
+            $subCategoryMarkerArray = [];
+            $catArray = [];
+            $dataArray = '';
+            $offset = 0;
+            $depth = 0;
+            $allMarkers = $this->getTemplateMarkers($t);
 
-			if (!empty($allMarkers['BROWSE_LINKS'])) {
-				$ctrlArray['bUseBrowser'] = true;
-			}
+            if (!empty($allMarkers['BROWSE_LINKS'])) {
+                $ctrlArray['bUseBrowser'] = true;
+            }
 
-			while(($pos = strpos($t['linkCategoryFrameWork'], '###SUBCATEGORY_', $offset)) !== false) {
-				if (($posEnd = strpos($t['linkCategoryFrameWork'], '###', $pos + 1)) !== false) {
-					$marker = substr($t['linkCategoryFrameWork'], $pos + 3, $posEnd - $pos - 3);
-					$tmpArray = explode('_', $marker);
-					$count = count($tmpArray);
-					if ($count) {
-						$theDepth = intval($tmpArray[$count-1]);
-						if ($theDepth > $depth) {
-							$depth = $theDepth;
-						}
-						$subCategoryMarkerArray[$theDepth] = $marker;
-					}
-				}
-				$offset = $pos+1;
-			}
-			$subpartArray = [];
-			$subpartArray['###LINK_CATEGORY###'] = '###CATEGORY_TMP###';
-			$tmp = $templateService->substituteMarkerArrayCached($t['categoryFrameWork'], [],$subpartArray);
-			$htmlParts = GeneralUtility::trimExplode('###CATEGORY_TMP###', $tmp);
-			$rootCat = $categoryTable->getRootCat() ?? '';
-			$currentCat = $categoryTable->getParamDefault($theCode, $piVars[tx_ttproducts_model_control::getPiVar($functablename)] ?? '');
+            while(($pos = strpos($t['linkCategoryFrameWork'], '###SUBCATEGORY_', $offset)) !== false) {
+                if (($posEnd = strpos($t['linkCategoryFrameWork'], '###', $pos + 1)) !== false) {
+                    $marker = substr($t['linkCategoryFrameWork'], $pos + 3, $posEnd - $pos - 3);
+                    $tmpArray = explode('_', $marker);
+                    $count = count($tmpArray);
+                    if ($count) {
+                        $theDepth = intval($tmpArray[$count-1]);
+                        if ($theDepth > $depth) {
+                            $depth = $theDepth;
+                        }
+                        $subCategoryMarkerArray[$theDepth] = $marker;
+                    }
+                }
+                $offset = $pos+1;
+            }
+            $subpartArray = [];
+            $subpartArray['###LINK_CATEGORY###'] = '###CATEGORY_TMP###';
+            $tmp = $templateService->substituteMarkerArrayCached($t['categoryFrameWork'], [],$subpartArray);
+            $htmlParts = GeneralUtility::trimExplode('###CATEGORY_TMP###', $tmp);
+            $rootCat = $categoryTable->getRootCat() ?? '';
+            $currentCat = $categoryTable->getParamDefault($theCode, $piVars[tx_ttproducts_model_control::getPiVar($functablename)] ?? '');
 
-			$startCat = $currentCat;
-			if (strpos($theCode, 'SELECT') !== false) {
-				$startCat = 0;
-			}
+            $startCat = $currentCat;
+            if (strpos($theCode, 'SELECT') !== false) {
+                $startCat = 0;
+            }
 
-			if ($pageAsCategory && $functablename == 'pages') {
-				$excludeCat = $pibaseObj->cObj->data['pages'];
+            if ($pageAsCategory && $functablename == 'pages') {
+                $excludeCat = $pibaseObj->cObj->data['pages'];
 
-				if (!$rootCat) {
-					$rootCat = $excludeCat;
-				}
-			} else {
-				if (
-					isset($tableConf['special.']['all']) &&
-					$startCat == $tableConf['special.']['all']
-				) {
-					$mode = 'all';
-				}
+                if (!$rootCat) {
+                    $rootCat = $excludeCat;
+                }
+            } else {
+                if (
+                    isset($tableConf['special.']['all']) &&
+                    $startCat == $tableConf['special.']['all']
+                ) {
+                    $mode = 'all';
+                }
 
-				$where_clause = '';
-				if (
-					isset($tableConf['filter.']['where.']['field.']) &&
-					is_array($tableConf['filter.']['where.']['field.'])
-				) {
-					foreach ($tableConf['filter.']['where.']['field.'] as $field => $value) {
+                $where_clause = '';
+                if (
+                    isset($tableConf['filter.']['where.']['field.']) &&
+                    is_array($tableConf['filter.']['where.']['field.'])
+                ) {
+                    foreach ($tableConf['filter.']['where.']['field.'] as $field => $value) {
 
-						if (trim($value) != '') {
-							$where_clause =
-								tx_ttproducts_model_control::getWhereByFields(
-									$tablename,
-									$alias,
-									'',
-									$field,
-									$value,
-									$tableConf['filter.']['delimiter.']['field.'][$field]
-								);
-						}
-					}
-				}
+                        if (trim($value) != '') {
+                            $where_clause =
+                                tx_ttproducts_model_control::getWhereByFields(
+                                    $tablename,
+                                    $alias,
+                                    '',
+                                    $field,
+                                    $value,
+                                    $tableConf['filter.']['delimiter.']['field.'][$field]
+                                );
+                        }
+                    }
+                }
 
-				if ($searchboxWhere != '') {
-					if ($where_clause != '') {
-						$where_clause = '(' . $where_clause . ') AND (' . $searchboxWhere.')';
-					} else {
-						$where_clause = $searchboxWhere;
-					}
-				}
+                if ($searchboxWhere != '') {
+                    if ($where_clause != '') {
+                        $where_clause = '(' . $where_clause . ') AND (' . $searchboxWhere.')';
+                    } else {
+                        $where_clause = $searchboxWhere;
+                    }
+                }
 
-				if ($rootCat != '' && $where_clause != '') {
-					$where_clause .= ' OR ' . $alias . '.uid IN (' . $rootCat . ')';
-				}
+                if ($rootCat != '' && $where_clause != '') {
+                    $where_clause .= ' OR ' . $alias . '.uid IN (' . $rootCat . ')';
+                }
 
-				if (
-					isset($tableConf['filter.']['param.']['cat']) &&
-					$tableConf['filter.']['param.']['cat'] == 'gp'
-				) {
-					$bUseFilter = true;
-					if ($mode == 'all') {
-						$tmpRowArray = $dataArray = $categoryTable->get('0');
-						unset($tmpRowArray[$startCat]);
-						$childArray = array_keys($tmpRowArray);
-					} else {
-						$childArray = $categoryTable->getChildCategoryArray($startCat);
-					}
-					$allowedCatArray = [];
+                if (
+                    isset($tableConf['filter.']['param.']['cat']) &&
+                    $tableConf['filter.']['param.']['cat'] == 'gp'
+                ) {
+                    $bUseFilter = true;
+                    if ($mode == 'all') {
+                        $tmpRowArray = $dataArray = $categoryTable->get('0');
+                        unset($tmpRowArray[$startCat]);
+                        $childArray = array_keys($tmpRowArray);
+                    } else {
+                        $childArray = $categoryTable->getChildCategoryArray($startCat);
+                    }
+                    $allowedCatArray = [];
 
-					foreach ($childArray as $k => $cat) {
-						$bIsSpecial = $categoryTable->hasSpecialConf($cat, $theCode, 'no');
+                    foreach ($childArray as $k => $cat) {
+                        $bIsSpecial = $categoryTable->hasSpecialConf($cat, $theCode, 'no');
 
-						if (!$bIsSpecial) {
-							$dataArray =
-								$categoryTable->get(
-									$cat,
-									$this->pidListObj->getPidlist(),
-									true,
-									'',
-									'',
-									$orderBy
-								);	// read all categories
+                        if (!$bIsSpecial) {
+                            $dataArray =
+                                $categoryTable->get(
+                                    $cat,
+                                    $this->pidListObj->getPidlist(),
+                                    true,
+                                    '',
+                                    '',
+                                    $orderBy
+                                );	// read all categories
 
-							if ($depth && !$tableConf['onlyChildsOfCurrent']) {
-								$subChildArray = $categoryTable->getChildCategoryArray($cat);
-								foreach ($subChildArray as $k2 => $subCat) {
-									$categoryTable->get(
-										$subCat,
-										$this->pidListObj->getPidlist()
-									);	// read the sub categories
-								}
-							}
-							$allowedCatArray[] = $cat;
-						}
-					}
-					$rootCat = $startCat;
-					if (
-						MathUtility::canBeInterpretedAsInteger($rootCat)
-					) {
-						$allowedCatArray[] = $rootCat;
-					}
+                            if ($depth && !$tableConf['onlyChildsOfCurrent']) {
+                                $subChildArray = $categoryTable->getChildCategoryArray($cat);
+                                foreach ($subChildArray as $k2 => $subCat) {
+                                    $categoryTable->get(
+                                        $subCat,
+                                        $this->pidListObj->getPidlist()
+                                    );	// read the sub categories
+                                }
+                            }
+                            $allowedCatArray[] = $cat;
+                        }
+                    }
+                    $rootCat = $startCat;
+                    if (
+                        MathUtility::canBeInterpretedAsInteger($rootCat)
+                    ) {
+                        $allowedCatArray[] = $rootCat;
+                    }
 
-					$allowedCats = implode(',', $allowedCatArray);
-					$excludeCat = $rootCat;
-				} else if ($tableConf['onlyChildsOfCurrent']) {
-					$pids = $this->pidListObj->getPidlist();
-					if (!$rootCat) {
-						$rootCat =
-							$categoryTable->getAllChildCats(
-								$pids,
-								$orderBy,
-								''
-							);
-						if ($rootCat == '') {
-							$rootCat = 0;
-						}
-					}
-					$relatedArray =
-						$categoryTable->getRelated(
-							$rootCat,
-							$startCat,
-							$pids,
-							$orderBy
-						);	// read only related categories
-				} else if ($tableConf['rootChildsOfCurrent']) {
-					$pids = $this->pidListObj->getPidlist();
-					$childrenCat =
-						$categoryTable->getAllChildCats(
-							$pids,
-							$orderBy,
-							$startCat
-						);
+                    $allowedCats = implode(',', $allowedCatArray);
+                    $excludeCat = $rootCat;
+                } else if ($tableConf['onlyChildsOfCurrent']) {
+                    $pids = $this->pidListObj->getPidlist();
+                    if (!$rootCat) {
+                        $rootCat =
+                            $categoryTable->getAllChildCats(
+                                $pids,
+                                $orderBy,
+                                ''
+                            );
+                        if ($rootCat == '') {
+                            $rootCat = 0;
+                        }
+                    }
+                    $relatedArray =
+                        $categoryTable->getRelated(
+                            $rootCat,
+                            $startCat,
+                            $pids,
+                            $orderBy
+                        );	// read only related categories
+                } else if ($tableConf['rootChildsOfCurrent']) {
+                    $pids = $this->pidListObj->getPidlist();
+                    $childrenCat =
+                        $categoryTable->getAllChildCats(
+                            $pids,
+                            $orderBy,
+                            $startCat
+                        );
 
-					if ($childrenCat == '') {
-						$rootCat = 0;
-						if ($tableConf['stickIfNoChild']) {
-							$parentRow = $categoryTable->getParent($startCat);
-							if (is_array($parentRow)) {
-								$parentCat = $parentRow['uid'];
-								$rootCat =
-									$categoryTable->getAllChildCats(
-										$pids,
-										$orderBy,
-										$parentCat
-									);
-							}
-						} else {
-							$rootCat = '';
-						}
-					} else {
-						if (
-							!$rootCat ||
-							$startCat
-						) {
-							$rootCat = $childrenCat;
-						} else {
-							$rootCatArray = explode(',', $rootCat);
-							$childrenCatArray = explode(',', $childrenCat);
-							$rootCatArray = array_intersect($rootCatArray, $childrenCatArray);
-							$rootCat = implode(',', $rootCatArray);
-						}
-					}
+                    if ($childrenCat == '') {
+                        $rootCat = 0;
+                        if ($tableConf['stickIfNoChild']) {
+                            $parentRow = $categoryTable->getParent($startCat);
+                            if (is_array($parentRow)) {
+                                $parentCat = $parentRow['uid'];
+                                $rootCat =
+                                    $categoryTable->getAllChildCats(
+                                        $pids,
+                                        $orderBy,
+                                        $parentCat
+                                    );
+                            }
+                        } else {
+                            $rootCat = '';
+                        }
+                    } else {
+                        if (
+                            !$rootCat ||
+                            $startCat
+                        ) {
+                            $rootCat = $childrenCat;
+                        } else {
+                            $rootCatArray = explode(',', $rootCat);
+                            $childrenCatArray = explode(',', $childrenCat);
+                            $rootCatArray = array_intersect($rootCatArray, $childrenCatArray);
+                            $rootCat = implode(',', $rootCatArray);
+                        }
+                    }
 
-					$relatedArray =
-						$categoryTable->getRelated(
-							$rootCat,
-							0,
-							$pids,
-							$orderBy
-						);	// read only related categories
-				} else {
-					// read in all categories
-					$latest = ($latest ? $latest : '');
-					$relatedArray =
-						$categoryTable->get(
-							'',
-							$this->pidListObj->getPidlist(),
-							true,
-							$where_clause,
-							'',
-							$orderBy,
-							$latest,
-							'',
-							false,
-							$aliasPostfix
-						);	// read all categories
-					$excludeCat = 0;
-				}
+                    $relatedArray =
+                        $categoryTable->getRelated(
+                            $rootCat,
+                            0,
+                            $pids,
+                            $orderBy
+                        );	// read only related categories
+                } else {
+                    // read in all categories
+                    $latest = ($latest ? $latest : '');
+                    $relatedArray =
+                        $categoryTable->get(
+                            '',
+                            $this->pidListObj->getPidlist(),
+                            true,
+                            $where_clause,
+                            '',
+                            $orderBy,
+                            $latest,
+                            '',
+                            false,
+                            $aliasPostfix
+                        );	// read all categories
+                    $excludeCat = 0;
+                }
 
-				if (!empty($relatedArray)) {
- 					$excludeCat = 0;
-					$categoryTable->translateByFields($relatedArray, $theCode);
- 				}
+                if (!empty($relatedArray)) {
+                    $excludeCat = 0;
+                    $categoryTable->translateByFields($relatedArray, $theCode);
+                }
 
-				if (
+                if (
                     isset($tableConf['special.']) &&
                     is_array($tableConf['special.']) && 
                     strlen($tableConf['special.']['no'])
                 ) {
-					$excludeCat = $tableConf['special.']['no'];
-				}
-			} // if ($pageAsCategory && $functablename == 'pages')
-			if ($functablename == 'pages') {
-				$allowedCats = $this->pidListObj->getPidlist($rootCat);
-			}
+                    $excludeCat = $tableConf['special.']['no'];
+                }
+            } // if ($pageAsCategory && $functablename == 'pages')
+            if ($functablename == 'pages') {
+                $allowedCats = $this->pidListObj->getPidlist($rootCat);
+            }
 
-			$categoryArray =
-				$categoryTable->getRelationArray(
-					$relatedArray,
-					$excludeCat,
-					$rootCat,
-					$allowedCats
-				);
-			$rootpathArray =
-				$categoryTable->getRootpathArray(
-					$categoryArray,
-					$rootCat,
-					$startCat
-				);
-			$rootArray =
-				$categoryTable->getRootArray(
-					$rootCat,
-					$categoryArray,
-					!isset($tableConf['autoRoot']) || $tableConf['autoRoot']
-				);
-			$activeRootline =
-				$this->getActiveRootline(
-					$startCat,
-					$categoryArray
-				);
-			$this->setDepths($categoryArray, $catArray, $rootArray);
-			$depth = 1;
-			if ($bUseFilter) {
-				$catArray[(int) $depth] = $allowedCatArray;
-			}
+            $categoryArray =
+                $categoryTable->getRelationArray(
+                    $relatedArray,
+                    $excludeCat,
+                    $rootCat,
+                    $allowedCats
+                );
+            $rootpathArray =
+                $categoryTable->getRootpathArray(
+                    $categoryArray,
+                    $rootCat,
+                    $startCat
+                );
+            $rootArray =
+                $categoryTable->getRootArray(
+                    $rootCat,
+                    $categoryArray,
+                    !isset($tableConf['autoRoot']) || $tableConf['autoRoot']
+                );
+            $activeRootline =
+                $this->getActiveRootline(
+                    $startCat,
+                    $categoryArray
+                );
+            $this->setDepths($categoryArray, $catArray, $rootArray);
+            $depth = 1;
+            if ($bUseFilter) {
+                $catArray[(int) $depth] = $allowedCatArray;
+            }
 
-			if ($ctrlArray['bUseBrowser']) {
-				$ctrlArray['limit'] = $this->config['limit'];
-				$this->getBrowserMarkerArray(
-					$browseMarkerArray,
-					$t,
-					count($categoryArray) - count($rootArray),
-					$ctrlArray['limit'],
-					$maxPages,
-					[],
-					[]
-				);
-				$t['listFrameWork'] = $templateService->substituteMarkerArrayCached($t['listFrameWork'], $browseMarkerArray);
-			}
-		} else if (!$t['listFrameWork']) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$error_code[0] = 'no_subtemplate';
-			$error_code[1] = '###' . $templateArea . $templateSuffix . '###';
-			$error_code[2] = $templateObj->getTemplateFile();
-			$rc = false;
-		} else if (!is_object($categoryTable)) {
-			$error_code[0] = 'internal_error';
-			$error_code[1] = 'TTP_1';
-			$error_code[2] = $functablename;
-			$rc = false;
-		}
-		return $rc;
-	} // printView
+            if ($ctrlArray['bUseBrowser']) {
+                $ctrlArray['limit'] = $this->config['limit'];
+                $this->getBrowserMarkerArray(
+                    $browseMarkerArray,
+                    $t,
+                    count($categoryArray) - count($rootArray),
+                    $ctrlArray['limit'],
+                    $maxPages,
+                    [],
+                    []
+                );
+                $t['listFrameWork'] = $templateService->substituteMarkerArrayCached($t['listFrameWork'], $browseMarkerArray);
+            }
+        } else if (!$t['listFrameWork']) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $error_code[0] = 'no_subtemplate';
+            $error_code[1] = '###' . $templateArea . $templateSuffix . '###';
+            $error_code[2] = $templateObj->getTemplateFile();
+            $rc = false;
+        } else if (!is_object($categoryTable)) {
+            $error_code[0] = 'internal_error';
+            $error_code[1] = 'TTP_1';
+            $error_code[2] = $functablename;
+            $rc = false;
+        }
+        return $rc;
+    } // printView
 }
 

--- a/view/class.tx_ttproducts_control_view.php
+++ b/view/class.tx_ttproducts_control_view.php
@@ -41,76 +41,76 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_control_view {
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a country
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	array		marker array
-	 * @return	array
-	 * @access private
-	 */
-	function getMarkerArray (&$markerArray, &$allMarkers, $tableConfArray) {
-		if (isset($tableConfArray) && is_array($tableConfArray)) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a country
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	array		marker array
+     * @return	array
+     * @access private
+     */
+    function getMarkerArray (&$markerArray, &$allMarkers, $tableConfArray) {
+        if (isset($tableConfArray) && is_array($tableConfArray)) {
             $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-			$allValueArray = [];
-			$controlArray = tx_ttproducts_model_control::getControlArray();
-			$separator = ';';
+            $allValueArray = [];
+            $controlArray = tx_ttproducts_model_control::getControlArray();
+            $separator = ';';
 
-			foreach ($tableConfArray as $functablename => $tableConf) {
+            foreach ($tableConfArray as $functablename => $tableConf) {
 
-				if (isset($tableConf['view.']) && is_array($tableConf['view.'])) {
-					foreach ($tableConf['view.'] as $type => $typeConf) {
+                if (isset($tableConf['view.']) && is_array($tableConf['view.'])) {
+                    foreach ($tableConf['view.'] as $type => $typeConf) {
 
-						if (is_array($typeConf)) {
-							$type = substr($type,0,strpos($type,'.'));
-							foreach ($typeConf as $numberx => $numberConf) {
-								$number = substr($numberx, 0, strpos($numberx, '.'));
-								$markerkey = strtoupper($type) . $number;
-								if (!empty($allMarkers[$markerkey])) {
-									$allValueArray[$type . $separator . $number] = $numberConf;
-								}
-							}
-						}
-					}
-				}
-			}
+                        if (is_array($typeConf)) {
+                            $type = substr($type,0,strpos($type,'.'));
+                            foreach ($typeConf as $numberx => $numberConf) {
+                                $number = substr($numberx, 0, strpos($numberx, '.'));
+                                $markerkey = strtoupper($type) . $number;
+                                if (!empty($allMarkers[$markerkey])) {
+                                    $allValueArray[$type . $separator . $number] = $numberConf;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			if (isset($allValueArray) && is_array($allValueArray)) {
+            if (isset($allValueArray) && is_array($allValueArray)) {
 
-				foreach ($allValueArray as $key => $xValueArray) {
-					$keyArray = GeneralUtility::trimExplode($separator, $key);
-					$type = $keyArray[0];
-					$valueArray = tx_ttproducts_form_div::fetchValueArray($xValueArray['valueArray.']);
-					$attributeArray = $xValueArray['attribute.'];
+                foreach ($allValueArray as $key => $xValueArray) {
+                    $keyArray = GeneralUtility::trimExplode($separator, $key);
+                    $type = $keyArray[0];
+                    $valueArray = tx_ttproducts_form_div::fetchValueArray($xValueArray['valueArray.']);
+                    $attributeArray = $xValueArray['attribute.'];
 
-					if (in_array($type, ['sortSelect', 'filterSelect'])) {
-						$out = tx_ttproducts_form_div::createSelect(
-							$languageObj,
-							$valueArray,
-							tx_ttproducts_model_control::getPrefixId() . '[' . tx_ttproducts_model_control::getControlVar() . '][' . $keyArray[0] . '][' . $keyArray[1] . ']',
-							$controlArray[$keyArray[0]][$keyArray[1]],
-							true,
-							true,
-							[],
-							'select',
-							$attributeArray,
-							''
-						);
-					} else if ($type == 'filterInput') {
-						$out = tx_ttproducts_form_div::createTag(
-							'input',
-							tx_ttproducts_model_control::getPrefixId() . '[' . tx_ttproducts_model_control::getControlVar() . '][' . $keyArray[0] . '][' . $keyArray[1] . ']',
-							$controlArray[$keyArray[0]][$keyArray[1]],
-							$attributeArray
-						);
-					}
-					$markerkey = strtoupper($keyArray[0]  . $keyArray[1]);
-					$markerArray['###' . $markerkey . '_LABEL###'] = $xValueArray['label'];
-					$markerArray['###' . $markerkey . '###'] = $out;
-				}
-			}
-		}
-	} // function getMarkerArray
+                    if (in_array($type, ['sortSelect', 'filterSelect'])) {
+                        $out = tx_ttproducts_form_div::createSelect(
+                            $languageObj,
+                            $valueArray,
+                            tx_ttproducts_model_control::getPrefixId() . '[' . tx_ttproducts_model_control::getControlVar() . '][' . $keyArray[0] . '][' . $keyArray[1] . ']',
+                            $controlArray[$keyArray[0]][$keyArray[1]],
+                            true,
+                            true,
+                            [],
+                            'select',
+                            $attributeArray,
+                            ''
+                        );
+                    } else if ($type == 'filterInput') {
+                        $out = tx_ttproducts_form_div::createTag(
+                            'input',
+                            tx_ttproducts_model_control::getPrefixId() . '[' . tx_ttproducts_model_control::getControlVar() . '][' . $keyArray[0] . '][' . $keyArray[1] . ']',
+                            $controlArray[$keyArray[0]][$keyArray[1]],
+                            $attributeArray
+                        );
+                    }
+                    $markerkey = strtoupper($keyArray[0]  . $keyArray[1]);
+                    $markerArray['###' . $markerkey . '_LABEL###'] = $xValueArray['label'];
+                    $markerArray['###' . $markerkey . '###'] = $out;
+                }
+            }
+        }
+    } // function getMarkerArray
 }
 

--- a/view/class.tx_ttproducts_country_view.php
+++ b/view/class.tx_ttproducts_country_view.php
@@ -41,15 +41,15 @@
 
 class tx_ttproducts_country_view extends tx_ttproducts_table_base_view {
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a country
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	array		marker array
-	 * @return	array
-	 * @access private
-	 */
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a country
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	array		marker array
+     * @return	array
+     * @access private
+     */
     public function getRowMarkers (&$markerArray, $prefix, $row) {
 
         $thePrefix = $prefix . '_' . $this->getMarker() . '_';

--- a/view/class.tx_ttproducts_dam_view.php
+++ b/view/class.tx_ttproducts_dam_view.php
@@ -38,17 +38,17 @@
 
 
 class tx_ttproducts_dam_view extends tx_ttproducts_article_base_view {
-	public $marker = 'DAM';
-	public $piVar = 'dam';
+    public $marker = 'DAM';
+    public $piVar = 'dam';
 
 
-	/**
-	 * Sets the markers for DAM specific FORM fields
-	 *
-	 */
-	public function setFormMarkerArray($uid, &$markerArray) {
-		$markerArray['###DAM_FIELD_NAME###'] = 'ttp_basket[dam]';
-		$markerArray['###DAM_UID###'] = intval($uid);
-	}
+    /**
+     * Sets the markers for DAM specific FORM fields
+     *
+     */
+    public function setFormMarkerArray($uid, &$markerArray) {
+        $markerArray['###DAM_FIELD_NAME###'] = 'ttp_basket[dam]';
+        $markerArray['###DAM_UID###'] = intval($uid);
+    }
 }
 

--- a/view/class.tx_ttproducts_damcategory_view.php
+++ b/view/class.tx_ttproducts_damcategory_view.php
@@ -40,7 +40,7 @@
 
 
 class tx_ttproducts_damcategory_view extends tx_ttproducts_category_view {
-	public $piVar = 'damcat';
+    public $piVar = 'damcat';
 
 }
 

--- a/view/class.tx_ttproducts_download_view.php
+++ b/view/class.tx_ttproducts_download_view.php
@@ -43,55 +43,55 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_download_view extends tx_ttproducts_article_base_view {
-	public $marker = 'DOWNLOAD';
+    public $marker = 'DOWNLOAD';
 
-	/**
-	 * Generates a radio or selector box for download
-	 */
-	public function generateRadioSelect (
-		$theCode,
-		$row
-	) {
-	}
+    /**
+     * Generates a radio or selector box for download
+     */
+    public function generateRadioSelect (
+        $theCode,
+        $row
+    ) {
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	array		Returns a markerArray ready for substitution with information
-	 * @access private
-	 */
-	public function getDownloadMarkerSubpartArrays (
-		$templateCode,
-		$conf,
-		$rowArray,
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$parentMarker,
-		$tagArray,
-		$hiddenFields,
-		$multiOrderArray,
-		$productRowArray,
-		$checkPriceZero = false
-	) {
-		$error = false;
-		$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-		$cObj->start([]);
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$functablename = 'tt_products';
-		$itemTableView = $tablesObj->get($functablename, true);
-		$itemTable = $itemTableView->getModelObj();
-		$orderObj = $tablesObj->get('sys_products_orders');
-		$variantSeparator = $itemTable->getVariant()->getSplitSeparator();
-		$t = [];
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	array		Returns a markerArray ready for substitution with information
+     * @access private
+     */
+    public function getDownloadMarkerSubpartArrays (
+        $templateCode,
+        $conf,
+        $rowArray,
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $parentMarker,
+        $tagArray,
+        $hiddenFields,
+        $multiOrderArray,
+        $productRowArray,
+        $checkPriceZero = false
+    ) {
+        $error = false;
+        $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+        $cObj->start([]);
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $functablename = 'tt_products';
+        $itemTableView = $tablesObj->get($functablename, true);
+        $itemTable = $itemTableView->getModelObj();
+        $orderObj = $tablesObj->get('sys_products_orders');
+        $variantSeparator = $itemTable->getVariant()->getSplitSeparator();
+        $t = [];
 
-		if (isset($tagArray['DOWNLOAD_SINGLE'])) {
-			$t['item'] = $templateService->getSubpart($templateCode, '###DOWNLOAD_SINGLE###');
-		}
+        if (isset($tagArray['DOWNLOAD_SINGLE'])) {
+            $t['item'] = $templateService->getSubpart($templateCode, '###DOWNLOAD_SINGLE###');
+        }
 
 // 			<!-- ###DOWNLOAD_SINGLE### begin -->
 // 				###DOWNLOAD_TITLE###
@@ -101,282 +101,282 @@ class tx_ttproducts_download_view extends tx_ttproducts_article_base_view {
 // 			<!-- ###DOWNLOAD_SINGLE### end -->
 
 
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$postVar = tx_ttproducts_control_command::getCommandVar();
-		$downloadVar = tx_ttproducts_model_control::getPiVar($this->getModelObj()->getFuncTablename());
-		$bAddonsEM = ExtensionManagementUtility::isLoaded('addons_em');
-		tx_ttproducts_control_access::getVariables(
-			$conf,
-			$updateCode,
-			$bIsAllowed,
-			$bValidUpdateCode,
-			$trackingCode
-		);
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $postVar = tx_ttproducts_control_command::getCommandVar();
+        $downloadVar = tx_ttproducts_model_control::getPiVar($this->getModelObj()->getFuncTablename());
+        $bAddonsEM = ExtensionManagementUtility::isLoaded('addons_em');
+        tx_ttproducts_control_access::getVariables(
+            $conf,
+            $updateCode,
+            $bIsAllowed,
+            $bValidUpdateCode,
+            $trackingCode
+        );
 
-		$subpartArray['###DOWNLOAD_SINGLE###'] = '';
+        $subpartArray['###DOWNLOAD_SINGLE###'] = '';
 
-		if (
-			isset($rowArray) &&
-			is_array($rowArray) &&
-			count($rowArray)
-		) {		
-			foreach ($rowArray as $k => $row) {
-				$content = '';
-				$marker = $parentMarker . '_' . $this->getMarker() . '_' . strtoupper($row['marker']);
+        if (
+            isset($rowArray) &&
+            is_array($rowArray) &&
+            count($rowArray)
+        ) {		
+            foreach ($rowArray as $k => $row) {
+                $content = '';
+                $marker = $parentMarker . '_' . $this->getMarker() . '_' . strtoupper($row['marker']);
 
-				$selectValueArray = [];
-				$selectedKey = 0;
-				$productUid = 0;
+                $selectValueArray = [];
+                $selectedKey = 0;
+                $productUid = 0;
 
-				if (
-					isset($productRowArray) &&
-					is_array($productRowArray) &&
-					count($productRowArray)
-				) {
-					$productUid = $productRowArray['0']['uid'];
+                if (
+                    isset($productRowArray) &&
+                    is_array($productRowArray) &&
+                    count($productRowArray)
+                ) {
+                    $productUid = $productRowArray['0']['uid'];
 
-					foreach ($productRowArray as $productRow) {
+                    foreach ($productRowArray as $productRow) {
 
-						$selectValueArray = $itemTable->getEditVariant()->getVariantRowFromProductRow($productRow);
-					}
+                        $selectValueArray = $itemTable->getEditVariant()->getVariantRowFromProductRow($productRow);
+                    }
 
-					if (is_array($selectValueArray) && count($selectValueArray)) {
-						sort($selectValueArray, SORT_STRING);
-					}
-				}
+                    if (is_array($selectValueArray) && count($selectValueArray)) {
+                        sort($selectValueArray, SORT_STRING);
+                    }
+                }
 
-				$selectOut = '';
-				$selectedDomain = '';
-				$markerSelect = $marker . '_SELECT';
+                $selectOut = '';
+                $selectedDomain = '';
+                $markerSelect = $marker . '_SELECT';
 
-				if (is_array($selectValueArray) && count($selectValueArray) && isset($selectValueArray['edit_domain'])) {
-					$piVars = tx_ttproducts_model_control::getPiVars();
-					$domainVar = 'domain';
-					$piVar = $domainVar;
+                if (is_array($selectValueArray) && count($selectValueArray) && isset($selectValueArray['edit_domain'])) {
+                    $piVars = tx_ttproducts_model_control::getPiVars();
+                    $domainVar = 'domain';
+                    $piVar = $domainVar;
 
-					$tagName = tx_ttproducts_model_control::getPrefixId() . '[' . $piVar . '][' . $productUid . '][' . $row['uid'] . ']';
+                    $tagName = tx_ttproducts_model_control::getPrefixId() . '[' . $piVar . '][' . $productUid . '][' . $row['uid'] . ']';
 
-					if (
-						isset($piVars[$piVar]) &&
-						is_array($piVars[$piVar]) &&
-						isset($piVars[$piVar][$productUid]) &&
-						is_array($piVars[$piVar][$productUid]) &&
-						isset($piVars[$piVar][$productUid][$row['uid']])
-					) {
-						$selectedKey = $piVars[$piVar][$productUid][$row['uid']];
-					}
+                    if (
+                        isset($piVars[$piVar]) &&
+                        is_array($piVars[$piVar]) &&
+                        isset($piVars[$piVar][$productUid]) &&
+                        is_array($piVars[$piVar][$productUid]) &&
+                        isset($piVars[$piVar][$productUid][$row['uid']])
+                    ) {
+                        $selectedKey = $piVars[$piVar][$productUid][$row['uid']];
+                    }
 
-					$selectedDomain = $selectValueArray[$selectedKey];
+                    $selectedDomain = $selectValueArray[$selectedKey];
 
-					if (isset($tagArray[$markerSelect])) {
-						$selectOut = tx_ttproducts_form_div::createSelect(
-							$languageObj,
-							$selectValueArray,
-							$tagName,
-							$selectedKey,
-							true,
-							true,
-							[],
-							'select',
-							['title' => 'Auswahl der Domäne', 'onchange' => 'submit();']
-						);
-					}
-				}
+                    if (isset($tagArray[$markerSelect])) {
+                        $selectOut = tx_ttproducts_form_div::createSelect(
+                            $languageObj,
+                            $selectValueArray,
+                            $tagName,
+                            $selectedKey,
+                            true,
+                            true,
+                            [],
+                            'select',
+                            ['title' => 'Auswahl der Domäne', 'onchange' => 'submit();']
+                        );
+                    }
+                }
 
-				$markerArray['###HIDDENFIELDS###'] = $hiddenFields;
+                $markerArray['###HIDDENFIELDS###'] = $hiddenFields;
 
-				if (isset($tagArray[$markerSelect])) {
-					$markerArray['###' . $markerSelect . '###'] = $selectOut;
-				}
+                if (isset($tagArray[$markerSelect])) {
+                    $markerArray['###' . $markerSelect . '###'] = $selectOut;
+                }
 
 // hier die Select Box für die Auswahl der Domäne zum Download
 
-				if ($bAddonsEM) {
-					$fileArray = $this->getModelObj()->getFileArray(
+                if ($bAddonsEM) {
+                    $fileArray = $this->getModelObj()->getFileArray(
                         $orderObj,
-						$row,
-						$multiOrderArray,
-						$checkPriceZero
-					);
-					if (empty($fileArray)) { // If there is no file to download, then skip the whole download object
-						continue;
-					}
+                        $row,
+                        $multiOrderArray,
+                        $checkPriceZero
+                    );
+                    if (empty($fileArray)) { // If there is no file to download, then skip the whole download object
+                        continue;
+                    }
 
                     $path = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/';
-					$path = $path . $row['path'] . '/';
+                    $path = $path . $row['path'] . '/';
 
-					// $directLink = TYPO3_SITE_SCRIPT;
-					$paramArray = [];
-					if ($bValidUpdateCode) {
-						$paramArray['update_code'] = $updateCode;
-					} else if ($trackingCode != '') {
-						$paramArray['tracking'] = $trackingCode;
-					}
+                    // $directLink = TYPO3_SITE_SCRIPT;
+                    $paramArray = [];
+                    if ($bValidUpdateCode) {
+                        $paramArray['update_code'] = $updateCode;
+                    } else if ($trackingCode != '') {
+                        $paramArray['tracking'] = $trackingCode;
+                    }
 
-					$prefixId = tx_ttproducts_model_control::getPrefixId();
-					$paramArray[$prefixId . '[' . $downloadVar . ']'] = $row['uid'];
+                    $prefixId = tx_ttproducts_model_control::getPrefixId();
+                    $paramArray[$prefixId . '[' . $downloadVar . ']'] = $row['uid'];
 
-					if ($selectedDomain != '') {
-						$paramArray[$prefixId . '[' . $domainVar . ']'] = $selectedDomain;
-					}
-					$orderUid = 0;
+                    if ($selectedDomain != '') {
+                        $paramArray[$prefixId . '[' . $domainVar . ']'] = $selectedDomain;
+                    }
+                    $orderUid = 0;
 
-					if (
-						isset($multiOrderArray) &&
-						is_array($multiOrderArray) &&
-						count($multiOrderArray)
-					) {
-						$currentOrderUid = 0;
-						foreach($multiOrderArray as $orderRow) {
-							if (
+                    if (
+                        isset($multiOrderArray) &&
+                        is_array($multiOrderArray) &&
+                        count($multiOrderArray)
+                    ) {
+                        $currentOrderUid = 0;
+                        foreach($multiOrderArray as $orderRow) {
+                            if (
                                 isset($orderRow['edit_variants']) &&
-								strlen($orderRow['edit_variants']) &&
-								strpos($orderRow['edit_variants'], 'domain:') !== false
-							) {
+                                strlen($orderRow['edit_variants']) &&
+                                strpos($orderRow['edit_variants'], 'domain:') !== false
+                            ) {
 // andere Varianten erlauben
-								$editVariants =
-									preg_split(
-										'/[\h]*' . $variantSeparator . '[\h]*/',
-										$orderRow['edit_variants'],
-										-1,
-										PREG_SPLIT_NO_EMPTY
-									);
+                                $editVariants =
+                                    preg_split(
+                                        '/[\h]*' . $variantSeparator . '[\h]*/',
+                                        $orderRow['edit_variants'],
+                                        -1,
+                                        PREG_SPLIT_NO_EMPTY
+                                    );
 
                                 if (
                                     $selectedDomain != '' && 
                                     is_array($editVariants) &&
                                     count($editVariants)
                                 ) {
-									$editVariantComparator = 'domain:' . $selectedDomain;
-									foreach($editVariants as $editVariant) {
+                                    $editVariantComparator = 'domain:' . $selectedDomain;
+                                    foreach($editVariants as $editVariant) {
 
-										if ($editVariant == $editVariantComparator) {
-											$orderUid = $orderRow['uid'];
-											break;
-										}
-									}
-									if ($orderUid) {
-										break;
-									}
-								}
-							} else {
-								$currentOrderUid = $orderRow['uid'];
-							}
-						}
-						if (!$orderUid && $bValidUpdateCode) {
-							$orderUid = $currentOrderUid;
-						}
-					}
+                                        if ($editVariant == $editVariantComparator) {
+                                            $orderUid = $orderRow['uid'];
+                                            break;
+                                        }
+                                    }
+                                    if ($orderUid) {
+                                        break;
+                                    }
+                                }
+                            } else {
+                                $currentOrderUid = $orderRow['uid'];
+                            }
+                        }
+                        if (!$orderUid && $bValidUpdateCode) {
+                            $orderUid = $currentOrderUid;
+                        }
+                    }
 
-					$orderPivar = tx_ttproducts_model_control::getPiVar('sys_products_orders');
+                    $orderPivar = tx_ttproducts_model_control::getPiVar('sys_products_orders');
 
-					if ($orderUid) {
-						$paramArray[$prefixId . '[' . $orderPivar . ']'] = $orderUid;
-					}
+                    if ($orderUid) {
+                        $paramArray[$prefixId . '[' . $orderPivar . ']'] = $orderUid;
+                    }
 
                     $downloadImageFile = PathUtility::getAbsoluteWebPath(ExtensionManagementUtility::extPath(TT_PRODUCTS_EXT) . 'Resources/Public/Icons/system-extension-download.png');
             
-					foreach ($fileArray as $k => $file) {
-						if ($file != $path) {
-							if (substr($file, -1) == '/') {
-								// $extKey
-								$paramArray[$postVar . '[download]'] = $k;
+                    foreach ($fileArray as $k => $file) {
+                        if ($file != $path) {
+                            if (substr($file, -1) == '/') {
+                                // $extKey
+                                $paramArray[$postVar . '[download]'] = $k;
 
-								$url = FrontendUtility::getTypoLink_URL(
-									$cObj,
-									$GLOBALS['TSFE']->id,
-									$paramArray
-								);
-								$foldername = basename($file);
+                                $url = FrontendUtility::getTypoLink_URL(
+                                    $cObj,
+                                    $GLOBALS['TSFE']->id,
+                                    $paramArray
+                                );
+                                $foldername = basename($file);
 
-								$content .= '<a href="' . htmlspecialchars($url) . '" title="' .
-									$GLOBALS['TSFE']->sL(DIV2007_LANGUAGE_PATH . 'locallang_common.xlf:download') . ' ' . $foldername . '">' .
-								$foldername . '<img src="' . $downloadImageFile . '">' . '</a>';
-							} else {
-								$paramArray[$postVar . '[fal]'] = $k;
-								$url = FrontendUtility::getTypoLink_URL(
-									$cObj,
-									$GLOBALS['TSFE']->id,
-									$paramArray
-								);
-								$filename = basename($file);
+                                $content .= '<a href="' . htmlspecialchars($url) . '" title="' .
+                                    $GLOBALS['TSFE']->sL(DIV2007_LANGUAGE_PATH . 'locallang_common.xlf:download') . ' ' . $foldername . '">' .
+                                $foldername . '<img src="' . $downloadImageFile . '">' . '</a>';
+                            } else {
+                                $paramArray[$postVar . '[fal]'] = $k;
+                                $url = FrontendUtility::getTypoLink_URL(
+                                    $cObj,
+                                    $GLOBALS['TSFE']->id,
+                                    $paramArray
+                                );
+                                $filename = basename($file);
 
-								$content .= '<a href="' . htmlspecialchars($url) . '" title="' .
-									$GLOBALS['TSFE']->sL(DIV2007_LANGUAGE_PATH . 'locallang_common.xlf:download') . ' ' . $filename . '">' . $filename . '<img src="' . $downloadImageFile . '">' . '</a>';
-							}
-						}
-					}
-				} else {
-					$content = 'error: "addons_em" has not been installed';
-					$error = true;
-				}
+                                $content .= '<a href="' . htmlspecialchars($url) . '" title="' .
+                                    $GLOBALS['TSFE']->sL(DIV2007_LANGUAGE_PATH . 'locallang_common.xlf:download') . ' ' . $filename . '">' . $filename . '<img src="' . $downloadImageFile . '">' . '</a>';
+                            }
+                        }
+                    }
+                } else {
+                    $content = 'error: "addons_em" has not been installed';
+                    $error = true;
+                }
 
-				if (isset($tagArray[$marker])) {
-					$markerArray['###' . $marker . '###'] = $content;
-				} else if ($error) {
-					$subpartArray['###DOWNLOAD_SINGLE###'] .= $content;
-				} else if ($t['item'] != '') {
-	// 			<!-- ###DOWNLOAD_SINGLE### begin -->
-	// 				###DOWNLOAD_TITLE###
-	// 				###DOWNLOAD_NOTE###
-	// 				###DOWNLOAD_LINK###
-	// 				<br/>
-	// 			<!-- ###DOWNLOAD_SINGLE### end -->
+                if (isset($tagArray[$marker])) {
+                    $markerArray['###' . $marker . '###'] = $content;
+                } else if ($error) {
+                    $subpartArray['###DOWNLOAD_SINGLE###'] .= $content;
+                } else if ($t['item'] != '') {
+    // 			<!-- ###DOWNLOAD_SINGLE### begin -->
+    // 				###DOWNLOAD_TITLE###
+    // 				###DOWNLOAD_NOTE###
+    // 				###DOWNLOAD_LINK###
+    // 				<br/>
+    // 			<!-- ###DOWNLOAD_SINGLE### end -->
 
-					$downloadMarker = $this->getMarker();
-					$markerLink = $downloadMarker . '_' . strtoupper('link');
+                    $downloadMarker = $this->getMarker();
+                    $markerLink = $downloadMarker . '_' . strtoupper('link');
 
-					if (isset($tagArray[$markerLink])) {
-						$markerArray['###' . $markerLink . '###'] = $content;
-					}
+                    if (isset($tagArray[$markerLink])) {
+                        $markerArray['###' . $markerLink . '###'] = $content;
+                    }
 
-					$fieldArray = ['author', 'edition', 'note', 'title'];
+                    $fieldArray = ['author', 'edition', 'note', 'title'];
 
-					foreach ($fieldArray as $field) {
-						$fieldMarker = $downloadMarker . '_' . strtoupper($field);
+                    foreach ($fieldArray as $field) {
+                        $fieldMarker = $downloadMarker . '_' . strtoupper($field);
 
-						if (isset($tagArray[$fieldMarker])) {
-							$value = $row[$field];
-							if ($field == 'note') {
-								$value = ($conf['nl2brNote'] ? nl2br($value) : $value);
+                        if (isset($tagArray[$fieldMarker])) {
+                            $value = $row[$field];
+                            if ($field == 'note') {
+                                $value = ($conf['nl2brNote'] ? nl2br($value) : $value);
 
-									// Extension CSS styled content
-								if (ExtensionManagementUtility::isLoaded('css_styled_content')) {
-									$value =
-										FrontendUtility::RTEcssText(
-											$cObj,
-											$value
-										);
-								} else if (is_array($conf['parseFunc.'])) {
-									$value =
-										$cObj->parseFunc(
-											$value,
-											$conf['parseFunc.']
-										);
-								}
-							}
-							$markerArray['###' . $fieldMarker . '###'] = $value;
-						}
-					}
+                                    // Extension CSS styled content
+                                if (ExtensionManagementUtility::isLoaded('css_styled_content')) {
+                                    $value =
+                                        FrontendUtility::RTEcssText(
+                                            $cObj,
+                                            $value
+                                        );
+                                } else if (is_array($conf['parseFunc.'])) {
+                                    $value =
+                                        $cObj->parseFunc(
+                                            $value,
+                                            $conf['parseFunc.']
+                                        );
+                                }
+                            }
+                            $markerArray['###' . $fieldMarker . '###'] = $value;
+                        }
+                    }
 
-					$out = $templateService->substituteMarkerArrayCached($t['item'], $markerArray);
+                    $out = $templateService->substituteMarkerArrayCached($t['item'], $markerArray);
 
-					$subpartArray['###DOWNLOAD_SINGLE###'] .= $out;
-				}
-			}
-		} else {
-		// mothing
-		}
+                    $subpartArray['###DOWNLOAD_SINGLE###'] .= $out;
+                }
+            }
+        } else {
+        // mothing
+        }
 
-		$this->setMarkersEmpty(
-			$tagArray,
-			[$parentMarker . '_' . $this->getMarker()],
-			$markerArray
-		);
+        $this->setMarkersEmpty(
+            $tagArray,
+            [$parentMarker . '_' . $this->getMarker()],
+            $markerArray
+        );
 
-		if (!isset($subpartArray['###DOWNLOAD_SINGLE###'])) {
-			$wrappedSubpartArray['###DOWNLOAD_SINGLE###'] = ['', ''];
-		}
-	}
+        if (!isset($subpartArray['###DOWNLOAD_SINGLE###'])) {
+            $wrappedSubpartArray['###DOWNLOAD_SINGLE###'] = ['', ''];
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_edit_variant_dummy_view.php
+++ b/view/class.tx_ttproducts_edit_variant_dummy_view.php
@@ -40,20 +40,20 @@
 
 class tx_ttproducts_edit_variant_dummy_view implements tx_ttproducts_edit_variant_view_int, \TYPO3\CMS\Core\SingletonInterface {
 
-	public function init($modelObj) {
-	}
+    public function init($modelObj) {
+    }
 
-	public function getSubpartMarkerArray (
-		$templateCode,
-		$functablename,
-		$row,
-		$theCode,
-		$bEditable,
-		$tagArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
-	}
+    public function getSubpartMarkerArray (
+        $templateCode,
+        $functablename,
+        $row,
+        $theCode,
+        $bEditable,
+        $tagArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
+    }
 
 }
 

--- a/view/class.tx_ttproducts_edit_variant_view.php
+++ b/view/class.tx_ttproducts_edit_variant_view.php
@@ -42,163 +42,163 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_edit_variant_view implements tx_ttproducts_edit_variant_view_int, \TYPO3\CMS\Core\SingletonInterface {
 
-	protected $modelObj;
+    protected $modelObj;
 
-	public function init ($modelObj) {
-		$this->modelObj = $modelObj;
-	}
+    public function init ($modelObj) {
+        $this->modelObj = $modelObj;
+    }
 
-	public function getModelObj () {
-		return $this->modelObj;
-	}
+    public function getModelObj () {
+        return $this->modelObj;
+    }
 
-	public function getMarkerArray (
-		$bEditable,
-		$row,
-		$functablename,
-		$theCode,
-		$config,
-		&$markerArray
-	) {
-		if (isset($config) && is_array($config)) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$itemTableView = $tablesObj->get($functablename, true);
-			$uid = $row['uid'];
-			$mainAttributes = '';
+    public function getMarkerArray (
+        $bEditable,
+        $row,
+        $functablename,
+        $theCode,
+        $config,
+        &$markerArray
+    ) {
+        if (isset($config) && is_array($config)) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $itemTableView = $tablesObj->get($functablename, true);
+            $uid = $row['uid'];
+            $mainAttributes = '';
 
-			if (isset($config['params'])) {
-				$mainAttributes = $config['params'];
-			}
+            if (isset($config['params'])) {
+                $mainAttributes = $config['params'];
+            }
 
-			if (isset($config['suffix'])) {
-				$suffix = '_' . $config['suffix'];
-			} else {
-				$suffix = $config['index'];
-			}
-			$field = 'edit' . $suffix;
-			$name = tx_ttproducts_control_basket::getTagName($row['uid'], $field);
-			$value = '';
-			if (isset($row[$field])) {
-				$value = $row[$field];
-			}
+            if (isset($config['suffix'])) {
+                $suffix = '_' . $config['suffix'];
+            } else {
+                $suffix = $config['index'];
+            }
+            $field = 'edit' . $suffix;
+            $name = tx_ttproducts_control_basket::getTagName($row['uid'], $field);
+            $value = '';
+            if (isset($row[$field])) {
+                $value = $row[$field];
+            }
 
-			if ($bEditable) {
-				$basketExtRaw = tx_ttproducts_control_basket::getBasketExtRaw();
-				if (isset($basketExtRaw) && is_array($basketExtRaw)) {
-					if (isset($basketExtRaw[$uid]) && is_array($basketExtRaw[$uid])) {
-						$value = $basketExtRaw[$uid][$field];
-					}
-				}
+            if ($bEditable) {
+                $basketExtRaw = tx_ttproducts_control_basket::getBasketExtRaw();
+                if (isset($basketExtRaw) && is_array($basketExtRaw)) {
+                    if (isset($basketExtRaw[$uid]) && is_array($basketExtRaw[$uid])) {
+                        $value = $basketExtRaw[$uid][$field];
+                    }
+                }
 
-				$ajaxFunction = tx_ttproducts_control_basket::getAjaxVariantFunction($row, $functablename, $theCode);
-				$splitArray = preg_split('/ *= */', $mainAttributes);
-				$mainAttributesArray = [];
+                $ajaxFunction = tx_ttproducts_control_basket::getAjaxVariantFunction($row, $functablename, $theCode);
+                $splitArray = preg_split('/ *= */', $mainAttributes);
+                $mainAttributesArray = [];
 
-				if (isset($splitArray) && is_array($splitArray)) {
-					$lastKey = 0;
-					$lastAttribute = '';
-					$switch = 'read_key';
+                if (isset($splitArray) && is_array($splitArray)) {
+                    $lastKey = 0;
+                    $lastAttribute = '';
+                    $switch = 'read_key';
 
-					foreach ($splitArray as $v) {
-						if (
-							($switch == 'read_value') &&
-							preg_match('/".*"/', $v)
-						) {
-							$mainAttributesArray[$lastAttribute] = str_replace('"', '', $v);
-							$switch = 'read_key';
-						} else {
-							$lastAttribute = strtolower($v);
-							if ($switch == 'read_value') {
-								$mainAttributesArray[$lastAttribute] = '';
-							}
-							$switch = 'read_value';
-						}
-					}
-				}
+                    foreach ($splitArray as $v) {
+                        if (
+                            ($switch == 'read_value') &&
+                            preg_match('/".*"/', $v)
+                        ) {
+                            $mainAttributesArray[$lastAttribute] = str_replace('"', '', $v);
+                            $switch = 'read_key';
+                        } else {
+                            $lastAttribute = strtolower($v);
+                            if ($switch == 'read_value') {
+                                $mainAttributesArray[$lastAttribute] = '';
+                            }
+                            $switch = 'read_value';
+                        }
+                    }
+                }
 
-				if (!isset($mainAttributesArray['onchange'])) {
-					$mainAttributesArray['onchange'] = $ajaxFunction;
-				}
+                if (!isset($mainAttributesArray['onchange'])) {
+                    $mainAttributesArray['onchange'] = $ajaxFunction;
+                }
 
-				$mainId = $itemTableView->getId($row, '', $theCode);
-				$id = $mainId . '-' . str_replace('_', '-', $field);
-				$mainAttributesArray['id'] = $id;
+                $mainId = $itemTableView->getId($row, '', $theCode);
+                $id = $mainId . '-' . str_replace('_', '-', $field);
+                $mainAttributesArray['id'] = $id;
 
-				$html = tx_ttproducts_form_div::createTag(
-					'input',
-					$name,
-					$value,
-					'',
-					$mainAttributesArray
-				);
-			} else {
-				$html = '';
-				if (isset($row[$field])) {
-					$html = htmlspecialchars($row[$field], $flags);
-				}
-			}
+                $html = tx_ttproducts_form_div::createTag(
+                    'input',
+                    $name,
+                    $value,
+                    '',
+                    $mainAttributesArray
+                );
+            } else {
+                $html = '';
+                if (isset($row[$field])) {
+                    $html = htmlspecialchars($row[$field], $flags);
+                }
+            }
 
-			$markerArray['###EDIT_VARIANT###'] = $html;
-		}
-	}
+            $markerArray['###EDIT_VARIANT###'] = $html;
+        }
+    }
 
-	public function getSubpartMarkerArray (
-		$templateCode,
-		$functablename,
-		$row,
-		$theCode,
-		$bEditable,
-		$tagArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
+    public function getSubpartMarkerArray (
+        $templateCode,
+        $functablename,
+        $row,
+        $theCode,
+        $bEditable,
+        $tagArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
 // 		###edit_variant1###
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$editConf = $this->getModelObj()->getValidConfig($row);
+        $editConf = $this->getModelObj()->getValidConfig($row);
 
-		if (isset($editConf) && is_array($editConf)) {
+        if (isset($editConf) && is_array($editConf)) {
             $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
 
-			foreach ($editConf as $k => $config) {
-				if (isset($config['suffix'])) {
-					$suffix = '_' . $config['suffix'];
-				} else {
-					$suffix = $config['index'];
-				}
-				$marker = 'edit_variant' . $suffix;
+            foreach ($editConf as $k => $config) {
+                if (isset($config['suffix'])) {
+                    $suffix = '_' . $config['suffix'];
+                } else {
+                    $suffix = $config['index'];
+                }
+                $marker = 'edit_variant' . $suffix;
 
-				if (isset($tagArray[$marker])) {
-					$subpartMarker = '###' . $marker . '###';
-					// $wrappedSubpartArray[$subpartMarker] = '';
-					$markerArray = [];
-					$this->getMarkerArray(
-						$bEditable,
-						$row,
-						$functablename,
-						$theCode,
-						$config,
-						$markerArray
-					);
+                if (isset($tagArray[$marker])) {
+                    $subpartMarker = '###' . $marker . '###';
+                    // $wrappedSubpartArray[$subpartMarker] = '';
+                    $markerArray = [];
+                    $this->getMarkerArray(
+                        $bEditable,
+                        $row,
+                        $functablename,
+                        $theCode,
+                        $config,
+                        $markerArray
+                    );
 
-					$subpartContent = $cObj->getSubpart($templateCode, $subpartMarker);
-					$content =
-						$templateService->substituteMarkerArrayCached(
-							$subpartContent,
-							$markerArray
-						);
-					$subpartArray[$subpartMarker] = $content;
-				}
-			}
-		}
+                    $subpartContent = $cObj->getSubpart($templateCode, $subpartMarker);
+                    $content =
+                        $templateService->substituteMarkerArrayCached(
+                            $subpartContent,
+                            $markerArray
+                        );
+                    $subpartArray[$subpartMarker] = $content;
+                }
+            }
+        }
 
-		foreach ($tagArray as $tag => $number) {
-			if (strpos($tag, 'edit_variant') === 0) {
-				if (!isset($subpartArray['###' . $tag . '###'])) {
+        foreach ($tagArray as $tag => $number) {
+            if (strpos($tag, 'edit_variant') === 0) {
+                if (!isset($subpartArray['###' . $tag . '###'])) {
 
-					$subpartArray['###' . $tag . '###'] = '';
-				}
-			}
-		}
-	}
+                    $subpartArray['###' . $tag . '###'] = '';
+                }
+            }
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_fal_view.php
+++ b/view/class.tx_ttproducts_fal_view.php
@@ -46,8 +46,8 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_fal_view extends tx_ttproducts_article_base_view {
-	public $marker = 'FAL';
-	public $piVar = 'fal';
+    public $marker = 'FAL';
+    public $piVar = 'fal';
 
 
     public function getItemSubpartArrays (

--- a/view/class.tx_ttproducts_fpdf_view.php
+++ b/view/class.tx_ttproducts_fpdf_view.php
@@ -43,130 +43,130 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_fpdf_view {
 
-	/**
-	 * generates the bill as a PDF file
-	 *
-	 * @param	string		reference to an item array with all the data of the item
-	 * @return	string / boolean	returns the absolute filename of the PDF bill or false
-	 * 		 			for the tt_producst record, $row
-	 * @access private
-	 */
-	public function generate (
-		$cObj,
-		$basketView,
-		$infoViewObj,
-		$templateCode,
-		$mainMarkerArray,
-		$itemArray,
-		$calculatedArray,
-		$orderArray,
-		$productRowArray,
-		$basketExtra,
-		$basketRecs,
-		$typeCode,
-		$generationConf,
-		$absFileName
-	) {
-		$result = false;
-		$renderCharset = 'UTF-8';
+    /**
+     * generates the bill as a PDF file
+     *
+     * @param	string		reference to an item array with all the data of the item
+     * @return	string / boolean	returns the absolute filename of the PDF bill or false
+     * 		 			for the tt_producst record, $row
+     * @access private
+     */
+    public function generate (
+        $cObj,
+        $basketView,
+        $infoViewObj,
+        $templateCode,
+        $mainMarkerArray,
+        $itemArray,
+        $calculatedArray,
+        $orderArray,
+        $productRowArray,
+        $basketExtra,
+        $basketRecs,
+        $typeCode,
+        $generationConf,
+        $absFileName
+    ) {
+        $result = false;
+        $renderCharset = 'UTF-8';
 
 // require_once '/path/to/src/PhpWord/Autoloader.php';
 // \PhpOffice\PhpWord\Autoloader::register();
 
-		$subpart = $typeCode . '_PDF_HEADER_TEMPLATE';
-		$header = $basketView->getView(
-			$errorCode,
-			$templateCode,
-			$typeCode,
-			$infoViewObj,
-			false,
-			true,
-			$calculatedArray,
-			false,
-			$subpart,
-			$mainMarkerArray,
-			'',
-			$itemArray,
+        $subpart = $typeCode . '_PDF_HEADER_TEMPLATE';
+        $header = $basketView->getView(
+            $errorCode,
+            $templateCode,
+            $typeCode,
+            $infoViewObj,
+            false,
+            true,
+            $calculatedArray,
+            false,
+            $subpart,
+            $mainMarkerArray,
+            '',
+            $itemArray,
             $notOverwritePriceIfSet = false,
-			['0' => $orderArray],
-			$productRowArray,
-			$basketExtra,
-			$basketRecs
-		);
-		$subpart = $typeCode . '_PDF_TEMPLATE';
-		$body = $basketView->getView(
-			$errorCode,
-			$templateCode,
-			$typeCode,
-			$infoViewObj,
-			false,
-			true,
-			$calculatedArray,
-			false,
-			$subpart,
-			$mainMarkerArray,
-			'',
-			$itemArray,
+            ['0' => $orderArray],
+            $productRowArray,
+            $basketExtra,
+            $basketRecs
+        );
+        $subpart = $typeCode . '_PDF_TEMPLATE';
+        $body = $basketView->getView(
+            $errorCode,
+            $templateCode,
+            $typeCode,
+            $infoViewObj,
+            false,
+            true,
+            $calculatedArray,
+            false,
+            $subpart,
+            $mainMarkerArray,
+            '',
+            $itemArray,
             $notOverwritePriceIfSet = false,
-			['0' => $orderArray],
-			$basketExtra,
-			$basketRecs
-		);
+            ['0' => $orderArray],
+            $basketExtra,
+            $basketRecs
+        );
 
-		$subpart = $typeCode . '_PDF_FOOTER_TEMPLATE';
-		$footer = $basketView->getView(
-			$errorCode,
-			$templateCode,
-			$typeCode,
-			$infoViewObj,
-			false,
-			true,
-			$calculatedArray,
-			false,
-			$subpart,
-			$mainMarkerArray,
-			'',
-			$itemArray,
+        $subpart = $typeCode . '_PDF_FOOTER_TEMPLATE';
+        $footer = $basketView->getView(
+            $errorCode,
+            $templateCode,
+            $typeCode,
+            $infoViewObj,
+            false,
+            true,
+            $calculatedArray,
+            false,
+            $subpart,
+            $mainMarkerArray,
+            '',
+            $itemArray,
             $notOverwritePriceIfSet = false,
-			['0' => $orderArray],
-			$productRowArray,
-			$basketExtra,
-			$basketRecs
-		);
+            ['0' => $orderArray],
+            $productRowArray,
+            $basketExtra,
+            $basketRecs
+        );
 
-		$csConvObj = GeneralUtility::makeInstance(CharsetConverter::class);
-		$header = $csConvObj->conv(
-			$header,
-			$renderCharset,
-			'iso-8859-1'
-		);
+        $csConvObj = GeneralUtility::makeInstance(CharsetConverter::class);
+        $header = $csConvObj->conv(
+            $header,
+            $renderCharset,
+            'iso-8859-1'
+        );
 
-		$body = $csConvObj->conv(
-			$body,
-			$renderCharset,
-			'iso-8859-1'
-		);
+        $body = $csConvObj->conv(
+            $body,
+            $renderCharset,
+            'iso-8859-1'
+        );
 
-		$footer = $csConvObj->conv(
-			$footer,
-			$renderCharset,
-			'iso-8859-1'
-		);
+        $footer = $csConvObj->conv(
+            $footer,
+            $renderCharset,
+            'iso-8859-1'
+        );
 
-		$pdf = GeneralUtility::makeInstance('tx_ttproducts_fpdf');
-		$pdf->init($cObj, 'Arial', '', 10);
-		$pdf->setHeader($header);
-		$pdf->setFooter($footer);
-		$pdf->AddPage();
-		$pdf->setBody($body);
-		$pdf->Body();
+        $pdf = GeneralUtility::makeInstance('tx_ttproducts_fpdf');
+        $pdf->init($cObj, 'Arial', '', 10);
+        $pdf->setHeader($header);
+        $pdf->setFooter($footer);
+        $pdf->AddPage();
+        $pdf->setBody($body);
+        $pdf->Body();
 
-		//$pdf->MultiCell(0, 4, $body, 1);
-		$pdf->Output($absFileName, 'F');
-		$result = $absFileName;
+        //$pdf->MultiCell(0, 4, $body, 1);
+        $pdf->Output($absFileName, 'F');
+        $result = $absFileName;
 
-		return $result;
-	}
+        return $result;
+    }
 }
 
 

--- a/view/class.tx_ttproducts_graduated_price_view.php
+++ b/view/class.tx_ttproducts_graduated_price_view.php
@@ -41,192 +41,192 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_graduated_price_view extends tx_ttproducts_table_base_view {
-	public $marker = 'GRADPRICE';
+    public $marker = 'GRADPRICE';
 
 
-	private function getFormulaMarkerArray (
-		$basketExtra,
-		$basketRecs,
-		$row,
-		$priceFormula,
-		$bTaxIncluded,
-		$bEnableTaxZero,
-		&$markerArray,
-		$suffix = ''
-	) {
-		if (isset($priceFormula) && is_array($priceFormula)) {
-			$marker = $this->getMarker();
+    private function getFormulaMarkerArray (
+        $basketExtra,
+        $basketRecs,
+        $row,
+        $priceFormula,
+        $bTaxIncluded,
+        $bEnableTaxZero,
+        &$markerArray,
+        $suffix = ''
+    ) {
+        if (isset($priceFormula) && is_array($priceFormula)) {
+            $marker = $this->getMarker();
             $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
             $conf = $cnfObj->getConf();
 
-			$priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
-			$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-			foreach ($priceFormula as $field => $value) {
-				$keyMarker = '###' . $marker . '_' . strtoupper($field) . $suffix . '###';
+            $priceObj = GeneralUtility::makeInstance('tx_ttproducts_field_price');
+            $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+            foreach ($priceFormula as $field => $value) {
+                $keyMarker = '###' . $marker . '_' . strtoupper($field) . $suffix . '###';
                 if (
                     !isset($GLOBALS['TCA'][$this->getModelObj()->getTablename()]['columns'][$field])
                 ) {
                     $value = '';
                 }
-				$markerArray[$keyMarker] = $value;
-			}
+                $markerArray[$keyMarker] = $value;
+            }
 
-			$priceNoTax =
-				$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceFormula['formula'],
-					false,
-					$row,
-					$bTaxIncluded,
-					$bEnableTaxZero
-				);
-			$priceTax =
-				$priceObj->getPrice(
-					$basketExtra,
-					$basketRecs,
-					$priceFormula['formula'],
-					true,
-					$row,
-					$bTaxIncluded,
-					$bEnableTaxZero
-				);
-			$keyMarker = '###' . $marker . '_' . 'PRICE_TAX' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($priceTax);
-			$keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($priceNoTax);
+            $priceNoTax =
+                $priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceFormula['formula'],
+                    false,
+                    $row,
+                    $bTaxIncluded,
+                    $bEnableTaxZero
+                );
+            $priceTax =
+                $priceObj->getPrice(
+                    $basketExtra,
+                    $basketRecs,
+                    $priceFormula['formula'],
+                    true,
+                    $row,
+                    $bTaxIncluded,
+                    $bEnableTaxZero
+                );
+            $keyMarker = '###' . $marker . '_' . 'PRICE_TAX' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($priceTax);
+            $keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($priceNoTax);
 
-			$basePriceTax = $priceObj->getResellerPrice($basketExtra, $basketRecs, $row, 1);
-			$basePriceNoTax = $priceObj->getResellerPrice($basketExtra, $basketRecs, $row, 0);
+            $basePriceTax = $priceObj->getResellerPrice($basketExtra, $basketRecs, $row, 1);
+            $basePriceNoTax = $priceObj->getResellerPrice($basketExtra, $basketRecs, $row, 0);
 
-			if ($basePriceTax) {
-				$skontoTax = ($basePriceTax - $priceTax);
-				$tmpPercentTax = number_format(($skontoTax / $basePriceTax) * 100, $conf['percentDec']);
-				$skontoNoTax = ($basePriceNoTax - $priceNoTax);
-				$tmpPercentNoTax = number_format(($skontoNoTax / $basePriceNoTax) * 100, $conf['percentDec']);
-			} else {
-				$skontoTax = 'total';
-				$skontoNoTax = 'total';
-				$tmpPercentTax = 'infinite';
-				$tmpPercentNoTax = 'infinite';
-			}
+            if ($basePriceTax) {
+                $skontoTax = ($basePriceTax - $priceTax);
+                $tmpPercentTax = number_format(($skontoTax / $basePriceTax) * 100, $conf['percentDec']);
+                $skontoNoTax = ($basePriceNoTax - $priceNoTax);
+                $tmpPercentNoTax = number_format(($skontoNoTax / $basePriceNoTax) * 100, $conf['percentDec']);
+            } else {
+                $skontoTax = 'total';
+                $skontoNoTax = 'total';
+                $tmpPercentTax = 'infinite';
+                $tmpPercentNoTax = 'infinite';
+            }
 
-			$keyMarker = '###' . $marker . '_' . 'PRICE_TAX_DISCOUNT' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($skontoTax);
-			$keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX_DISCOUNT' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($skontoNoTax);
-			$keyMarker = '###' . $marker . '_' . 'PRICE_TAX_DISCOUNT_PERCENT' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($tmpPercentTax);
-			$keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX_DISCOUNT_PERCENT' . $suffix . '###';
-			$markerArray[$keyMarker] = $priceViewObj->priceFormat($tmpPercentNoTax);
-		}
-	}
+            $keyMarker = '###' . $marker . '_' . 'PRICE_TAX_DISCOUNT' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($skontoTax);
+            $keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX_DISCOUNT' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($skontoNoTax);
+            $keyMarker = '###' . $marker . '_' . 'PRICE_TAX_DISCOUNT_PERCENT' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($tmpPercentTax);
+            $keyMarker = '###' . $marker . '_' . 'PRICE_NO_TAX_DISCOUNT_PERCENT' . $suffix . '###';
+            $markerArray[$keyMarker] = $priceViewObj->priceFormat($tmpPercentNoTax);
+        }
+    }
 
-	public function getPriceSubpartArrays (
-		$templateCode,
-		$row,
-		$fieldname,
-		$bTaxIncluded,
-		$bEnableTaxZero,
-		$priceFormulaArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		&$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '1'
-	) {
+    public function getPriceSubpartArrays (
+        $templateCode,
+        $row,
+        $fieldname,
+        $bTaxIncluded,
+        $bEnableTaxZero,
+        $priceFormulaArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        &$tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '1'
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
 
-		$t = [];
-		$t['listFrameWork'] = $templateService->getSubpart($templateCode,'###GRADPRICE_FORMULA_ITEMS###');
-		$t['itemFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###ITEM_FORMULA###');
+        $t = [];
+        $t['listFrameWork'] = $templateService->getSubpart($templateCode,'###GRADPRICE_FORMULA_ITEMS###');
+        $t['itemFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###ITEM_FORMULA###');
 
         if (is_array($priceFormulaArray) && count($priceFormulaArray)) {
-			$content = '';
-			foreach ($priceFormulaArray as $k => $priceFormula) {
-				if (isset($priceFormula) && is_array($priceFormula)) {
-					$itemMarkerArray = [];
-					$this->getFormulaMarkerArray(
-						$basketExtra,
-						$basketRecs,
-						$row,
-						$priceFormula,
-						$bTaxIncluded,
-						$bEnableTaxZero,
-						$itemMarkerArray
-					);
+            $content = '';
+            foreach ($priceFormulaArray as $k => $priceFormula) {
+                if (isset($priceFormula) && is_array($priceFormula)) {
+                    $itemMarkerArray = [];
+                    $this->getFormulaMarkerArray(
+                        $basketExtra,
+                        $basketRecs,
+                        $row,
+                        $priceFormula,
+                        $bTaxIncluded,
+                        $bEnableTaxZero,
+                        $itemMarkerArray
+                    );
 
-					$formulaContent = $templateService->substituteMarkerArray($t['itemFrameWork'], $itemMarkerArray);
-					$content .= $templateService->substituteSubpart($t['listFrameWork'], '###ITEM_FORMULA###', $formulaContent) ;
-				}
-			}
-			$subpartArray['###GRADPRICE_FORMULA_ITEMS###'] = $content;
-		} else {
-			$subpartArray['###GRADPRICE_FORMULA_ITEMS###'] = '';
-		}
+                    $formulaContent = $templateService->substituteMarkerArray($t['itemFrameWork'], $itemMarkerArray);
+                    $content .= $templateService->substituteSubpart($t['listFrameWork'], '###ITEM_FORMULA###', $formulaContent) ;
+                }
+            }
+            $subpartArray['###GRADPRICE_FORMULA_ITEMS###'] = $content;
+        } else {
+            $subpartArray['###GRADPRICE_FORMULA_ITEMS###'] = '';
+        }
 
 //  ###GRADPRICE_PRICE_TAX###. ###GRADPRICE_PRICE_NO_TAX### ###GRADPRICE_PRICE_ONLY_TAX###
 //  ###GRADPRICE_FORMULA1_PRICE_NO_TAX###  ###GRADPRICE_FORMULA1_PRICE_TAX###
-	}
+    }
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getPriceMarkerArray (
-		$row,
-		$bTaxIncluded,
-		$bEnableTaxZero,
-		$basketExtra,
-		$basketRecs,
-		&$markerArray,
-		$tagArray
-	) {
-		if ($this->getModelObj()->hasDiscountPrice($row)) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getPriceMarkerArray (
+        $row,
+        $bTaxIncluded,
+        $bEnableTaxZero,
+        $basketExtra,
+        $basketRecs,
+        &$markerArray,
+        $tagArray
+    ) {
+        if ($this->getModelObj()->hasDiscountPrice($row)) {
 
-			$priceFormulaArray = $this->getModelObj()->getFormulasByItem($row['uid']);
-			foreach ($priceFormulaArray as $k => $priceFormula) {
-				if (isset($priceFormula) && is_array($priceFormula)) {
-					$this->getFormulaMarkerArray(
-						$basketExtra,
-						$basketRecs,
-						$row,
-						$priceFormula,
-						$bTaxIncluded,
-						$bEnableTaxZero,
-						$markerArray,
-						($k + 1)
-					);
-				}
-			}
-		}
+            $priceFormulaArray = $this->getModelObj()->getFormulasByItem($row['uid']);
+            foreach ($priceFormulaArray as $k => $priceFormula) {
+                if (isset($priceFormula) && is_array($priceFormula)) {
+                    $this->getFormulaMarkerArray(
+                        $basketExtra,
+                        $basketRecs,
+                        $row,
+                        $priceFormula,
+                        $bTaxIncluded,
+                        $bEnableTaxZero,
+                        $markerArray,
+                        ($k + 1)
+                    );
+                }
+            }
+        }
 
-		$marker = $this->getMarker();
+        $marker = $this->getMarker();
 
-		// empty all fields with no available entry
-		foreach ($tagArray as $value => $k1) {
-			$keyMarker = '###' . $value . '###';
-			if (
-				strpos($value, $marker . '_') &&
-				!$markerArray[$keyMarker] &&
-				$value != 'GRADPRICE_FORMULA_ITEMS'
-			) {
-				$markerArray[$keyMarker] = '';
-			}
-		}
-	}
+        // empty all fields with no available entry
+        foreach ($tagArray as $value => $k1) {
+            $keyMarker = '###' . $value . '###';
+            if (
+                strpos($value, $marker . '_') &&
+                !$markerArray[$keyMarker] &&
+                $value != 'GRADPRICE_FORMULA_ITEMS'
+            ) {
+                $markerArray[$keyMarker] = '';
+            }
+        }
+    }
 }
 
 

--- a/view/class.tx_ttproducts_info_view.php
+++ b/view/class.tx_ttproducts_info_view.php
@@ -48,179 +48,179 @@ use JambageCom\TtProducts\Api\CustomerApi;
 
 
 class tx_ttproducts_info_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $config;
-	public $infoArray; // elements: 'billing' and 'delivery' addresses
-			// contains former basket $personInfo and $deliveryInfo
+    public $conf;
+    public $config;
+    public $infoArray; // elements: 'billing' and 'delivery' addresses
+            // contains former basket $personInfo and $deliveryInfo
 
-	public $country;			// object of the type tx_table_db
-	public $password;	// automatically generated random password for a new frontend user
-	public $bHasBeenInitialised = false;
-
-
-
-	/**
-	 */
-	public function init ($bProductsPayment, $fixCountry, $basketExtra) {
-
-		$result = true;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
-
-		$this->infoArray = tx_ttproducts_control_basket::getInfoArray();
-
-		tx_ttproducts_control_basket::uncheckAgb(
-			$this->infoArray,
-			$bProductsPayment
-		);
-
-		$this->bHasBeenInitialised = true;
-		return $result;
-	} // init
+    public $country;			// object of the type tx_table_db
+    public $password;	// automatically generated random password for a new frontend user
+    public $bHasBeenInitialised = false;
 
 
-	/**
-	 */
-	public function init2 ($infoArray) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		$this->conf = $cnf->conf;
-		$this->config = $cnf->config;
+    /**
+     */
+    public function init ($bProductsPayment, $fixCountry, $basketExtra) {
 
-		$this->infoArray = $infoArray;
+        $result = true;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		$this->bHasBeenInitialised = true;
-	}
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
 
+        $this->infoArray = tx_ttproducts_control_basket::getInfoArray();
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+        tx_ttproducts_control_basket::uncheckAgb(
+            $this->infoArray,
+            $bProductsPayment
+        );
 
-
-	public function getInfoArray () {
-		return $this->infoArray;
-	}
-
-
-	public function getCustomerEmail () {
-		$result = (
-			$this->conf['orderEmail_toDelivery'] && $this->infoArray['delivery']['email'] ||
-			!$this->infoArray['billing']['email'] ?
-				$this->infoArray['delivery']['email'] :
-				$this->infoArray['billing']['email']
-		); // former: deliveryInfo
-
-		return $result;
-	}
+        $this->bHasBeenInitialised = true;
+        return $result;
+    } // init
 
 
-	/**
-	 * Fills in all empty fields in the delivery info array
-	 */
-	public function mapPersonIntoDelivery ($basketExtra) {
-			// all of the delivery address will be overwritten when no address and no email address have been filled in
-		if (
-			(
-				!trim($this->infoArray['delivery']['address']) &&
-				!trim($this->infoArray['delivery']['email']) ||
-				JambageCom\TtProducts\Api\ControlApi::isOverwriteMode($this->infoArray)
-			) &&
-			tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra)
-		) {
-			$address = trim($this->infoArray['delivery']['address']);
-			$fields = CustomerApi::getFields();
-			$fieldArray = GeneralUtility::trimExplode(',', $fields . ',feusers_uid');
+    /**
+     */
+    public function init2 ($infoArray) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-			foreach($fieldArray as $k => $fName) {
-				if (
-					isset($this->infoArray['billing'][$fName]) &&
-					(
+        $this->conf = $cnf->conf;
+        $this->config = $cnf->config;
+
+        $this->infoArray = $infoArray;
+
+        $this->bHasBeenInitialised = true;
+    }
+
+
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
+
+
+    public function getInfoArray () {
+        return $this->infoArray;
+    }
+
+
+    public function getCustomerEmail () {
+        $result = (
+            $this->conf['orderEmail_toDelivery'] && $this->infoArray['delivery']['email'] ||
+            !$this->infoArray['billing']['email'] ?
+                $this->infoArray['delivery']['email'] :
+                $this->infoArray['billing']['email']
+        ); // former: deliveryInfo
+
+        return $result;
+    }
+
+
+    /**
+     * Fills in all empty fields in the delivery info array
+     */
+    public function mapPersonIntoDelivery ($basketExtra) {
+            // all of the delivery address will be overwritten when no address and no email address have been filled in
+        if (
+            (
+                !trim($this->infoArray['delivery']['address']) &&
+                !trim($this->infoArray['delivery']['email']) ||
+                JambageCom\TtProducts\Api\ControlApi::isOverwriteMode($this->infoArray)
+            ) &&
+            tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra)
+        ) {
+            $address = trim($this->infoArray['delivery']['address']);
+            $fields = CustomerApi::getFields();
+            $fieldArray = GeneralUtility::trimExplode(',', $fields . ',feusers_uid');
+
+            foreach($fieldArray as $k => $fName) {
+                if (
+                    isset($this->infoArray['billing'][$fName]) &&
+                    (
                         !isset($this->infoArray['delivery'][$fName]) ||
-						$this->infoArray['delivery'][$fName] == '' ||
-						(
-							$this->infoArray['delivery'][$fName] == '0' && !$address
-						) ||
+                        $this->infoArray['delivery'][$fName] == '' ||
+                        (
+                            $this->infoArray['delivery'][$fName] == '0' && !$address
+                        ) ||
                         in_array($fName, ['country', 'country_code', 'zone'])
-					)
-				) {
-					$this->infoArray['delivery'][$fName] = $this->infoArray['billing'][$fName];
-				}
-			}
-		}
+                    )
+                ) {
+                    $this->infoArray['delivery'][$fName] = $this->infoArray['billing'][$fName];
+                }
+            }
+        }
 
-		if (
-			isset($this->infoArray['delivery']) &&
-			is_array($this->infoArray['delivery']) &&
-			!isset($this->infoArray['delivery']['name']) &&
-			!isset($this->infoArray['delivery']['last_name']) &&
-			!isset($this->infoArray['delivery']['company'])
-		) {
-			unset($this->infoArray['delivery']['salutation']);
-			if (count($this->infoArray['delivery']) < 3) {
-				unset($this->infoArray['delivery']);
-			}
-		}
+        if (
+            isset($this->infoArray['delivery']) &&
+            is_array($this->infoArray['delivery']) &&
+            !isset($this->infoArray['delivery']['name']) &&
+            !isset($this->infoArray['delivery']['last_name']) &&
+            !isset($this->infoArray['delivery']['company'])
+        ) {
+            unset($this->infoArray['delivery']['salutation']);
+            if (count($this->infoArray['delivery']) < 3) {
+                unset($this->infoArray['delivery']);
+            }
+        }
 
-			// Call info hooks
-		if (
+            // Call info hooks
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['info']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['info'])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['info'] as $classRef) {
-				$hookObj = GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'mapPersonIntoDelivery')) {
-					$hookObj->mapPersonIntoDelivery($this);
-				}
-			}
-		}
-	} // mapPersonIntoDelivery
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['info'] as $classRef) {
+                $hookObj = GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'mapPersonIntoDelivery')) {
+                    $hookObj->mapPersonIntoDelivery($this);
+                }
+            }
+        }
+    } // mapPersonIntoDelivery
 
 
-	/**
-	 * Gets regular Expressions for Field-Checks
-	 */
-	public function getFieldChecks ($type) {
-		$rc = '';
-		$fieldCheckArray = $this->conf['regExCheck.'];
+    /**
+     * Gets regular Expressions for Field-Checks
+     */
+    public function getFieldChecks ($type) {
+        $rc = '';
+        $fieldCheckArray = $this->conf['regExCheck.'];
 
-		$fieldChecks = [];
-		if (isset($fieldCheckArray) && is_array($fieldCheckArray)) {
-			// Array komplett durchlaufen
-			foreach ($fieldCheckArray as $key => $value) {
-				if (isset($value) && is_array($value)) {
-					// spezifischer TS-Eintrag
-					if ($key == $type . '.') {
-						foreach ($value as $key2 => $value2) {
-							$fieldChecks[$key2] = $value2;
-						}
-					}
-				} else {
-					// unspezifischer TS-Eintrag
-					$fieldChecks[$key] = $value;
-				}
-			}
-		}
-		return $fieldChecks;
-	}
+        $fieldChecks = [];
+        if (isset($fieldCheckArray) && is_array($fieldCheckArray)) {
+            // Array komplett durchlaufen
+            foreach ($fieldCheckArray as $key => $value) {
+                if (isset($value) && is_array($value)) {
+                    // spezifischer TS-Eintrag
+                    if ($key == $type . '.') {
+                        foreach ($value as $key2 => $value2) {
+                            $fieldChecks[$key2] = $value2;
+                        }
+                    }
+                } else {
+                    // unspezifischer TS-Eintrag
+                    $fieldChecks[$key] = $value;
+                }
+            }
+        }
+        return $fieldChecks;
+    }
 
-	/**
-	 * Checks if required fields are filled in
-	 */
-	public function checkRequired ($type, $basketExtra) {
+    /**
+     * Checks if required fields are filled in
+     */
+    public function checkRequired ($type, $basketExtra) {
 
         $result = '';
 
-		if (
-			tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra) ||
-			$type == 'billing'
-		) {
-			$requiredInfoFields = CustomerApi::getRequiredInfoFields($type);
+        if (
+            tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra) ||
+            $type == 'billing'
+        ) {
+            $requiredInfoFields = CustomerApi::getRequiredInfoFields($type);
 
-			if ($requiredInfoFields) {
-				$infoFields = GeneralUtility::trimExplode(',', $requiredInfoFields);
+            if ($requiredInfoFields) {
+                $infoFields = GeneralUtility::trimExplode(',', $requiredInfoFields);
 
                 foreach($infoFields as $fName) {
 
@@ -236,165 +236,165 @@ class tx_ttproducts_info_view implements \TYPO3\CMS\Core\SingletonInterface {
             }
 
 
-			// RegEx-Check
-			$checkFieldsExpr = $this->getFieldChecks($type);
-			if (($checkFieldsExpr) && (is_array($checkFieldsExpr))) {
-				foreach ($checkFieldsExpr as $fName => $checkExpr) {
+            // RegEx-Check
+            $checkFieldsExpr = $this->getFieldChecks($type);
+            if (($checkFieldsExpr) && (is_array($checkFieldsExpr))) {
+                foreach ($checkFieldsExpr as $fName => $checkExpr) {
                     if (
                         isset($this->infoArray[$type][$fName]) &&
                         trim($this->infoArray[$type][$fName]) != ''
                         ) {
-						if (
+                        if (
                             preg_match('/' . $checkExpr . '/', $this->infoArray[$type][$fName]) == 0
                         ) {
-							$result = $fName;
-							break;
-						}
-					}
-				}
-			}
-		}
+                            $result = $fName;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
 
-		return $result;
-	} // checkRequired
+        return $result;
+    } // checkRequired
 
 
-	/**
-	 * Checks if the filled in fields are allowed
-	 */
-	public function checkAllowed ($basketExtra) {
-		$rc = '';
+    /**
+     * Checks if the filled in fields are allowed
+     */
+    public function checkAllowed ($basketExtra) {
+        $rc = '';
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
         } else {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\OldStaticInfoTablesApi::class);
         }
-		$where = $this->getWhereAllowedCountries($basketExtra);
+        $where = $this->getWhereAllowedCountries($basketExtra);
 
-		if (
-			$where &&
-			!empty($this->conf['useStaticInfoCountry']) &&
-			$staticInfoApi->isActive()
-		) {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$countryObj = $tablesObj->get('static_countries');
-			if (is_object($countryObj)) {
-				$type = (
-					!tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra) ?
-						'billing' :
-						'delivery'
-					);
-				$row = $countryObj->isoGet($this->infoArray[$type]['country_code'], $where);
-				if (!$row) {
-					$rc = 'country';
-				}
-			}
-		}
+        if (
+            $where &&
+            !empty($this->conf['useStaticInfoCountry']) &&
+            $staticInfoApi->isActive()
+        ) {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $countryObj = $tablesObj->get('static_countries');
+            if (is_object($countryObj)) {
+                $type = (
+                    !tx_ttproducts_control_basket::needsDeliveryAddresss($basketExtra) ?
+                        'billing' :
+                        'delivery'
+                    );
+                $row = $countryObj->isoGet($this->infoArray[$type]['country_code'], $where);
+                if (!$row) {
+                    $rc = 'country';
+                }
+            }
+        }
 
-		return $rc;
-	} // checkAllowed
+        return $rc;
+    } // checkAllowed
 
 
-	/**
-	 * gets the WHERE clause for the allowed static_countries
-	 */
-	public function getWhereAllowedCountries ($basketExtra) {
+    /**
+     * gets the WHERE clause for the allowed static_countries
+     */
+    public function getWhereAllowedCountries ($basketExtra) {
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
         } else {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\OldStaticInfoTablesApi::class);
         }
-		$where = '';
+        $where = '';
 
         if ($staticInfoApi->isActive()) {
-			$where = \JambageCom\TtProducts\Api\PaymentShippingHandling::getWhere($basketExtra, 'static_countries');
-		}
-		return $where;
-	} // getWhereAllowedCountries
+            $where = \JambageCom\TtProducts\Api\PaymentShippingHandling::getWhere($basketExtra, 'static_countries');
+        }
+        return $where;
+    } // getWhereAllowedCountries
 
 
 
-	public function getFromArray ($customerEmail) {
+    public function getFromArray ($customerEmail) {
 
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		$resultArray = [];
-		$resultArray['shop'] = [
-			'email' => $conf['orderEmail_from'],
-			'name' => $conf['orderEmail_fromName']
-		];
-		$resultArray['customer'] = [
-			'email' => $customerEmail,
-			'name' => $this->infoArray['billing']['name']
-		];
+        $resultArray = [];
+        $resultArray['shop'] = [
+            'email' => $conf['orderEmail_from'],
+            'name' => $conf['orderEmail_fromName']
+        ];
+        $resultArray['customer'] = [
+            'email' => $customerEmail,
+            'name' => $this->infoArray['billing']['name']
+        ];
 
-		return $resultArray;
-	}
+        return $resultArray;
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getRowMarkerArray (
-		$basketExtra,
-		&$markerArray,
-		$bHtml,
-		$bSelectSalutation
-	) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getRowMarkerArray (
+        $basketExtra,
+        &$markerArray,
+        $bHtml,
+        $bSelectSalutation
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
         $context = GeneralUtility::makeInstance(Context::class);
 
-		$fields = CustomerApi::getFields();
-		$infoFields = GeneralUtility::trimExplode(',', $fields); // Fields...
-		$orderAddressViewObj = $tablesObj->get('fe_users', true);
-		$orderAddressObj = $orderAddressViewObj->getModelObj();
-		$selectInfoFields = $orderAddressObj->getSelectInfoFields();
-		$piVars = tx_ttproducts_model_control::getPiVars();
+        $fields = CustomerApi::getFields();
+        $infoFields = GeneralUtility::trimExplode(',', $fields); // Fields...
+        $orderAddressViewObj = $tablesObj->get('fe_users', true);
+        $orderAddressObj = $orderAddressViewObj->getModelObj();
+        $selectInfoFields = $orderAddressObj->getSelectInfoFields();
+        $piVars = tx_ttproducts_model_control::getPiVars();
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\StaticInfoTablesApi::class);
         } else {
             $staticInfoApi = GeneralUtility::makeInstance(\JambageCom\Div2007\Api\OldStaticInfoTablesApi::class);
         }
 
-		foreach ($infoFields as $k => $fName) {
-			if (!in_array($fName, $selectInfoFields)) {
-				$fieldMarker = strtoupper($fName);
-				if ($bHtml) {
-					$markerArray['###PERSON_' . $fieldMarker . '###'] =
-					htmlspecialchars($this->infoArray['billing'][$fName] ?? '');
-					$markerArray['###DELIVERY_' . $fieldMarker . '###'] =
-					htmlspecialchars($this->infoArray['delivery'][$fName] ?? '');
-				} else {
-					$markerArray['###PERSON_' . $fieldMarker . '###'] =
-					$this->infoArray['billing'][$fName] ?? '';
-					$markerArray['###DELIVERY_' . $fieldMarker . '###'] =
-					$this->infoArray['delivery'][$fName] ?? '';
-				}
-			}
-		}
+        foreach ($infoFields as $k => $fName) {
+            if (!in_array($fName, $selectInfoFields)) {
+                $fieldMarker = strtoupper($fName);
+                if ($bHtml) {
+                    $markerArray['###PERSON_' . $fieldMarker . '###'] =
+                    htmlspecialchars($this->infoArray['billing'][$fName] ?? '');
+                    $markerArray['###DELIVERY_' . $fieldMarker . '###'] =
+                    htmlspecialchars($this->infoArray['delivery'][$fName] ?? '');
+                } else {
+                    $markerArray['###PERSON_' . $fieldMarker . '###'] =
+                    $this->infoArray['billing'][$fName] ?? '';
+                    $markerArray['###DELIVERY_' . $fieldMarker . '###'] =
+                    $this->infoArray['delivery'][$fName] ?? '';
+                }
+            }
+        }
 
-		if (!empty($this->conf['useStaticInfoCountry']) && $staticInfoApi->isActive()) {
+        if (!empty($this->conf['useStaticInfoCountry']) && $staticInfoApi->isActive()) {
             $countryViewObj = $tablesObj->get('static_countries', true);
             $countryObj = $countryViewObj->getModelObj();
 
-			$bReady = false;
-			$whereCountries = $this->getWhereAllowedCountries($basketExtra);
-			$countryCodeArray = [];
-			$countryCodeArray['billing'] = ($this->infoArray['billing']['country_code'] ?? $context->getPropertyFromAspect('frontend.user', 'isLoggedIn') && ($context->getPropertyFromAspect('frontend.user', 'isLoggedIn') && !empty($GLOBALS['TSFE']->fe_user->user['static_info_country']) ? $GLOBALS['TSFE']->fe_user->user['static_info_country'] : false));
+            $bReady = false;
+            $whereCountries = $this->getWhereAllowedCountries($basketExtra);
+            $countryCodeArray = [];
+            $countryCodeArray['billing'] = ($this->infoArray['billing']['country_code'] ?? $context->getPropertyFromAspect('frontend.user', 'isLoggedIn') && ($context->getPropertyFromAspect('frontend.user', 'isLoggedIn') && !empty($GLOBALS['TSFE']->fe_user->user['static_info_country']) ? $GLOBALS['TSFE']->fe_user->user['static_info_country'] : false));
             $countryCodeArray['delivery'] = ($this->infoArray['delivery']['country_code'] ?? ($context->getPropertyFromAspect('frontend.user', 'isLoggedIn') &&  !empty($GLOBALS['TSFE']->fe_user->user['static_info_country']) ? $GLOBALS['TSFE']->fe_user->user['static_info_country'] : false));
 
             $zoneCodeArray = [];
@@ -425,89 +425,89 @@ class tx_ttproducts_info_view implements \TYPO3\CMS\Core\SingletonInterface {
             } else if (
                 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_tables')
             ) {
-				$eInfo = ExtensionUtility::getExtensionInfo('static_info_tables');
-				$sitVersion = $eInfo['version'];
+                $eInfo = ExtensionUtility::getExtensionInfo('static_info_tables');
+                $sitVersion = $eInfo['version'];
 
-				if (version_compare($sitVersion, '2.0.1', '>=')) {
-					$markerArray['###PERSON_COUNTRY_CODE###'] =
-						$staticInfoApi->buildStaticInfoSelector(
-							'COUNTRIES',
-							'recs[personinfo][country_code]',
-							'',
-							$countryCodeArray['billing'],
-							'',
-							$this->conf['onChangeCountryAttribute'],
-							'field_personinfo_country_code',
-							'',
-							$whereCountries,
-							'',
-							false,
-							[],
-							1,
-							$outSelectedArray
-						);
+                if (version_compare($sitVersion, '2.0.1', '>=')) {
+                    $markerArray['###PERSON_COUNTRY_CODE###'] =
+                        $staticInfoApi->buildStaticInfoSelector(
+                            'COUNTRIES',
+                            'recs[personinfo][country_code]',
+                            '',
+                            $countryCodeArray['billing'],
+                            '',
+                            $this->conf['onChangeCountryAttribute'],
+                            'field_personinfo_country_code',
+                            '',
+                            $whereCountries,
+                            '',
+                            false,
+                            [],
+                            1,
+                            $outSelectedArray
+                        );
 
-					if (isset($outSelectedArray) && is_array($outSelectedArray)) {
+                    if (isset($outSelectedArray) && is_array($outSelectedArray)) {
                         $countryCode = current($outSelectedArray);
-						$markerArray['###PERSON_ZONE###'] =
-							$staticInfoApi->buildStaticInfoSelector(
-								'SUBDIVISIONS',
-								'recs[personinfo][zone]',
-								'',
-								$zoneCodeArray['billing'],
-								$countryCode, // neu
-								0,
-								'',
-								'',
-								'',
-								''
-							);
+                        $markerArray['###PERSON_ZONE###'] =
+                            $staticInfoApi->buildStaticInfoSelector(
+                                'SUBDIVISIONS',
+                                'recs[personinfo][zone]',
+                                '',
+                                $zoneCodeArray['billing'],
+                                $countryCode, // neu
+                                0,
+                                '',
+                                '',
+                                '',
+                                ''
+                            );
                         $countryRow = $countryObj->isoGet($countryCode);
                         $countryViewObj->getRowMarkers($markerArray, 'PERSON', $countryRow);
-					} else {
-						$markerArray['###PERSON_ZONE###'] = '';
-					}
-					$countryArray = $staticInfoApi->initCountries('ALL', '', false, $whereCountries);
-					$markerArray['###PERSON_COUNTRY_FIRST###'] = current($countryArray);
-					$markerArray['###PERSON_COUNTRY_FIRST_HIDDEN###'] = '<input type="hidden" name="recs[personinfo][country_code]" size="3" value="'.current(array_keys($countryArray)).'">';
+                    } else {
+                        $markerArray['###PERSON_ZONE###'] = '';
+                    }
+                    $countryArray = $staticInfoApi->initCountries('ALL', '', false, $whereCountries);
+                    $markerArray['###PERSON_COUNTRY_FIRST###'] = current($countryArray);
+                    $markerArray['###PERSON_COUNTRY_FIRST_HIDDEN###'] = '<input type="hidden" name="recs[personinfo][country_code]" size="3" value="'.current(array_keys($countryArray)).'">';
 
-					$markerArray['###PERSON_COUNTRY###'] =
-						$staticInfoApi->getStaticInfoName($countryCodeArray['billing'], 'COUNTRIES', '', '');
-					unset($outSelectedArray);
+                    $markerArray['###PERSON_COUNTRY###'] =
+                        $staticInfoApi->getStaticInfoName($countryCodeArray['billing'], 'COUNTRIES', '', '');
+                    unset($outSelectedArray);
 
-					$markerArray['###DELIVERY_COUNTRY_CODE###'] =
-						$staticInfoApi->buildStaticInfoSelector(
-							'COUNTRIES',
-							'recs[delivery][country_code]',
-							'',
-							$countryCodeArray['delivery'],
-							'',
-							$this->conf['onChangeCountryAttribute'],
-							'field_delivery_country_code',
-							'',
-							$whereCountries,
-							'',
-							false,
-							[],
-							1,
-							$outSelectedArray
-						);
+                    $markerArray['###DELIVERY_COUNTRY_CODE###'] =
+                        $staticInfoApi->buildStaticInfoSelector(
+                            'COUNTRIES',
+                            'recs[delivery][country_code]',
+                            '',
+                            $countryCodeArray['delivery'],
+                            '',
+                            $this->conf['onChangeCountryAttribute'],
+                            'field_delivery_country_code',
+                            '',
+                            $whereCountries,
+                            '',
+                            false,
+                            [],
+                            1,
+                            $outSelectedArray
+                        );
 
-					if (isset($outSelectedArray) && is_array($outSelectedArray)) {
+                    if (isset($outSelectedArray) && is_array($outSelectedArray)) {
                         $countryCode = current($outSelectedArray);
-						$markerArray['###DELIVERY_ZONE###'] =
-							$staticInfoApi->buildStaticInfoSelector(
-								'SUBDIVISIONS',
-								'recs[delivery][zone]',
-								'',
-								$zoneCodeArray['billing'],
-								$countryCode,
-								0,
-								'',
-								'',
-								'',
-								''
-							);
+                        $markerArray['###DELIVERY_ZONE###'] =
+                            $staticInfoApi->buildStaticInfoSelector(
+                                'SUBDIVISIONS',
+                                'recs[delivery][zone]',
+                                '',
+                                $zoneCodeArray['billing'],
+                                $countryCode,
+                                0,
+                                '',
+                                '',
+                                '',
+                                ''
+                            );
                         $countryRow = $countryObj->isoGet($countryCode);
                         $countryViewObj->getRowMarkers(
                             $markerArray,
@@ -515,251 +515,251 @@ class tx_ttproducts_info_view implements \TYPO3\CMS\Core\SingletonInterface {
                             $countryRow
                         );
                     } else {
-						$markerArray['###DELIVERY_ZONE###'] = '';
-					}
+                        $markerArray['###DELIVERY_ZONE###'] = '';
+                    }
 
-					$markerArray['###DELIVERY_COUNTRY_FIRST###'] = $markerArray['###PERSON_COUNTRY_FIRST###'];
-					$markerArray['###DELIVERY_COUNTRY###'] =
-						$staticInfoApi->getStaticInfoName(
-							$countryCodeArray['delivery'],
-							'COUNTRIES',
-							'',
-							''
-						);
-					$bReady = true;
-				}
+                    $markerArray['###DELIVERY_COUNTRY_FIRST###'] = $markerArray['###PERSON_COUNTRY_FIRST###'];
+                    $markerArray['###DELIVERY_COUNTRY###'] =
+                        $staticInfoApi->getStaticInfoName(
+                            $countryCodeArray['delivery'],
+                            'COUNTRIES',
+                            '',
+                            ''
+                        );
+                    $bReady = true;
+                }
 
-				$markerArray['###PERSON_ZONE_DISPLAY###'] =
-					StaticInfoTablesUtility::getTitleFromIsoCode(
-						'static_country_zones',
-						[
+                $markerArray['###PERSON_ZONE_DISPLAY###'] =
+                    StaticInfoTablesUtility::getTitleFromIsoCode(
+                        'static_country_zones',
+                        [
                             $zoneCodeArray['billing'],
                             $countryCodeArray['billing']
                         ]
-					);
-				$markerArray['###DELIVERY_ZONE_DISPLAY###'] =
-					StaticInfoTablesUtility::getTitleFromIsoCode(
-						'static_country_zones',
-						[
+                    );
+                $markerArray['###DELIVERY_ZONE_DISPLAY###'] =
+                    StaticInfoTablesUtility::getTitleFromIsoCode(
+                        'static_country_zones',
+                        [
                             $zoneCodeArray['delivery'],
                             $countryCodeArray['delivery']
                         ]
-					);
-			}
+                    );
+            }
 
-			if (!$bReady) {
-				$markerArray['###PERSON_COUNTRY_CODE###'] =
-					$staticInfoApi->buildStaticInfoSelector(
-						'COUNTRIES',
-						'recs[personinfo][country_code]',
-						'',
-						$countryCodeArray['billing'],
-						'',
-						0,
-						'field_personinfo_country_code'
-					);
-				$markerArray['###PERSON_COUNTRY###'] =
-					$staticInfoApi->getStaticInfoName(
-						$countryCodeArray['billing'],
-						'COUNTRIES',
-						'',
-						''
-					);
+            if (!$bReady) {
+                $markerArray['###PERSON_COUNTRY_CODE###'] =
+                    $staticInfoApi->buildStaticInfoSelector(
+                        'COUNTRIES',
+                        'recs[personinfo][country_code]',
+                        '',
+                        $countryCodeArray['billing'],
+                        '',
+                        0,
+                        'field_personinfo_country_code'
+                    );
+                $markerArray['###PERSON_COUNTRY###'] =
+                    $staticInfoApi->getStaticInfoName(
+                        $countryCodeArray['billing'],
+                        'COUNTRIES',
+                        '',
+                        ''
+                    );
         
-				$markerArray['###DELIVERY_COUNTRY_CODE###'] =
-					$staticInfoApi->buildStaticInfoSelector(
-						'COUNTRIES',
-						'recs[delivery][country_code]',
-						'',
-						$countryCodeArray['delivery'],
-						'',
-						0,
-						'field_delivery_country_code'
-					);
-				$markerArray['###DELIVERY_COUNTRY###'] =
-					$staticInfoApi->getStaticInfoName(
-						$countryCodeArray['delivery'],
-						'COUNTRIES',
-						'',
-						''
-					);
-			}
-		}
+                $markerArray['###DELIVERY_COUNTRY_CODE###'] =
+                    $staticInfoApi->buildStaticInfoSelector(
+                        'COUNTRIES',
+                        'recs[delivery][country_code]',
+                        '',
+                        $countryCodeArray['delivery'],
+                        '',
+                        0,
+                        'field_delivery_country_code'
+                    );
+                $markerArray['###DELIVERY_COUNTRY###'] =
+                    $staticInfoApi->getStaticInfoName(
+                        $countryCodeArray['delivery'],
+                        'COUNTRIES',
+                        '',
+                        ''
+                    );
+            }
+        }
 
-			// Markers for use if you want to output line-broken address information
-		$markerArray['###PERSON_ADDRESS_DISPLAY###'] = nl2br($markerArray['###PERSON_ADDRESS###']);
-		$markerArray['###DELIVERY_ADDRESS_DISPLAY###'] = nl2br($markerArray['###DELIVERY_ADDRESS###']);
+            // Markers for use if you want to output line-broken address information
+        $markerArray['###PERSON_ADDRESS_DISPLAY###'] = nl2br($markerArray['###PERSON_ADDRESS###']);
+        $markerArray['###DELIVERY_ADDRESS_DISPLAY###'] = nl2br($markerArray['###DELIVERY_ADDRESS###']);
 
-		$orderAddressViewObj->getAddressMarkerArray(
-			'fe_users',
-			$this->infoArray['billing'],
-			$markerArray,
-			$bSelectSalutation,
-			'personinfo'
-		);
+        $orderAddressViewObj->getAddressMarkerArray(
+            'fe_users',
+            $this->infoArray['billing'],
+            $markerArray,
+            $bSelectSalutation,
+            'personinfo'
+        );
 
-		$orderAddressViewObj->getAddressMarkerArray(
-			'fe_users',
-			$this->infoArray['delivery'],
-			$markerArray,
-			$bSelectSalutation,
-			'delivery'
-		);
+        $orderAddressViewObj->getAddressMarkerArray(
+            'fe_users',
+            $this->infoArray['delivery'],
+            $markerArray,
+            $bSelectSalutation,
+            'delivery'
+        );
 
-		$text = $this->infoArray['delivery']['note'] ?? '';
-		$markerArray['###DELIVERY_NOTE###'] = $text;
-		$markerArray['###DELIVERY_NOTE_DISPLAY###'] = nl2br($text);
-		$markerArray['###DELIVERY_GIFT_SERVICE###'] = $this->infoArray['delivery']['giftservice'] ?? '';
-		$markerArray['###DELIVERY_GIFT_SERVICE_DISPLAY###'] = nl2br($this->infoArray['delivery']['giftservice'] ?? '');
-		if (isset($this->infoArray['delivery']['radio1'])) {
+        $text = $this->infoArray['delivery']['note'] ?? '';
+        $markerArray['###DELIVERY_NOTE###'] = $text;
+        $markerArray['###DELIVERY_NOTE_DISPLAY###'] = nl2br($text);
+        $markerArray['###DELIVERY_GIFT_SERVICE###'] = $this->infoArray['delivery']['giftservice'] ?? '';
+        $markerArray['###DELIVERY_GIFT_SERVICE_DISPLAY###'] = nl2br($this->infoArray['delivery']['giftservice'] ?? '');
+        if (isset($this->infoArray['delivery']['radio1'])) {
             $markerArray['###DELIVERY_RADIO1_1###'] = ($this->infoArray['delivery']['radio1'] == '1' ? 'checked ' : '');
             $markerArray['###DELIVERY_RADIO1_2###'] = ($this->infoArray['delivery']['radio1'] == '2' ? 'checked ' : '');
             $markerArray['###DELIVERY_RADIO1_DISPLAY###'] = $this->infoArray['delivery']['radio1'];
         }
 
-			// Desired delivery date.
-		$markerArray['###DELIVERY_DESIRED_DATE###'] = $this->infoArray['delivery']['desired_date'] ?? '';
-		$markerArray['###DELIVERY_DESIRED_TIME###'] = $this->infoArray['delivery']['desired_time'] ?? '';
-		$markerArray['###DELIVERY_STORE_SELECT###'] = '';
+            // Desired delivery date.
+        $markerArray['###DELIVERY_DESIRED_DATE###'] = $this->infoArray['delivery']['desired_date'] ?? '';
+        $markerArray['###DELIVERY_DESIRED_TIME###'] = $this->infoArray['delivery']['desired_time'] ?? '';
+        $markerArray['###DELIVERY_STORE_SELECT###'] = '';
 
-		$shippingType = \JambageCom\TtProducts\Api\PaymentShippingHandling::get(
-			'shipping',
-			'type',
-			$basketExtra
-		);
+        $shippingType = \JambageCom\TtProducts\Api\PaymentShippingHandling::get(
+            'shipping',
+            'type',
+            $basketExtra
+        );
 
-		if ($shippingType == 'pick_store') {
-			$addressObj = $tablesObj->get('address', false);
-			if (is_object($addressObj)) {
-				$markerArray['###DELIVERY_STORE_SELECT###'] = '';
-				$tablename = $addressObj->getTablename();
-				$tableconf = $cnf->getTableConf('address', 'INFO');
-				$formConf = $cnf->getFormConf('INFO');
-				$layout = '';
-				if (
-					isset($formConf) &&
-					is_array($formConf) &&
-					isset($formConf['selectStore.']) &&
-					isset($formConf['selectStore.']['layout'])
-				) {
-					$layout = $formConf['selectStore.']['layout'];
-				}
-				$orderBy = $tableconf['orderBy'];
-				$uidStoreArray = [];
+        if ($shippingType == 'pick_store') {
+            $addressObj = $tablesObj->get('address', false);
+            if (is_object($addressObj)) {
+                $markerArray['###DELIVERY_STORE_SELECT###'] = '';
+                $tablename = $addressObj->getTablename();
+                $tableconf = $cnf->getTableConf('address', 'INFO');
+                $formConf = $cnf->getFormConf('INFO');
+                $layout = '';
+                if (
+                    isset($formConf) &&
+                    is_array($formConf) &&
+                    isset($formConf['selectStore.']) &&
+                    isset($formConf['selectStore.']['layout'])
+                ) {
+                    $layout = $formConf['selectStore.']['layout'];
+                }
+                $orderBy = $tableconf['orderBy'];
+                $uidStoreArray = [];
 
-				if (isset($this->conf['UIDstore'])) {
+                if (isset($this->conf['UIDstore'])) {
 
-					$tmpArray = GeneralUtility::trimExplode(',', $this->conf['UIDstore']);
-					foreach ($tmpArray as $value) {
-						if ($value) {
-							$uidStoreArray[] = $value;
-						}
-					}
-				}
+                    $tmpArray = GeneralUtility::trimExplode(',', $this->conf['UIDstore']);
+                    foreach ($tmpArray as $value) {
+                        if ($value) {
+                            $uidStoreArray[] = $value;
+                        }
+                    }
+                }
 
-				$where_clause = '';
-				if ($tablename == 'fe_users' && !empty($this->conf['UIDstoreGroup'])) {
+                $where_clause = '';
+                if ($tablename == 'fe_users' && !empty($this->conf['UIDstoreGroup'])) {
 
-					$orChecks = [];
-					$memberGroups = GeneralUtility::trimExplode(',', $this->conf['UIDstoreGroup']);
-					foreach ($memberGroups as $value) {
-						$orChecks[] = $GLOBALS['TYPO3_DB']->listQuery('usergroup', $value, $tablename);
-					}
-					$where_clause = implode(' OR ', $orChecks);
-				}
+                    $orChecks = [];
+                    $memberGroups = GeneralUtility::trimExplode(',', $this->conf['UIDstoreGroup']);
+                    foreach ($memberGroups as $value) {
+                        $orChecks[] = $GLOBALS['TYPO3_DB']->listQuery('usergroup', $value, $tablename);
+                    }
+                    $where_clause = implode(' OR ', $orChecks);
+                }
 
-				if (is_array($uidStoreArray) && count($uidStoreArray)) {
-					if ($where_clause != '') {
-						$where_clause .= ' OR ';
-					}
-					$where_clause .= 'uid IN (' . implode(',', $uidStoreArray) . ')';
-				}
+                if (is_array($uidStoreArray) && count($uidStoreArray)) {
+                    if ($where_clause != '') {
+                        $where_clause .= ' OR ';
+                    }
+                    $where_clause .= 'uid IN (' . implode(',', $uidStoreArray) . ')';
+                }
 
-				if ($where_clause != '') {
-					$addressArray =
-						$addressObj->get(
-							'',
-							0,
-							false,
-							$where_clause,
-							'',
-							$orderBy,
-							'',
-							'',
-							false,
-							''
-						);
+                if ($where_clause != '') {
+                    $addressArray =
+                        $addressObj->get(
+                            '',
+                            0,
+                            false,
+                            $where_clause,
+                            '',
+                            $orderBy,
+                            '',
+                            '',
+                            false,
+                            ''
+                        );
 
-					$actUidStore = $this->infoArray['delivery']['store'];
-					$tableFieldArray = [
-						'tx_party_addresses' => ['post_code', 'locality', 'remarks'],
-						'tt_address' => ['zip', 'city', 'name', 'address'],
-						'fe_users' => ['zip', 'city', 'name', 'address']
-					];
-					$valueArray = [];
-					if ($addressArray && isset($tableFieldArray[$tablename]) && is_array($tableFieldArray[$tablename])) {
-						foreach ($addressArray as $uid => $row) {
+                    $actUidStore = $this->infoArray['delivery']['store'];
+                    $tableFieldArray = [
+                        'tx_party_addresses' => ['post_code', 'locality', 'remarks'],
+                        'tt_address' => ['zip', 'city', 'name', 'address'],
+                        'fe_users' => ['zip', 'city', 'name', 'address']
+                    ];
+                    $valueArray = [];
+                    if ($addressArray && isset($tableFieldArray[$tablename]) && is_array($tableFieldArray[$tablename])) {
+                        foreach ($addressArray as $uid => $row) {
 
-							$boxContent = '';
-							if ($layout != '') {
-								$boxMarkerArray = [];
-								foreach ($row as $field => $value) {
-									$boxMarkerArray['###' . strtoupper($field) . '###'] = $value;
-								}
-								$boxContent = $templateService->substituteMarkerArray($layout, $boxMarkerArray);
-							} else {
-								$partRow = [];
-								foreach ($tableFieldArray[$tablename] as $field) {
-									$partRow[$field] = $row[$field];
-								}
-								$boxContent = implode(',', $partRow);
-							}
-							$valueArray[$uid] = $boxContent;
-						}
-						$theFormConf = $formConf['selectStore.'];
-						$dataArray = $theFormConf['data.'];
+                            $boxContent = '';
+                            if ($layout != '') {
+                                $boxMarkerArray = [];
+                                foreach ($row as $field => $value) {
+                                    $boxMarkerArray['###' . strtoupper($field) . '###'] = $value;
+                                }
+                                $boxContent = $templateService->substituteMarkerArray($layout, $boxMarkerArray);
+                            } else {
+                                $partRow = [];
+                                foreach ($tableFieldArray[$tablename] as $field) {
+                                    $partRow[$field] = $row[$field];
+                                }
+                                $boxContent = implode(',', $partRow);
+                            }
+                            $valueArray[$uid] = $boxContent;
+                        }
+                        $theFormConf = $formConf['selectStore.'];
+                        $dataArray = $theFormConf['data.'];
 
-						$markerArray['###DELIVERY_STORE_SELECT###'] =
-							tx_ttproducts_form_div::createSelect(
-								$languageObj,
-								$valueArray,
-								'recs[delivery][store]',
-								$actUidStore,
-								true,
-								false,
-								[],
-								'select',
-								$dataArray,
-								'',
-								'',
-								''
-							);
-					}
+                        $markerArray['###DELIVERY_STORE_SELECT###'] =
+                            tx_ttproducts_form_div::createSelect(
+                                $languageObj,
+                                $valueArray,
+                                'recs[delivery][store]',
+                                $actUidStore,
+                                true,
+                                false,
+                                [],
+                                'select',
+                                $dataArray,
+                                '',
+                                '',
+                                ''
+                            );
+                    }
 
-					if ($actUidStore && $addressArray[$actUidStore]) {
-						$row = $addressArray[$actUidStore];
-						foreach ($row as $field => $value) {
-							$markerArray['###DELIVERY_' . strtoupper($field) . '###'] = $value;
-						}
-					}
-				}
-			}
-		}
+                    if ($actUidStore && $addressArray[$actUidStore]) {
+                        $row = $addressArray[$actUidStore];
+                        foreach ($row as $field => $value) {
+                            $markerArray['###DELIVERY_' . strtoupper($field) . '###'] = $value;
+                        }
+                    }
+                }
+            }
+        }
 
 
-			// Fe users:
-		$markerArray['###FE_USER_TT_PRODUCTS_DISCOUNT###'] = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'] ?? '';
-		$markerArray['###FE_USER_USERNAME###'] = $GLOBALS['TSFE']->fe_user->user['username'] ?? '';
-		$markerArray['###FE_USER_UID###'] = $GLOBALS['TSFE']->fe_user->user['uid'] ?? '';
-		$bAgb = (isset($this->infoArray['billing']['agb']) && $this->infoArray['billing']['agb'] && (!isset($piVars['agb']) || $piVars['agb'] > 0));
-		$markerArray['###FE_USER_CNUM###'] = $GLOBALS['TSFE']->fe_user->user['cnum'] ?? '';
-		$markerArray['###PERSON_AGB###'] = 'value="1" ' . ($bAgb ? 'checked="checked"' : '');
-		$markerArray['###USERNAME###'] = $this->infoArray['billing']['email'] ?? '';
-		$markerArray['###PASSWORD###'] = $this->password;
-		$valueArray = $GLOBALS['TCA']['sys_products_orders']['columns']['foundby']['config']['items'];
-		
-		$foundbyType = 'radio';
-		if (
+            // Fe users:
+        $markerArray['###FE_USER_TT_PRODUCTS_DISCOUNT###'] = $GLOBALS['TSFE']->fe_user->user['tt_products_discount'] ?? '';
+        $markerArray['###FE_USER_USERNAME###'] = $GLOBALS['TSFE']->fe_user->user['username'] ?? '';
+        $markerArray['###FE_USER_UID###'] = $GLOBALS['TSFE']->fe_user->user['uid'] ?? '';
+        $bAgb = (isset($this->infoArray['billing']['agb']) && $this->infoArray['billing']['agb'] && (!isset($piVars['agb']) || $piVars['agb'] > 0));
+        $markerArray['###FE_USER_CNUM###'] = $GLOBALS['TSFE']->fe_user->user['cnum'] ?? '';
+        $markerArray['###PERSON_AGB###'] = 'value="1" ' . ($bAgb ? 'checked="checked"' : '');
+        $markerArray['###USERNAME###'] = $this->infoArray['billing']['email'] ?? '';
+        $markerArray['###PASSWORD###'] = $this->password;
+        $valueArray = $GLOBALS['TCA']['sys_products_orders']['columns']['foundby']['config']['items'];
+        
+        $foundbyType = 'radio';
+        if (
             isset($conf['foundby.']) &&
             isset($conf['foundby.']['type'])
         ) {
@@ -773,27 +773,27 @@ class tx_ttproducts_info_view implements \TYPO3\CMS\Core\SingletonInterface {
             unset($valueArray['0']);
         }
 
-		$foundbyText = tx_ttproducts_form_div::createSelect(
-			$languageObj,
-			$valueArray,
-			'recs[delivery][foundby]',
-			$this->infoArray['delivery']['foundby'] ?? '',
-			true,
-			true,
-			[],
-			$foundbyType
-		);
+        $foundbyText = tx_ttproducts_form_div::createSelect(
+            $languageObj,
+            $valueArray,
+            'recs[delivery][foundby]',
+            $this->infoArray['delivery']['foundby'] ?? '',
+            true,
+            true,
+            [],
+            $foundbyType
+        );
 
-		$foundbyKey = $this->infoArray['delivery']['foundby'] ?? '';
-		if (isset($valueArray[$foundbyKey])) {
-			$tmp = $languageObj->splitLabel($valueArray[$foundbyKey][0]);
-			$text = $languageObj->getLabel($tmp);
-		}
+        $foundbyKey = $this->infoArray['delivery']['foundby'] ?? '';
+        if (isset($valueArray[$foundbyKey])) {
+            $tmp = $languageObj->splitLabel($valueArray[$foundbyKey][0]);
+            $text = $languageObj->getLabel($tmp);
+        }
 
-		$markerArray['###DELIVERY_FOUNDBY###'] = $text;
-		$markerArray['###DELIVERY_FOUNDBY_KEY###'] = $foundbyKey;
-		$markerArray['###DELIVERY_FOUNDBY_SELECTOR###'] = $foundbyText;
-		$markerArray['###DELIVERY_FOUNDBY_OTHERS###'] = $this->infoArray['delivery']['foundby_others'] ?? '';
-	} // getMarkerArray
+        $markerArray['###DELIVERY_FOUNDBY###'] = $text;
+        $markerArray['###DELIVERY_FOUNDBY_KEY###'] = $foundbyKey;
+        $markerArray['###DELIVERY_FOUNDBY_SELECTOR###'] = $foundbyText;
+        $markerArray['###DELIVERY_FOUNDBY_OTHERS###'] = $this->infoArray['delivery']['foundby_others'] ?? '';
+    } // getMarkerArray
 }
 

--- a/view/class.tx_ttproducts_list_view.php
+++ b/view/class.tx_ttproducts_list_view.php
@@ -51,34 +51,34 @@ use JambageCom\TtProducts\Model\Field\FieldInterface;
 
 
 class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pid; // pid where to go
-	public $uidArray;
-	public $pidListObj;
+    public $pid; // pid where to go
+    public $uidArray;
+    public $pidListObj;
 
 
-	public function init (
-		$pid,
-		$uidArray,
-		$pid_list,
-		$recursive
-	) {
-		$this->pid = $pid;
-		$this->uidArray = $uidArray;
+    public function init (
+        $pid,
+        $uidArray,
+        $pid_list,
+        $recursive
+    ) {
+        $this->pid = $pid;
+        $this->uidArray = $uidArray;
 
-		$this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$this->pidListObj->applyRecursive($recursive, $pid_list, true);
-		$this->pidListObj->setPageArray();
-	}
+        $this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $this->pidListObj->applyRecursive($recursive, $pid_list, true);
+        $this->pidListObj->setPageArray();
+    }
 
-	public function finishHTMLRow (
-		&$cssConf,
-		&$iColCount,
-		$tableRowOpen,
-		$displayColumns
-	) {
-		$itemsOut = '';
-		if ($tableRowOpen) {
-			$iColCount++;
+    public function finishHTMLRow (
+        &$cssConf,
+        &$iColCount,
+        $tableRowOpen,
+        $displayColumns
+    ) {
+        $itemsOut = '';
+        if ($tableRowOpen) {
+            $iColCount++;
             if (isset($cssConf['itemSingleWrap'])) {
                 $itemSingleWrapArray = GeneralUtility::trimExplode('|', $cssConf['itemSingleWrap']);
                 $bIsTable = (strpos($itemSingleWrapArray['0'], 'td') != false);
@@ -101,1710 +101,1710 @@ class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
     } // finishHTMLRow
 
 
-	public function advanceCategory (
-		&$categoryAndItemsFrameWork,
-		&$itemListOut,
-		&$categoryOut,
-		$itemListSubpart,
-		$oldFormCount,
-		&$formCount
-	) {
+    public function advanceCategory (
+        &$categoryAndItemsFrameWork,
+        &$itemListOut,
+        &$categoryOut,
+        $itemListSubpart,
+        $oldFormCount,
+        &$formCount
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$subpartArray = [];
-		$subpartArray['###ITEM_CATEGORY###'] = $categoryOut;
-		$subpartArray[$itemListSubpart] = $itemListOut;
-		$rc = $templateService->substituteMarkerArrayCached($categoryAndItemsFrameWork, [], $subpartArray);
-		if ($formCount == $oldFormCount) {
-			$formCount++; // next form must have another name
-		}
-		$categoryOut = '';
-		$itemListOut = '';	// Clear the item-code var
-		return $rc;
-	}
+        $subpartArray = [];
+        $subpartArray['###ITEM_CATEGORY###'] = $categoryOut;
+        $subpartArray[$itemListSubpart] = $itemListOut;
+        $rc = $templateService->substituteMarkerArrayCached($categoryAndItemsFrameWork, [], $subpartArray);
+        if ($formCount == $oldFormCount) {
+            $formCount++; // next form must have another name
+        }
+        $categoryOut = '';
+        $itemListOut = '';	// Clear the item-code var
+        return $rc;
+    }
 
 
-	public function advanceProduct (
-		&$productAndItemsFrameWork,
-		&$productFrameWork,
-		&$itemListOut,
-		&$productMarkerArray,
-		&$categoryMarkerArray
-	) {
+    public function advanceProduct (
+        &$productAndItemsFrameWork,
+        &$productFrameWork,
+        &$itemListOut,
+        &$productMarkerArray,
+        &$categoryMarkerArray
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$markerArray = array_merge($productMarkerArray, $categoryMarkerArray);
-		$productOut = $templateService->substituteMarkerArray($productFrameWork, $markerArray);
-		$subpartArray = [];
-		$subpartArray['###ITEM_PRODUCT###'] = $productOut;
-		$subpartArray['###ITEM_LIST###'] = $itemListOut;
-		$rc = $templateService->substituteMarkerArrayCached($productAndItemsFrameWork, [], $subpartArray);
-		$categoryOut = '';
-		$itemListOut = '';	// Clear the item-code var
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $markerArray = array_merge($productMarkerArray, $categoryMarkerArray);
+        $productOut = $templateService->substituteMarkerArray($productFrameWork, $markerArray);
+        $subpartArray = [];
+        $subpartArray['###ITEM_PRODUCT###'] = $productOut;
+        $subpartArray['###ITEM_LIST###'] = $itemListOut;
+        $rc = $templateService->substituteMarkerArrayCached($productAndItemsFrameWork, [], $subpartArray);
+        $categoryOut = '';
+        $itemListOut = '';	// Clear the item-code var
 
-		return $rc;
-	}
-
-
-	/**
-	 * [Describe function...]
-	 *
-	 * @param	[type]		$$queryString: ...
-	 * @return	[type]		...
-	 */
-	public function getSearchParams (&$queryString) {
-		$sword = GeneralUtility::_GP('sword');
-
-		if (!isset($sword)) {
-			$sword = GeneralUtility::_GP('swords');
-		}
-
-		if ($sword) {
-			$sword = rawurlencode($sword);
-		}
-
-		if (!isset($sword)) {
-			$piVars = tx_ttproducts_model_control::getPiVars();
-			$sword = $piVars['sword'] ?? null;
-		}
-
-		if ($sword) {
-			$queryString['sword'] = $sword;
-		}
-	}
+        return $rc;
+    }
 
 
-	protected function getCategories (
-		$catObj,
-		$catArray,
-		$rootCatArray,
-		&$rootLineArray,
-		$cat,
-		&$currentCat,
-		&$displayCat
-	) {
-		if (in_array($cat, $catArray)) {
-			$currentCat = $cat;
-		} else {
-			$currentCat = current($catArray);
-		}
+    /**
+     * [Describe function...]
+     *
+     * @param	[type]		$$queryString: ...
+     * @return	[type]		...
+     */
+    public function getSearchParams (&$queryString) {
+        $sword = GeneralUtility::_GP('sword');
 
-		foreach ($catArray as $displayCat) {
-			$totalRootLineArray = $catObj->getLineArray($currentCat, [0]);
+        if (!isset($sword)) {
+            $sword = GeneralUtility::_GP('swords');
+        }
 
-			if (($displayCat != $currentCat) && !in_array($displayCat, $totalRootLineArray)) {
-				break;
-			}
-		}
-		$rootLineArray = $catObj->getLineArray($currentCat, $rootCatArray);
-	}
+        if ($sword) {
+            $sword = rawurlencode($sword);
+        }
 
+        if (!isset($sword)) {
+            $piVars = tx_ttproducts_model_control::getPiVars();
+            $sword = $piVars['sword'] ?? null;
+        }
 
-	protected function getDisplayInfo (
-		$displayConf,
-		$type,
-		$depth,
-		$bLast
-	) {
-		$result = '';
-		if (is_array($displayConf[$type])) {
-			foreach ($displayConf[$type] as $k => $val) {
-				if (
-					MathUtility::canBeInterpretedAsInteger($k) &&
-					$depth >= $k
-				) {
-					$result = $val;
-				} else {
-					break;
-				}
-			}
-
-			if (isset($displayConf[$type]['last']) && $bLast) {
-				$result = $displayConf[$type]['last'];
-			}
-		}
-		return $result;
-	}
+        if ($sword) {
+            $queryString['sword'] = $sword;
+        }
+    }
 
 
-	public function getBrowserConf ($tableConfArray) {
+    protected function getCategories (
+        $catObj,
+        $catArray,
+        $rootCatArray,
+        &$rootLineArray,
+        $cat,
+        &$currentCat,
+        &$displayCat
+    ) {
+        if (in_array($cat, $catArray)) {
+            $currentCat = $cat;
+        } else {
+            $currentCat = current($catArray);
+        }
 
-		$browserConf = '';
-		if (isset($tableConfArray['view.']) && $tableConfArray['view.']['browser'] == 'div2007') {
-			if (isset($tableConfArray['view.']['browser.'])) {
-				$browserConf = $tableConfArray['view.']['browser.'];
-			} else {
-				$browserConf = [];
-			}
-		}
-		return $browserConf;
-	}
+        foreach ($catArray as $displayCat) {
+            $totalRootLineArray = $catObj->getLineArray($currentCat, [0]);
 
-	public function getBrowserObj(
-		$conf,
-		$browserConf,
-		$productsCount,
-		$limit,
-		$maxPages
-	) {
-		$bShowFirstLast = true;
-		$dontLinkActivePage = 0;
-		$parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
+            if (($displayCat != $currentCat) && !in_array($displayCat, $totalRootLineArray)) {
+                break;
+            }
+        }
+        $rootLineArray = $catObj->getLineArray($currentCat, $rootCatArray);
+    }
 
-		if (
-			isset($browserConf) &&
-			is_array($browserConf)
-		) {
-			if (isset($browserConf['showFirstLast'])) {
+
+    protected function getDisplayInfo (
+        $displayConf,
+        $type,
+        $depth,
+        $bLast
+    ) {
+        $result = '';
+        if (is_array($displayConf[$type])) {
+            foreach ($displayConf[$type] as $k => $val) {
+                if (
+                    MathUtility::canBeInterpretedAsInteger($k) &&
+                    $depth >= $k
+                ) {
+                    $result = $val;
+                } else {
+                    break;
+                }
+            }
+
+            if (isset($displayConf[$type]['last']) && $bLast) {
+                $result = $displayConf[$type]['last'];
+            }
+        }
+        return $result;
+    }
+
+
+    public function getBrowserConf ($tableConfArray) {
+
+        $browserConf = '';
+        if (isset($tableConfArray['view.']) && $tableConfArray['view.']['browser'] == 'div2007') {
+            if (isset($tableConfArray['view.']['browser.'])) {
+                $browserConf = $tableConfArray['view.']['browser.'];
+            } else {
+                $browserConf = [];
+            }
+        }
+        return $browserConf;
+    }
+
+    public function getBrowserObj(
+        $conf,
+        $browserConf,
+        $productsCount,
+        $limit,
+        $maxPages
+    ) {
+        $bShowFirstLast = true;
+        $dontLinkActivePage = 0;
+        $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
+
+        if (
+            isset($browserConf) &&
+            is_array($browserConf)
+        ) {
+            if (isset($browserConf['showFirstLast'])) {
                 $bShowFirstLast = $browserConf['showFirstLast'];
             }
-			if (isset($browserConf['dontLinkActivePage'])) {
+            if (isset($browserConf['dontLinkActivePage'])) {
                 $dontLinkActivePage = $browserConf['dontLinkActivePage'];
             }
-		}
+        }
 
-		$pagefloat = 0;
-		$imageArray = [];
-		$imageActiveArray = [];
-		$piVars = $parameterApi->getPiVars();
-		$browseObj = GeneralUtility::makeInstance(\JambageCom\Div2007\Base\BrowserBase::class);
-		$browseObj->init(
-			$conf,
-			$piVars,
-			[],
-			false,	// no autocache used yet
-			tx_ttproducts_control_pibase::$pi_USER_INT_obj,
-			$productsCount,
-			$limit,
-			$maxPages,
-			$bShowFirstLast,
-			false,
-			$pagefloat,
-			$imageArray,
-			$imageActiveArray,
-			$dontLinkActivePage
-		);
+        $pagefloat = 0;
+        $imageArray = [];
+        $imageActiveArray = [];
+        $piVars = $parameterApi->getPiVars();
+        $browseObj = GeneralUtility::makeInstance(\JambageCom\Div2007\Base\BrowserBase::class);
+        $browseObj->init(
+            $conf,
+            $piVars,
+            [],
+            false,	// no autocache used yet
+            tx_ttproducts_control_pibase::$pi_USER_INT_obj,
+            $productsCount,
+            $limit,
+            $maxPages,
+            $bShowFirstLast,
+            false,
+            $pagefloat,
+            $imageArray,
+            $imageActiveArray,
+            $dontLinkActivePage
+        );
 
-		return $browseObj;
-	}
+        return $browseObj;
+    }
 
-	public function getBrowserMarkers (
-		$browseObj,
-		$browserConf,
-		$t,
-		$addQueryString,
-		$productsCount,
-		$more,
-		$limit,
-		$begin_at,
-		$useCacheHash,
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
+    public function getBrowserMarkers (
+        $browseObj,
+        $browserConf,
+        $t,
+        $addQueryString,
+        $productsCount,
+        $more,
+        $limit,
+        $begin_at,
+        $useCacheHash,
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
         $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
         $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
+        $parameterApi = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\ParameterApi::class);
 
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$pointerParam = $parameterApi->getPointerPiVar('LIST');
-		$splitMark = md5(microtime());
-		$prefixId = $parameterApi->getPrefixId();
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $pointerParam = $parameterApi->getPointerPiVar('LIST');
+        $splitMark = md5(microtime());
+        $prefixId = $parameterApi->getPrefixId();
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
 
-		if ($more) {
-			$next = ($begin_at + $limit >= $productsCount) ? ($productsCount >= $limit ? $productsCount - $limit : 0) : $begin_at + $limit;
+        if ($more) {
+            $next = ($begin_at + $limit >= $productsCount) ? ($productsCount >= $limit ? $productsCount - $limit : 0) : $begin_at + $limit;
             $next = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($next, 0);
 
-			$addQueryString[$pointerParam] = intval($next / $limit);
-			$this->getSearchParams($addQueryString);
-			
-			$tempUrl =
-				BrowserUtility::linkTPKeepCtrlVars(
-					$browseObj,
-					$cObj,
-					$prefixId,
-					$splitMark,
-					$addQueryString,
-					$useCacheHash
-				);
-			$wrappedSubpartArray['###LINK_NEXT###'] = explode($splitMark, $tempUrl);
-		} else {
-			$subpartArray['###LINK_NEXT###'] = '';
-		}
+            $addQueryString[$pointerParam] = intval($next / $limit);
+            $this->getSearchParams($addQueryString);
+            
+            $tempUrl =
+                BrowserUtility::linkTPKeepCtrlVars(
+                    $browseObj,
+                    $cObj,
+                    $prefixId,
+                    $splitMark,
+                    $addQueryString,
+                    $useCacheHash
+                );
+            $wrappedSubpartArray['###LINK_NEXT###'] = explode($splitMark, $tempUrl);
+        } else {
+            $subpartArray['###LINK_NEXT###'] = '';
+        }
 
-		if ($begin_at) {
-			$prev = ($begin_at - $limit < 0) ? 0 : $begin_at - $limit;
+        if ($begin_at) {
+            $prev = ($begin_at - $limit < 0) ? 0 : $begin_at - $limit;
             $prev = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($prev, 0);
-			$addQueryString[$pointerParam] = intval($prev / $limit);
-			$this->getSearchParams($addQueryString);
-			$tempUrl =
-				BrowserUtility::linkTPKeepCtrlVars(
-					$browseObj,
-					$cObj,
-					$prefixId,
-					$splitMark,
-					$addQueryString,
-					$useCacheHash
-				);
+            $addQueryString[$pointerParam] = intval($prev / $limit);
+            $this->getSearchParams($addQueryString);
+            $tempUrl =
+                BrowserUtility::linkTPKeepCtrlVars(
+                    $browseObj,
+                    $cObj,
+                    $prefixId,
+                    $splitMark,
+                    $addQueryString,
+                    $useCacheHash
+                );
 
 // 			$tempUrl = $pibaseObj->pi_linkTP_keepPIvars($splitMark,$addQueryString,$useCacheHash,0);
-			$wrappedSubpartArray['###LINK_PREV###'] = explode($splitMark, $tempUrl);
-		} else {
-			$subpartArray['###LINK_PREV###'] = '';
-		}
+            $wrappedSubpartArray['###LINK_PREV###'] = explode($splitMark, $tempUrl);
+        } else {
+            $subpartArray['###LINK_PREV###'] = '';
+        }
 
-		$markerArray['###BROWSE_LINKS###'] = '';
+        $markerArray['###BROWSE_LINKS###'] = '';
 
-		if ($productsCount > $limit) { // there is more than one page, so let's browse
+        if ($productsCount > $limit) { // there is more than one page, so let's browse
 
-			$t['browseFrameWork'] = $templateService->getSubpart(
-				$t['listFrameWork'],
-				$subpartmarkerObj->spMarker('###LINK_BROWSE###')
-			);
-			if ($t['browseFrameWork'] != '') {
+            $t['browseFrameWork'] = $templateService->getSubpart(
+                $t['listFrameWork'],
+                $subpartmarkerObj->spMarker('###LINK_BROWSE###')
+            );
+            if ($t['browseFrameWork'] != '') {
 
-				$wrappedSubpartArray['###LINK_BROWSE###'] = ['', ''];
+                $wrappedSubpartArray['###LINK_BROWSE###'] = ['', ''];
 
-				if (is_array($browserConf)) {
-					$addQueryString = [];
-					$this->getSearchParams($addQueryString);
+                if (is_array($browserConf)) {
+                    $addQueryString = [];
+                    $this->getSearchParams($addQueryString);
 
-					$markerArray['###BROWSE_LINKS###'] =
-						BrowserUtility::render(
-							$browseObj,
-							$languageObj,
-							$cObj,
-							$prefixId,
-							true,
-							1,
-							'',
-							$browserConf,
-							$pointerParam,
-							true,
-							$addQueryString
-						);
-				} else {
-					for ($i = 0 ; $i < ($productsCount / $limit); $i++) {
-						if (($begin_at >= $i * $limit) && ($begin_at < $i * $limit + $limit)) {
-							$markerArray['###BROWSE_LINKS###'] .= ' <em>' . (string) ($i + 1) . '</em> ';
-							//	you may use this if you want to link to the current page also
-							//
-						} else {
-							$addQueryString[$pointerParam] = (string) ($i);
-							$tempUrl =
-								BrowserUtility::linkTPKeepCtrlVars(
-									$browseObj,
-									$cObj,
-									$prefixId,
-									(string)($i + 1) . ' ',
-									$addQueryString,
-									$useCacheHash
-								);
+                    $markerArray['###BROWSE_LINKS###'] =
+                        BrowserUtility::render(
+                            $browseObj,
+                            $languageObj,
+                            $cObj,
+                            $prefixId,
+                            true,
+                            1,
+                            '',
+                            $browserConf,
+                            $pointerParam,
+                            true,
+                            $addQueryString
+                        );
+                } else {
+                    for ($i = 0 ; $i < ($productsCount / $limit); $i++) {
+                        if (($begin_at >= $i * $limit) && ($begin_at < $i * $limit + $limit)) {
+                            $markerArray['###BROWSE_LINKS###'] .= ' <em>' . (string) ($i + 1) . '</em> ';
+                            //	you may use this if you want to link to the current page also
+                            //
+                        } else {
+                            $addQueryString[$pointerParam] = (string) ($i);
+                            $tempUrl =
+                                BrowserUtility::linkTPKeepCtrlVars(
+                                    $browseObj,
+                                    $cObj,
+                                    $prefixId,
+                                    (string)($i + 1) . ' ',
+                                    $addQueryString,
+                                    $useCacheHash
+                                );
 
-							$markerArray['###BROWSE_LINKS###'] .= $tempUrl;
-						}
-					}
-				}
-			}
-			// ###CURRENT_PAGE### of ###TOTAL_PAGES###
-			$markerArray['###CURRENT_PAGE###'] = intval($begin_at / $limit + 1);
-			$markerArray['###TOTAL_PAGES###'] = ceil($productsCount / $limit);
-		} else {
-			$subpartArray['###LINK_BROWSE###'] = '';
-			$markerArray['###CURRENT_PAGE###'] = '1';
-			$markerArray['###TOTAL_PAGES###'] = '1';
-		}
-	}
+                            $markerArray['###BROWSE_LINKS###'] .= $tempUrl;
+                        }
+                    }
+                }
+            }
+            // ###CURRENT_PAGE### of ###TOTAL_PAGES###
+            $markerArray['###CURRENT_PAGE###'] = intval($begin_at / $limit + 1);
+            $markerArray['###TOTAL_PAGES###'] = ceil($productsCount / $limit);
+        } else {
+            $subpartArray['###LINK_BROWSE###'] = '';
+            $markerArray['###CURRENT_PAGE###'] = '1';
+            $markerArray['###TOTAL_PAGES###'] = '1';
+        }
+    }
 
 
-	// returns the products list view
-	public function printView (
-		$templateCode,
-		$theCode,
-		$functablename,
-		$allowedItems,
-		$additionalPages,
-		$hiddenFields,
-		&$error_code,
-		$templateArea = 'ITEM_LIST_TEMPLATE',
-		$pageAsCategory,
-		$basketExtra,
-		$basketRecs,
-		$mergeRow = [],
-		$calllevel = 0,
-		$callFunctableArray = [],
-		$parentDataArray = [],
-		$parentProductRow = [], // Download
-		$parentFuncTablename = '', // Download
-		$parentRows = [], // Download
-		$notOverwritePriceIfSet = true, // Download
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$bEditableVariants = true
-	) {
-		if (!empty($error_code)) {
-			return '';
-		}
+    // returns the products list view
+    public function printView (
+        $templateCode,
+        $theCode,
+        $functablename,
+        $allowedItems,
+        $additionalPages,
+        $hiddenFields,
+        &$error_code,
+        $templateArea = 'ITEM_LIST_TEMPLATE',
+        $pageAsCategory,
+        $basketExtra,
+        $basketRecs,
+        $mergeRow = [],
+        $calllevel = 0,
+        $callFunctableArray = [],
+        $parentDataArray = [],
+        $parentProductRow = [], // Download
+        $parentFuncTablename = '', // Download
+        $parentRows = [], // Download
+        $notOverwritePriceIfSet = true, // Download
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $bEditableVariants = true
+    ) {
+        if (!empty($error_code)) {
+            return '';
+        }
 
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
-		$config = $cnfObj->getConfig();
-		$cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$backPid = 0;
-		$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
+        $config = $cnfObj->getConfig();
+        $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $backPid = 0;
+        $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
 
-		$whereCat = '';
+        $whereCat = '';
         $whereProduct = '';
-		$itemArray = [];
+        $itemArray = [];
 
-		$viewedCodeArray = ['LISTAFFORDABLE', 'LISTVIEWEDITEMS', 'LISTVIEWEDMOST', 'LISTVIEWEDMOSTOTHERS'];
-		$bUseCache = true;
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $viewedCodeArray = ['LISTAFFORDABLE', 'LISTVIEWEDITEMS', 'LISTVIEWEDMOST', 'LISTVIEWEDMOSTOTHERS'];
+        $bUseCache = true;
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
 
-		$contentUid = $cObj->data['uid'] ?? 0;
-		$itemTableArray = [];
-		$itemTableViewArray = [];
-		$currentParentRow = '';
-		$externalRowArray = [];
-		$bCheckUnusedArticleMarkers = false;
+        $contentUid = $cObj->data['uid'] ?? 0;
+        $itemTableArray = [];
+        $itemTableViewArray = [];
+        $currentParentRow = '';
+        $externalRowArray = [];
+        $bCheckUnusedArticleMarkers = false;
 
-		if (
-			$parentFuncTablename != '' &&
-			isset($parentRows) &&
-			is_array($parentRows)
-		) {
-			$externalRowArray[$parentFuncTablename] = current($parentRows); // Todo: erweitern, damit die Datensätze mit dem jeweils zugehörenden Vater-Datensatz verbunden werden
-		}
+        if (
+            $parentFuncTablename != '' &&
+            isset($parentRows) &&
+            is_array($parentRows)
+        ) {
+            $externalRowArray[$parentFuncTablename] = current($parentRows); // Todo: erweitern, damit die Datensätze mit dem jeweils zugehörenden Vater-Datensatz verbunden werden
+        }
 
-		$relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
-		$relatedListView->init($this->pidListObj->getPidlist(), 0);
+        $relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
+        $relatedListView->init($this->pidListObj->getPidlist(), 0);
 
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$showArticles = false;
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $showArticles = false;
 
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-		$viewControlConf = $cnfObj->getViewControlConf($theCode);
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $viewControlConf = $cnfObj->getViewControlConf($theCode);
 
-		if (is_array($viewControlConf) && count($viewControlConf)) {
-			if (
-				isset($viewControlConf['param.']) &&
-				is_array($viewControlConf['param.'])
-			) {
-				$viewParamConf = $viewControlConf['param.'];
-			}
+        if (is_array($viewControlConf) && count($viewControlConf)) {
+            if (
+                isset($viewControlConf['param.']) &&
+                is_array($viewControlConf['param.'])
+            ) {
+                $viewParamConf = $viewControlConf['param.'];
+            }
 
-			if (
-				isset($viewControlConf['links.']) &&
-				is_array($viewControlConf['links.'])
-			) {
-				$linkConfArray = $viewControlConf['links.'];
-			}
-		}
+            if (
+                isset($viewControlConf['links.']) &&
+                is_array($viewControlConf['links.'])
+            ) {
+                $linkConfArray = $viewControlConf['links.'];
+            }
+        }
 
-		$useBackPid = (isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ? true : false);
-		if (PluginApi::isRelatedCode($theCode)) {
-			$backPid = $config['backPID']; // stay with the current backPid
-		}
+        $useBackPid = (isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ? true : false);
+        if (PluginApi::isRelatedCode($theCode)) {
+            $backPid = $config['backPID']; // stay with the current backPid
+        }
 
-		if (strpos($theCode, 'MEMO') === false) {
-			$memoViewObj = GeneralUtility::makeInstance('tx_ttproducts_memo_view');
+        if (strpos($theCode, 'MEMO') === false) {
+            $memoViewObj = GeneralUtility::makeInstance('tx_ttproducts_memo_view');
 
-			$memoViewObj->init(
-				$theCode,
-				$config['pid_list'],
-				$conf,
-				$conf['useArticles']
-			);
-		}
-		$pidMemo = ($conf['PIDmemo'] ? $conf['PIDmemo'] : $GLOBALS['TSFE']->id);
+            $memoViewObj->init(
+                $theCode,
+                $config['pid_list'],
+                $conf,
+                $conf['useArticles']
+            );
+        }
+        $pidMemo = ($conf['PIDmemo'] ? $conf['PIDmemo'] : $GLOBALS['TSFE']->id);
 
-		$sqlTableArray = [];
-		$tableAliasArray = [];
-		$sqlTableIndex = 0;
-		$headerFieldArray = [];
-		$headerTableArray = [];
-		$headerTableObjArray = [];
-		$content = '';
-		$out = '';
-		$t = [];
-		$childCatArray = [];
-		$rootCatArray = [];
-		$jsMarkerArray = [];
-		$childCatWrap = '';
-		$imageWrap = '';
-		$linkCat = '';
-		$depth = 1;	// TODO
-		if ($conf['displayBasketColumns'] == '{$plugin.tt_products.displayBasketColumns}') {
-			$conf['displayBasketColumns'] = '1';
-		}
-		$displayColumns = $conf['displayBasketColumns'];
-		$sword = null;
-		$htmlSwords = '';
+        $sqlTableArray = [];
+        $tableAliasArray = [];
+        $sqlTableIndex = 0;
+        $headerFieldArray = [];
+        $headerTableArray = [];
+        $headerTableObjArray = [];
+        $content = '';
+        $out = '';
+        $t = [];
+        $childCatArray = [];
+        $rootCatArray = [];
+        $jsMarkerArray = [];
+        $childCatWrap = '';
+        $imageWrap = '';
+        $linkCat = '';
+        $depth = 1;	// TODO
+        if ($conf['displayBasketColumns'] == '{$plugin.tt_products.displayBasketColumns}') {
+            $conf['displayBasketColumns'] = '1';
+        }
+        $displayColumns = $conf['displayBasketColumns'];
+        $sword = null;
+        $htmlSwords = '';
 
-		if ($calllevel == 0) {
-			$sword = GeneralUtility::_GP('sword');
-			$sword = (isset($sword) ? $sword : GeneralUtility::_GP('swords'));
+        if ($calllevel == 0) {
+            $sword = GeneralUtility::_GP('sword');
+            $sword = (isset($sword) ? $sword : GeneralUtility::_GP('swords'));
 
-			if (!isset($sword)) {
-				$postVars = GeneralUtility::_POST($prefixId);
-				$sword = $postVars['sword'] ?? null;
+            if (!isset($sword)) {
+                $postVars = GeneralUtility::_POST($prefixId);
+                $sword = $postVars['sword'] ?? null;
 
-				if (!isset($sword)) {
-					$getVars = GeneralUtility::_GET($prefixId);
-					$sword = $getVars['sword'] ?? null;
-				}
-			}
+                if (!isset($sword)) {
+                    $getVars = GeneralUtility::_GET($prefixId);
+                    $sword = $getVars['sword'] ?? null;
+                }
+            }
             if (!empty($sword)) {
                 $sword = rawurldecode($sword);
                 $htmlSwords = htmlspecialchars($sword);
             }
-		}
-		$more = 0;	// If set during this loop, the next-item is drawn
-		$where = '';
+        }
+        $more = 0;	// If set during this loop, the next-item is drawn
+        $where = '';
 
-		$formName = 'ShopListForm';
-		$formNameArray = [ // TODO all possible CODEs must have their own form names
-			'LISTRELATEDPARTIALDOWNLOAD' => 'PartialDownloadForm',
-			'LISTRELATEDCOMPLETEDOWNLOAD' => 'CompleteDownloadForm',
+        $formName = 'ShopListForm';
+        $formNameArray = [ // TODO all possible CODEs must have their own form names
+            'LISTRELATEDPARTIALDOWNLOAD' => 'PartialDownloadForm',
+            'LISTRELATEDCOMPLETEDOWNLOAD' => 'CompleteDownloadForm',
             'LISTRELATEDALLDOWNLOAD' => 'AllDownloadForm'
-		];
+        ];
 
-		if (isset($formNameArray[$theCode])) {
-			$formName = $formNameArray[$theCode];
-		}
+        if (isset($formNameArray[$theCode])) {
+            $formName = $formNameArray[$theCode];
+        }
 
-		$itemTableView = $tablesObj->get($functablename, true);
-		$itemTable = $itemTableView->getModelObj();
-		$tablename = $itemTable->getTablename();
-		$categoryfunctablename = '';
+        $itemTableView = $tablesObj->get($functablename, true);
+        $itemTable = $itemTableView->getModelObj();
+        $tablename = $itemTable->getTablename();
+        $categoryfunctablename = '';
 
-		if ($itemTable->getType() == 'dam') {
-			$categoryfunctablename = 'tx_dam_cat';
-		} else {
-			if ($functablename == 'tt_products') {
-				if (!$pageAsCategory || $pageAsCategory == 1) {
-					$categoryfunctablename = 'tt_products_cat';
-				} else {
-					$categoryfunctablename = 'pages';
-				}
-			}
-		}
-		$useCategories = true;
-		if ($categoryfunctablename == '') {
-			$categoryfunctablename = 'tt_products_cat';
-			$useCategories = false;
-		}
-		$keyFieldArray = $itemTable->getKeyFieldArray($theCode);
-		$tableConfArray = [];
-		$viewConfArray = [];
-		$functableArray = [$functablename, $categoryfunctablename];
-		tx_ttproducts_model_control::getTableConfArrays(
-			$cObj,
-			$functableArray,
-			$theCode,
-			$tableConfArray,
-			$viewConfArray
-		);
+        if ($itemTable->getType() == 'dam') {
+            $categoryfunctablename = 'tx_dam_cat';
+        } else {
+            if ($functablename == 'tt_products') {
+                if (!$pageAsCategory || $pageAsCategory == 1) {
+                    $categoryfunctablename = 'tt_products_cat';
+                } else {
+                    $categoryfunctablename = 'pages';
+                }
+            }
+        }
+        $useCategories = true;
+        if ($categoryfunctablename == '') {
+            $categoryfunctablename = 'tt_products_cat';
+            $useCategories = false;
+        }
+        $keyFieldArray = $itemTable->getKeyFieldArray($theCode);
+        $tableConfArray = [];
+        $viewConfArray = [];
+        $functableArray = [$functablename, $categoryfunctablename];
+        tx_ttproducts_model_control::getTableConfArrays(
+            $cObj,
+            $functableArray,
+            $theCode,
+            $tableConfArray,
+            $viewConfArray
+        );
 
-		$itemTable->initCodeConf($theCode, $tableConfArray[$functablename]);
-		$prodAlias = $itemTable->getTableObj()->getAlias();
-		$tableAliasArray[$tablename] = $itemTable->getAlias();
-		$itemTableArray[$itemTable->getType()] = $itemTable;
-		$itemTableViewArray[$itemTable->getType()] = $itemTableView;
-		$selectableVariantFieldArray = $itemTable->getVariant()->getSelectableFieldArray();
-		$useArticles = $cnfObj->getUseArticles();
+        $itemTable->initCodeConf($theCode, $tableConfArray[$functablename]);
+        $prodAlias = $itemTable->getTableObj()->getAlias();
+        $tableAliasArray[$tablename] = $itemTable->getAlias();
+        $itemTableArray[$itemTable->getType()] = $itemTable;
+        $itemTableViewArray[$itemTable->getType()] = $itemTableView;
+        $selectableVariantFieldArray = $itemTable->getVariant()->getSelectableFieldArray();
+        $useArticles = $cnfObj->getUseArticles();
 
-		$excludeList = '';
-		$pointerParam = tx_ttproducts_model_control::getPointerPiVar('LIST');
+        $excludeList = '';
+        $pointerParam = tx_ttproducts_model_control::getPointerPiVar('LIST');
 
-		if (
-			$itemTable->getType() == 'product' &&
-			in_array($useArticles, [1, 3])
-		) {
-			$articleViewObj = $tablesObj->get('tt_products_articles', true);
-			$articleTable = $articleViewObj->getModelObj();
-			$itemTableArray['article'] = $articleTable;
-			$itemTableViewArray['article'] = $articleViewObj;
-		} else if (
-			$itemTable->getType() == 'article' ||
-			$itemTable->getType() == 'dam' && !empty($conf['productDAMCategoryID']) ||
-			$itemTable->getType() == 'download' ||
-			$itemTable->getType() == 'fal'
-		) {
-			$itemTableViewArray['product'] =
-				$tablesObj->get(
-					'tt_products',
-					true
-				);
-			$itemTableArray['product'] = $itemTableViewArray['product']->getModelObj();
-			if ($itemTable->getType() == 'article')  {
-				$articleViewObj = $itemTableView;
-			}
-		}
+        if (
+            $itemTable->getType() == 'product' &&
+            in_array($useArticles, [1, 3])
+        ) {
+            $articleViewObj = $tablesObj->get('tt_products_articles', true);
+            $articleTable = $articleViewObj->getModelObj();
+            $itemTableArray['article'] = $articleTable;
+            $itemTableViewArray['article'] = $articleViewObj;
+        } else if (
+            $itemTable->getType() == 'article' ||
+            $itemTable->getType() == 'dam' && !empty($conf['productDAMCategoryID']) ||
+            $itemTable->getType() == 'download' ||
+            $itemTable->getType() == 'fal'
+        ) {
+            $itemTableViewArray['product'] =
+                $tablesObj->get(
+                    'tt_products',
+                    true
+                );
+            $itemTableArray['product'] = $itemTableViewArray['product']->getModelObj();
+            if ($itemTable->getType() == 'article')  {
+                $articleViewObj = $itemTableView;
+            }
+        }
 
-		if (
-			!PluginApi::isRelatedCode($theCode) &&
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax') &&
-			$itemTable->getType() == 'product' &&
-			(
-				$bEditableVariants ||
-				in_array($useArticles, [1, 2, 3])
-			)
-		) {
-			tx_ttproducts_control_product::addAjax(
-				$tablesObj,
-				$languageObj,
-				$theCode,
-				$itemTable->getFuncTablename()
-			);
-		}
+        if (
+            !PluginApi::isRelatedCode($theCode) &&
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax') &&
+            $itemTable->getType() == 'product' &&
+            (
+                $bEditableVariants ||
+                in_array($useArticles, [1, 2, 3])
+            )
+        ) {
+            tx_ttproducts_control_product::addAjax(
+                $tablesObj,
+                $languageObj,
+                $theCode,
+                $itemTable->getFuncTablename()
+            );
+        }
 
-		$cssConf = $cnfObj->getCSSConf($itemTable->getFuncTablename(), $theCode);
-		$categoryPivar = tx_ttproducts_model_control::getPiVar($categoryfunctablename);
+        $cssConf = $cnfObj->getCSSConf($itemTable->getFuncTablename(), $theCode);
+        $categoryPivar = tx_ttproducts_model_control::getPiVar($categoryfunctablename);
 
-		if ($useCategories) {
-			$categoryTableView = $tablesObj->get($categoryfunctablename, true);
-			$categoryTable = $categoryTableView->getModelObj();
-			$tableConfArray[$categoryfunctablename] = $categoryTable->getTableConf($theCode);
-			$catTableConf = $categoryTable->getTableConf($theCode);
-			$categoryTable->initCodeConf($theCode, $catTableConf);
-			$categoryAnd = tx_ttproducts_model_control::getAndVar($categoryPivar);
-		}
-		$whereArray = '';
-		if (!empty($piVars[tx_ttproducts_model_control::getPiVar($functablename)])) {
+        if ($useCategories) {
+            $categoryTableView = $tablesObj->get($categoryfunctablename, true);
+            $categoryTable = $categoryTableView->getModelObj();
+            $tableConfArray[$categoryfunctablename] = $categoryTable->getTableConf($theCode);
+            $catTableConf = $categoryTable->getTableConf($theCode);
+            $categoryTable->initCodeConf($theCode, $catTableConf);
+            $categoryAnd = tx_ttproducts_model_control::getAndVar($categoryPivar);
+        }
+        $whereArray = '';
+        if (!empty($piVars[tx_ttproducts_model_control::getPiVar($functablename)])) {
             $whereArray = $piVars[tx_ttproducts_model_control::getPiVar($functablename)];
         }
 
-		if (is_array($whereArray)) {
-			foreach ($whereArray as $field => $value) {
-				if (is_array($value)) {
-					foreach ($value as $comparator => $comparand) {
-						$sqlOperator = '';
-						$comparator = tx_ttproducts_sql::transformComparator($comparator);
+        if (is_array($whereArray)) {
+            foreach ($whereArray as $field => $value) {
+                if (is_array($value)) {
+                    foreach ($value as $comparator => $comparand) {
+                        $sqlOperator = '';
+                        $comparator = tx_ttproducts_sql::transformComparator($comparator);
 
-						if ($comparand) {
-							$tablename = $itemTable->getTableObj()->getName();
-							$whereField =
-								tx_ttproducts_sql::getWhere4Field(
-									$tablename,
-									$field,
-									$comparator,
-									$comparand
-								);
+                        if ($comparand) {
+                            $tablename = $itemTable->getTableObj()->getName();
+                            $whereField =
+                                tx_ttproducts_sql::getWhere4Field(
+                                    $tablename,
+                                    $field,
+                                    $comparator,
+                                    $comparand
+                                );
 
-							if ($whereField !== false) {
+                            if ($whereField !== false) {
 
-								$where .= $whereField;
-							}
-						}
-					}
-				} else {
-					$where .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $itemTable->getTableObj()->name);
-				}
-			}
-		}
-		$flexformArray = \JambageCom\TtProducts\Api\PluginApi::getFlexform();
-		$dam_group_by = '';
+                                $where .= $whereField;
+                            }
+                        }
+                    }
+                } else {
+                    $where .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $itemTable->getTableObj()->name);
+                }
+            }
+        }
+        $flexformArray = \JambageCom\TtProducts\Api\PluginApi::getFlexform();
+        $dam_group_by = '';
 
-		if ($itemTable->getType() == 'product') {
-			$product_where = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'product_where');
+        if ($itemTable->getType() == 'product') {
+            $product_where = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'product_where');
 
-			if ($product_where) {
-				$product_where = $itemTable->getTableObj()->transformWhere($product_where);
-				$where .= ' AND ' . $product_where;
-			}
-		} else if ($itemTable->getType() == 'dam') {
-			$dam_where = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_where');
-			$dam_group_by = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_group_by');
-			$dam_join_tables = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_join_tables');
-			$damJoinTableArray = GeneralUtility::trimExplode(',', $dam_join_tables);
+            if ($product_where) {
+                $product_where = $itemTable->getTableObj()->transformWhere($product_where);
+                $where .= ' AND ' . $product_where;
+            }
+        } else if ($itemTable->getType() == 'dam') {
+            $dam_where = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_where');
+            $dam_group_by = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_group_by');
+            $dam_join_tables = \JambageCom\Div2007\Utility\FlexformUtility::get($flexformArray, 'dam_join_tables');
+            $damJoinTableArray = GeneralUtility::trimExplode(',', $dam_join_tables);
 
-			if ($dam_where) {
-				$dam_where = $itemTable->getTableObj()->transformWhere($dam_where);
-				$where .= ' AND ' . $dam_where;
-			}
-		}
+            if ($dam_where) {
+                $dam_where = $itemTable->getTableObj()->transformWhere($dam_where);
+                $where .= ' AND ' . $dam_where;
+            }
+        }
 
-		// if parameter 'newitemdays' is specified, only new items from the last X days are displayed
-		$newitemdays = '';
-		if (!empty($piVars['newitemdays'])) {
+        // if parameter 'newitemdays' is specified, only new items from the last X days are displayed
+        $newitemdays = '';
+        if (!empty($piVars['newitemdays'])) {
             $newitemdays = $piVars['newitemdays'];
         }
-		$newitemdays = ($newitemdays ? $newitemdays : GeneralUtility::_GP('newitemdays'));
+        $newitemdays = ($newitemdays ? $newitemdays : GeneralUtility::_GP('newitemdays'));
 
-		if (
-			($newitemdays || $theCode == 'LISTNEWITEMS') &&
-			is_array($tableConfArray[$functablename]) &&
-			is_array($tableConfArray[$functablename]['controlFields.'])
-		) {
-			if (!$newitemdays) {
-				$newitemdays = $conf['newItemDays'];
-			}
-			$temptime = time() - 86400 * intval(trim($newitemdays));
-			$timeFieldArray = GeneralUtility::trimExplode(',', $tableConfArray[$functablename]['controlFields.']['newItemDays']);
-			$whereTimeFieldArray = [];
-			foreach ($timeFieldArray as $k => $value) {
-				$whereTimeFieldArray[] = $tableAliasArray[$tablename] . '.' . $value . ' >= ' . $temptime;
-			}
-			if (count($whereTimeFieldArray)) {
-				$where .= ' AND (' . implode(' OR ', $whereTimeFieldArray) . ')';
-			}
-		}
+        if (
+            ($newitemdays || $theCode == 'LISTNEWITEMS') &&
+            is_array($tableConfArray[$functablename]) &&
+            is_array($tableConfArray[$functablename]['controlFields.'])
+        ) {
+            if (!$newitemdays) {
+                $newitemdays = $conf['newItemDays'];
+            }
+            $temptime = time() - 86400 * intval(trim($newitemdays));
+            $timeFieldArray = GeneralUtility::trimExplode(',', $tableConfArray[$functablename]['controlFields.']['newItemDays']);
+            $whereTimeFieldArray = [];
+            foreach ($timeFieldArray as $k => $value) {
+                $whereTimeFieldArray[] = $tableAliasArray[$tablename] . '.' . $value . ' >= ' . $temptime;
+            }
+            if (count($whereTimeFieldArray)) {
+                $where .= ' AND (' . implode(' OR ', $whereTimeFieldArray) . ')';
+            }
+        }
 
-		if (
-			$useCategories &&
-			$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] != '2'
-		) {
-			$cat = $categoryTable->getParamDefault($theCode, $piVars[$categoryPivar] ?? '');
-		}
-		$searchboxWhere = '';
-		$searchVars = [];
-		if (isset($piVars[tx_ttproducts_model_control::getSearchboxVar()])) {
+        if (
+            $useCategories &&
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] != '2'
+        ) {
+            $cat = $categoryTable->getParamDefault($theCode, $piVars[$categoryPivar] ?? '');
+        }
+        $searchboxWhere = '';
+        $searchVars = [];
+        if (isset($piVars[tx_ttproducts_model_control::getSearchboxVar()])) {
             $searchVars = $piVars[tx_ttproducts_model_control::getSearchboxVar()];
         }
-		$bUseSearchboxArray = [];
-		$latest = '';
+        $bUseSearchboxArray = [];
+        $latest = '';
 
-		if (
+        if (
             !empty($searchVars) &&
             (
                 isset($searchVars['local']) ||
                 isset($searchVars['uid'])
             )
         ) {
-			tx_ttproducts_model_control::getSearchInfo(
-				$cObj,
-				$searchVars,
-				$functablename,
-				$tablename,
-				$searchboxWhere,
-				$bUseSearchboxArray,
-				$sqlTableIndex,
-				$latest
-			);
-		}
-		$pageViewObj = $tablesObj->get('pages', 1);
-		$pid =
-			$pageViewObj->getModelObj()->getParamDefault(
-				$theCode,
-				$piVars[$pageViewObj->piVar] ?? ''
-			);
+            tx_ttproducts_model_control::getSearchInfo(
+                $cObj,
+                $searchVars,
+                $functablename,
+                $tablename,
+                $searchboxWhere,
+                $bUseSearchboxArray,
+                $sqlTableIndex,
+                $latest
+            );
+        }
+        $pageViewObj = $tablesObj->get('pages', 1);
+        $pid =
+            $pageViewObj->getModelObj()->getParamDefault(
+                $theCode,
+                $piVars[$pageViewObj->piVar] ?? ''
+            );
 
-		$addressUid = $piVars['a'] ?? '';
+        $addressUid = $piVars['a'] ?? '';
 
-		$hookVar = 'allowedItems';
-		if (
+        $hookVar = 'allowedItems';
+        if (
             $hookVar &&
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar]) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'init')) {
-					$hookObj->init($this);
-				}
-				if (method_exists($hookObj, 'getAllowedItems')) {
-					$tmpArray =
-						$hookObj->getAllowedItems(
-							$allowedItems,
-							$itemTable,
-							$theCode,
-							$additionalPages,
-							$pageAsCategory
-						);
-				}
-			}
-		}
-		if ($allowedItems != '') { // formerly: !$tableConfArray[$functablename]['orderBy'] &&
-			$tableConfArray[$functablename]['orderBy'] = 'FIELD(' . $prodAlias . '.uid, ' . $allowedItems . ')';
-		}
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$hookVar] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'init')) {
+                    $hookObj->init($this);
+                }
+                if (method_exists($hookObj, 'getAllowedItems')) {
+                    $tmpArray =
+                        $hookObj->getAllowedItems(
+                            $allowedItems,
+                            $itemTable,
+                            $theCode,
+                            $additionalPages,
+                            $pageAsCategory
+                        );
+                }
+            }
+        }
+        if ($allowedItems != '') { // formerly: !$tableConfArray[$functablename]['orderBy'] &&
+            $tableConfArray[$functablename]['orderBy'] = 'FIELD(' . $prodAlias . '.uid, ' . $allowedItems . ')';
+        }
 
-		$whereAddress = '';
-		$addrTablename = $conf['table.']['address'];
-		if (
-			(
-				$addrTablename == 'tx_party_addresses' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(PARTY_EXT) ||
-				$addrTablename == 'tx_partner_main' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(PARTNER_EXT) ||
-				$addrTablename == 'tt_address' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TT_ADDRESS_EXT)
-			)
-			&& $addressUid && $itemTable->fieldArray['address']
-		) {
-			$addressViewObj = $tablesObj->get('address', true);
-			$addressObj = $addressViewObj->getModelObj();
+        $whereAddress = '';
+        $addrTablename = $conf['table.']['address'];
+        if (
+            (
+                $addrTablename == 'tx_party_addresses' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(PARTY_EXT) ||
+                $addrTablename == 'tx_partner_main' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(PARTNER_EXT) ||
+                $addrTablename == 'tt_address' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TT_ADDRESS_EXT)
+            )
+            && $addressUid && $itemTable->fieldArray['address']
+        ) {
+            $addressViewObj = $tablesObj->get('address', true);
+            $addressObj = $addressViewObj->getModelObj();
 
-			if (intval($addressUid)) {
-				$whereAddress = ' AND (' . $itemTable->fieldArray['address'] . '=' . intval($addressUid) . ')';
-			} else if ($addressObj->fieldArray['name']) {
-				$addressRow =
-					$addressObj->get(
-						'0',
-						0,
-						false,
-						$addressObj->fieldArray['name'] . '=' .
-						$GLOBALS['TYPO3_DB']->fullQuoteStr(
-							$addressUid,
-							$addressObj->getTablename(),
-							'',
-							'uid,' . $addressObj->fieldArray['name']
-						)
-					);
+            if (intval($addressUid)) {
+                $whereAddress = ' AND (' . $itemTable->fieldArray['address'] . '=' . intval($addressUid) . ')';
+            } else if ($addressObj->fieldArray['name']) {
+                $addressRow =
+                    $addressObj->get(
+                        '0',
+                        0,
+                        false,
+                        $addressObj->fieldArray['name'] . '=' .
+                        $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                            $addressUid,
+                            $addressObj->getTablename(),
+                            '',
+                            'uid,' . $addressObj->fieldArray['name']
+                        )
+                    );
 
-				$addressText = $addressRow[$addressObj->fieldArray['name']];
-				$whereAddress = ' AND (' . $itemTable->fieldArray['address'] . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($addressText, $addressObj->getTablename()) . ')';
-			}
-			$where .= $whereAddress;
-		}
+                $addressText = $addressRow[$addressObj->fieldArray['name']];
+                $whereAddress = ' AND (' . $itemTable->fieldArray['address'] . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($addressText, $addressObj->getTablename()) . ')';
+            }
+            $where .= $whereAddress;
+        }
 
-		if ($whereAddress == '') { // do not mix address with category filter
+        if ($whereAddress == '') { // do not mix address with category filter
             $bForceCatParams = false;
 
-			if (isset($tableConfArray[$functablename]['filter.']) && is_array($tableConfArray[$functablename]['filter.']) &&
-				isset($tableConfArray[$functablename]['filter.']['param.']) && is_array($tableConfArray[$functablename]['filter.']['param.']) &&
-				$tableConfArray[$functablename]['filter.']['param.']['cat'] == 'gp') {
-				$bForceCatParams = true;
-			}
+            if (isset($tableConfArray[$functablename]['filter.']) && is_array($tableConfArray[$functablename]['filter.']) &&
+                isset($tableConfArray[$functablename]['filter.']['param.']) && is_array($tableConfArray[$functablename]['filter.']['param.']) &&
+                $tableConfArray[$functablename]['filter.']['param.']['cat'] == 'gp') {
+                $bForceCatParams = true;
+            }
 
-			if (
-				$allowedItems == '' &&
-				!in_array($theCode, $viewedCodeArray) &&
-				$calllevel == 0 ||
+            if (
+                $allowedItems == '' &&
+                !in_array($theCode, $viewedCodeArray) &&
+                $calllevel == 0 ||
 
-				$bForceCatParams
-			) {
-				$whereCat =
-					$itemTable->addWhereCat(
-						$categoryTable,
-						$theCode,
-						$cat,
-						$categoryAnd,
-						$this->pidListObj->getPidlist(),
-						true
-					);
-			}
+                $bForceCatParams
+            ) {
+                $whereCat =
+                    $itemTable->addWhereCat(
+                        $categoryTable,
+                        $theCode,
+                        $cat,
+                        $categoryAnd,
+                        $this->pidListObj->getPidlist(),
+                        true
+                    );
+            }
 
-			if ($whereCat == '' && ($allowedItems == '' || $bForceCatParams)) {
-				$neededParams = $itemTable->getNeededUrlParams($functablename, $theCode);
-				$needArray = GeneralUtility::trimExplode(',', $neededParams);
-				$bListStartEmpty = false;
-				foreach($needArray as $k => $param) {
-					if ($param && !isset($piVars[$param])) {
-						$bListStartEmpty = true;
-						break;
-					}
-				}
-				if ($bListStartEmpty) {
-					$allowedItems = '0';	// not possible uid
-				}
-			}
+            if ($whereCat == '' && ($allowedItems == '' || $bForceCatParams)) {
+                $neededParams = $itemTable->getNeededUrlParams($functablename, $theCode);
+                $needArray = GeneralUtility::trimExplode(',', $neededParams);
+                $bListStartEmpty = false;
+                foreach($needArray as $k => $param) {
+                    if ($param && !isset($piVars[$param])) {
+                        $bListStartEmpty = true;
+                        break;
+                    }
+                }
+                if ($bListStartEmpty) {
+                    $allowedItems = '0';	// not possible uid
+                }
+            }
 
-			if ($searchboxWhere != '') {
-				if ($bUseSearchboxArray[$categoryfunctablename]) {
-					$whereCat .= ' AND ' . $searchboxWhere;
-				} else {
-					$whereProduct = ' AND ' . $searchboxWhere;
-				}
-			}
-			$where .= $whereCat . $whereProduct;
-		}
+            if ($searchboxWhere != '') {
+                if ($bUseSearchboxArray[$categoryfunctablename]) {
+                    $whereCat .= ' AND ' . $searchboxWhere;
+                } else {
+                    $whereProduct = ' AND ' . $searchboxWhere;
+                }
+            }
+            $where .= $whereCat . $whereProduct;
+        }
 
-		if (
+        if (
             isset($conf['form.'][$theCode . '.']) &&
             isset($conf['form.'][$theCode . '.']['data.']) &&
             isset($conf['form.'][$theCode . '.']['data.']['name'])
         ) {
-			$formNameSetup = $conf['form.'][$theCode . '.']['data.']['name'];
-		}
-		$formName = (!empty($formNameSetup) ? $formNameSetup : $formName);
+            $formNameSetup = $conf['form.'][$theCode . '.']['data.']['name'];
+        }
+        $formName = (!empty($formNameSetup) ? $formNameSetup : $formName);
 
-		if ($htmlSwords && (in_array($theCode, ['LIST', 'SEARCH']))) {
-				//extend standard search fields with user setup
-			$searchFieldList =
-				trim($conf['stdSearchFieldExt']) ?
-					implode(',', array_unique(GeneralUtility::trimExplode(',', $conf['stdSearchFieldExt']))) :
-					'title,note,' . $tablesObj->get('tt_products')->fieldArray['itemnumber'];
+        if ($htmlSwords && (in_array($theCode, ['LIST', 'SEARCH']))) {
+                //extend standard search fields with user setup
+            $searchFieldList =
+                trim($conf['stdSearchFieldExt']) ?
+                    implode(',', array_unique(GeneralUtility::trimExplode(',', $conf['stdSearchFieldExt']))) :
+                    'title,note,' . $tablesObj->get('tt_products')->fieldArray['itemnumber'];
 
-			$where .= $tablesObj->get('tt_products')->searchWhere($searchFieldList, trim($htmlSwords), $theCode);
-		}
+            $where .= $tablesObj->get('tt_products')->searchWhere($searchFieldList, trim($htmlSwords), $theCode);
+        }
 
-		if (isset($piVars['search']) && is_array($piVars['search'])) {
-			$searchWhere = '';
-			foreach ($piVars['search'] as $field => $value) {
-				if (isset($GLOBALS['TCA'][$tablename]['columns'][$field])) {
-					$searchWhere .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $tablename);
-				}
-			}
-			$where .= $searchWhere;
-		}
+        if (isset($piVars['search']) && is_array($piVars['search'])) {
+            $searchWhere = '';
+            foreach ($piVars['search'] as $field => $value) {
+                if (isset($GLOBALS['TCA'][$tablename]['columns'][$field])) {
+                    $searchWhere .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $tablename);
+                }
+            }
+            $where .= $searchWhere;
+        }
 
-		switch ($theCode) {
-			case 'LISTAFFORDABLE':
-				$formName = 'ListAffordable';
-			break;
-			case 'LISTARTICLES':
-			case 'LISTRELATEDARTICLES':
-				$formName = 'ListArticlesForm';
-			break;
-			case 'LISTDAM':
-			case 'MEMODAM':
-				if ($theCode == 'LISTDAM') {
-					$formName = 'ListDAMForm';
-					$templateArea = 'ITEM_LISTDAM_TEMPLATE' . $templateObj->getTemplateSuffix();
-				} else if ($theCode == 'MEMODAM') {
-					$formName = 'ListMemoDAMForm';
-					$bUseCache = false;
-				}
-			break;
-			case 'LISTGIFTS':
-				$formName = 'GiftForm';
-				$where .= ' AND ' . ($conf['whereGift'] ? $conf['whereGift'] : '1=0');
-				$templateArea = 'ITEM_LIST_GIFTS_TEMPLATE' . $templateObj->getTemplateSuffix();
-			break;
-			case 'LISTHIGHLIGHTS':
-				$formName = 'ListHighlightsForm';
-				$where .= ' AND highlight';
-			break;
-			case 'LISTNEWITEMS':
-				$formName = 'ListNewItemsForm';
-			break;
-			case 'LISTOFFERS':
-				$formName = 'ListOffersForm';
-				$where .= ' AND offer';
-			break;
-			case 'LISTORDERED':
-				$formName = 'ListOrderedForm';
-			break;
-			case 'LISTVIEWEDITEMS':
-				$formName = 'ListViewedItemsForm';
-			break;
-			case 'LISTVIEWEDMOST':
-				$formName = 'ListViewedMost';
-			break;
-			case 'LISTVIEWEDMOSTOTHERS':
-				$formName = 'ListViewedMostOthers';
-			break;
-			case 'MEMO':
-				$formName = 'ListMemoForm';
-				$bUseCache = false;
-			break;
-			case 'SEARCH':
-				$formName = 'ShopSearchForm';
-				$searchTemplateArea = 'ITEM_SEARCH';
-					// Get search subpart
-				$t['search'] =
-					$templateService->getSubpart(
-						$templateCode,
-						$subpartmarkerObj->spMarker('###' . $searchTemplateArea . '###' . $templateObj->getTemplateSuffix())
-					);
+        switch ($theCode) {
+            case 'LISTAFFORDABLE':
+                $formName = 'ListAffordable';
+            break;
+            case 'LISTARTICLES':
+            case 'LISTRELATEDARTICLES':
+                $formName = 'ListArticlesForm';
+            break;
+            case 'LISTDAM':
+            case 'MEMODAM':
+                if ($theCode == 'LISTDAM') {
+                    $formName = 'ListDAMForm';
+                    $templateArea = 'ITEM_LISTDAM_TEMPLATE' . $templateObj->getTemplateSuffix();
+                } else if ($theCode == 'MEMODAM') {
+                    $formName = 'ListMemoDAMForm';
+                    $bUseCache = false;
+                }
+            break;
+            case 'LISTGIFTS':
+                $formName = 'GiftForm';
+                $where .= ' AND ' . ($conf['whereGift'] ? $conf['whereGift'] : '1=0');
+                $templateArea = 'ITEM_LIST_GIFTS_TEMPLATE' . $templateObj->getTemplateSuffix();
+            break;
+            case 'LISTHIGHLIGHTS':
+                $formName = 'ListHighlightsForm';
+                $where .= ' AND highlight';
+            break;
+            case 'LISTNEWITEMS':
+                $formName = 'ListNewItemsForm';
+            break;
+            case 'LISTOFFERS':
+                $formName = 'ListOffersForm';
+                $where .= ' AND offer';
+            break;
+            case 'LISTORDERED':
+                $formName = 'ListOrderedForm';
+            break;
+            case 'LISTVIEWEDITEMS':
+                $formName = 'ListViewedItemsForm';
+            break;
+            case 'LISTVIEWEDMOST':
+                $formName = 'ListViewedMost';
+            break;
+            case 'LISTVIEWEDMOSTOTHERS':
+                $formName = 'ListViewedMostOthers';
+            break;
+            case 'MEMO':
+                $formName = 'ListMemoForm';
+                $bUseCache = false;
+            break;
+            case 'SEARCH':
+                $formName = 'ShopSearchForm';
+                $searchTemplateArea = 'ITEM_SEARCH';
+                    // Get search subpart
+                $t['search'] =
+                    $templateService->getSubpart(
+                        $templateCode,
+                        $subpartmarkerObj->spMarker('###' . $searchTemplateArea . '###' . $templateObj->getTemplateSuffix())
+                    );
 
-				if (!$t['search']) {
-					$error_code[0] = 'no_subtemplate';
-					$error_code[1] = '###' . $searchTemplateArea . '###';
-					$error_code[2] = $templateObj->getTemplateFile();
+                if (!$t['search']) {
+                    $error_code[0] = 'no_subtemplate';
+                    $error_code[1] = '###' . $searchTemplateArea . '###';
+                    $error_code[2] = $templateObj->getTemplateFile();
 
-					return '';
-				}
+                    return '';
+                }
 
-					// Substitute a few markers
-				$out = $t['search'];
-				$tmpPid = ($conf['PIDsearch'] ? $conf['PIDsearch'] : $GLOBALS['TSFE']->id);
-				$addQueryString = [];
-				$this->getSearchParams($addQueryString);
+                    // Substitute a few markers
+                $out = $t['search'];
+                $tmpPid = ($conf['PIDsearch'] ? $conf['PIDsearch'] : $GLOBALS['TSFE']->id);
+                $addQueryString = [];
+                $this->getSearchParams($addQueryString);
 
-				$excludeList = 'sword';
+                $excludeList = 'sword';
 
-				if (
-					isset($viewParamConf) &&
-					is_array($viewParamConf) &&
-					GeneralUtility::inList($viewParamConf['item'], $categoryPivar)
-				) {
-					// nothing
-				} else {
-					$excludeList .= ',' . $prefixId . '[' . $categoryPivar . ']';
-				}
+                if (
+                    isset($viewParamConf) &&
+                    is_array($viewParamConf) &&
+                    GeneralUtility::inList($viewParamConf['item'], $categoryPivar)
+                ) {
+                    // nothing
+                } else {
+                    $excludeList .= ',' . $prefixId . '[' . $categoryPivar . ']';
+                }
 
-				if (
-					isset($viewParamConf) &&
-					is_array($viewParamConf) &&
-					isset($viewParamConf['ignore'])
-				) {
-					$ignoreArray = GeneralUtility::trimExplode(',', $viewParamConf['ignore']);
-					foreach($ignoreArray as $ignoreParam) {
-						if ($ignoreParam == 'backPID') {
-							$useBackPid = false;
-						}
-						$excludeList .= ',' . $prefixId . '[' . $ignoreParam . ']';
-					}
-				}
+                if (
+                    isset($viewParamConf) &&
+                    is_array($viewParamConf) &&
+                    isset($viewParamConf['ignore'])
+                ) {
+                    $ignoreArray = GeneralUtility::trimExplode(',', $viewParamConf['ignore']);
+                    foreach($ignoreArray as $ignoreParam) {
+                        if ($ignoreParam == 'backPID') {
+                            $useBackPid = false;
+                        }
+                        $excludeList .= ',' . $prefixId . '[' . $ignoreParam . ']';
+                    }
+                }
 
-				$markerArray =
-					$urlObj->addURLMarkers(
-						$tmpPid,
-						[],
-						$addQueryString,
-						$excludeList,
-						$useBackPid,
-						$backPid
-					);
+                $markerArray =
+                    $urlObj->addURLMarkers(
+                        $tmpPid,
+                        [],
+                        $addQueryString,
+                        $excludeList,
+                        $useBackPid,
+                        $backPid
+                    );
 
-					// add Global Marker Array
-				$markerArray = array_merge($markerArray, $globalMarkerArray);
-				$markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid;
-				$markerArray['###SWORD###'] = $htmlSwords;
-				$markerArray['###SWORD_NAME###'] = $prefixId . '[sword]';
-				$markerArray['###SWORDS###'] = $htmlSwords; // for backwards compatibility
-				$out = $templateService->substituteMarkerArrayCached($out, $markerArray);
-				if ($formName) {
-						// Add to content
-					$content .= $out;
-				}
-				$out = '';
-				$bUseCache = false; // tt_products must be a USER_INT if the search word has been entered! You must not use a cache for a searched list or single view.
-			break;
-			default:
-				// nothing here
-			break;
-		}
+                    // add Global Marker Array
+                $markerArray = array_merge($markerArray, $globalMarkerArray);
+                $markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid;
+                $markerArray['###SWORD###'] = $htmlSwords;
+                $markerArray['###SWORD_NAME###'] = $prefixId . '[sword]';
+                $markerArray['###SWORDS###'] = $htmlSwords; // for backwards compatibility
+                $out = $templateService->substituteMarkerArrayCached($out, $markerArray);
+                if ($formName) {
+                        // Add to content
+                    $content .= $out;
+                }
+                $out = '';
+                $bUseCache = false; // tt_products must be a USER_INT if the search word has been entered! You must not use a cache for a searched list or single view.
+            break;
+            default:
+                // nothing here
+            break;
+        }
 
-		if ($useCategories) {
-			$currentCat = $categoryTable->getParamDefault($theCode, $piVars[$categoryPivar] ?? '');
-			$rootCat = $categoryTable->getRootCat() ?? '';
-			$relatedArray = $categoryTable->getRelated($rootCat, $currentCat, $this->pidListObj->getPidlist());	// read only related categories;
-			$excludeCat = 0;
-			$categoryArray = $categoryTable->getRelationArray($relatedArray, $excludeCat, $rootCat, implode(',', array_keys($relatedArray)));
-			$rootCatArray = $categoryTable->getRootArray($rootCat, $categoryArray, $tableConfArray[$functablename]['autoRoot'] ?? 0);
+        if ($useCategories) {
+            $currentCat = $categoryTable->getParamDefault($theCode, $piVars[$categoryPivar] ?? '');
+            $rootCat = $categoryTable->getRootCat() ?? '';
+            $relatedArray = $categoryTable->getRelated($rootCat, $currentCat, $this->pidListObj->getPidlist());	// read only related categories;
+            $excludeCat = 0;
+            $categoryArray = $categoryTable->getRelationArray($relatedArray, $excludeCat, $rootCat, implode(',', array_keys($relatedArray)));
+            $rootCatArray = $categoryTable->getRootArray($rootCat, $categoryArray, $tableConfArray[$functablename]['autoRoot'] ?? 0);
 
-			if ($conf['clickItemsIntoSubmenu']) {
-				$childCatArray = $categoryTable->getChildCategoryArray($currentCat);
-				if (count($childCatArray)) {
-					$templateArea = 'HAS_CHILDS_' . $templateArea;
-				}
-			}
-		}
+            if ($conf['clickItemsIntoSubmenu']) {
+                $childCatArray = $categoryTable->getChildCategoryArray($currentCat);
+                if (count($childCatArray)) {
+                    $templateArea = 'HAS_CHILDS_' . $templateArea;
+                }
+            }
+        }
 
-		$limit = isset($tableConfArray[$functablename]['limit']) ? $tableConfArray[$functablename]['limit'] : $config['limit'];
-		$limit = intval($limit);
-		$begin_at = 0;
+        $limit = isset($tableConfArray[$functablename]['limit']) ? $tableConfArray[$functablename]['limit'] : $config['limit'];
+        $limit = intval($limit);
+        $begin_at = 0;
 
         if ($calllevel == 0) {
 
-			$begin_at = ($piVars[$pointerParam] ?? 0) * $limit;
-		}
+            $begin_at = ($piVars[$pointerParam] ?? 0) * $limit;
+        }
         $begin_at = MathUtility::forceIntegerInRange($begin_at, 0, 100000);
 
-		if ($theCode == 'SINGLE') {
-			$begin_at = ''; // no page browser in single view for related products
-		}
+        if ($theCode == 'SINGLE') {
+            $begin_at = ''; // no page browser in single view for related products
+        }
 
-		if (
-			$theCode != 'SEARCH' ||
-			(
-				$conf['listViewOnSearch'] == '1' &&
-				$theCode == 'SEARCH' &&
-				$sword
-			)
-		) {
-			$t['listFrameWork'] = $templateService->getSubpart(
-				$templateCode,
-				$subpartmarkerObj->spMarker('###' . $templateArea . '###')
-			);
+        if (
+            $theCode != 'SEARCH' ||
+            (
+                $conf['listViewOnSearch'] == '1' &&
+                $theCode == 'SEARCH' &&
+                $sword
+            )
+        ) {
+            $t['listFrameWork'] = $templateService->getSubpart(
+                $templateCode,
+                $subpartmarkerObj->spMarker('###' . $templateArea . '###')
+            );
 
-			// $templateArea = 'ITEM_LIST_TEMPLATE'
-			if (!$t['listFrameWork']) {
-				$error_code[0] = 'no_subtemplate';
-				$error_code[1] = '###' . $templateArea . '###';
-				$error_code[2] = $templateObj->getTemplateFile();
+            // $templateArea = 'ITEM_LIST_TEMPLATE'
+            if (!$t['listFrameWork']) {
+                $error_code[0] = 'no_subtemplate';
+                $error_code[1] = '###' . $templateArea . '###';
+                $error_code[2] = $templateObj->getTemplateFile();
 
-				return $content;
-			}
+                return $content;
+            }
 
-			$checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
-			if (!empty($checkExpression)) {
-				$wrongPounds = preg_match_all($checkExpression, $t['listFrameWork'], $matches);
+            $checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
+            if (!empty($checkExpression)) {
+                $wrongPounds = preg_match_all($checkExpression, $t['listFrameWork'], $matches);
 
-				if ($wrongPounds) {
-					$error_code[0] = 'template_invalid_marker_border';
-					$error_code[1] = '###' . $templateArea . '###';
-					$error_code[2] =  htmlspecialchars(implode('|', $matches['0']));
+                if ($wrongPounds) {
+                    $error_code[0] = 'template_invalid_marker_border';
+                    $error_code[1] = '###' . $templateArea . '###';
+                    $error_code[2] =  htmlspecialchars(implode('|', $matches['0']));
 
-					return '';
-				}
-			}
+                    return '';
+                }
+            }
 
-			$addQueryString = $this->uidArray;
-			$excludeList = ($theCode == 'SEARCH' ? 'sword' : '');
-			$this->getSearchParams($addQueryString);
-			$markerArray = [];
-			$markerArray['###HIDDENFIELDS###'] = '';
-			$markerArray =
-				$urlObj->addURLMarkers(
-					$this->pid,
-					$markerArray,
-					$addQueryString,
-					$excludeList,
-					$useBackPid,
-					$backPid
-				); // clickIntoBasket
+            $addQueryString = $this->uidArray;
+            $excludeList = ($theCode == 'SEARCH' ? 'sword' : '');
+            $this->getSearchParams($addQueryString);
+            $markerArray = [];
+            $markerArray['###HIDDENFIELDS###'] = '';
+            $markerArray =
+                $urlObj->addURLMarkers(
+                    $this->pid,
+                    $markerArray,
+                    $addQueryString,
+                    $excludeList,
+                    $useBackPid,
+                    $backPid
+                ); // clickIntoBasket
 
-			if (strpos($theCode, 'MEMO') === false) {	// if you link to MEMO from somewhere else, you must not set some parameters for it coming from this list view
-				$excludeList = $pointerParam;
-			}
+            if (strpos($theCode, 'MEMO') === false) {	// if you link to MEMO from somewhere else, you must not set some parameters for it coming from this list view
+                $excludeList = $pointerParam;
+            }
 
-			$linkMemoConf = [];
-			if (
-				isset($linkConfArray) &&
-				is_array($linkConfArray) &&
-				isset($linkConfArray['FORM_MEMO.'])
-			) {
-				$linkMemoConf = $linkConfArray['FORM_MEMO.'];
-			}
+            $linkMemoConf = [];
+            if (
+                isset($linkConfArray) &&
+                is_array($linkConfArray) &&
+                isset($linkConfArray['FORM_MEMO.'])
+            ) {
+                $linkMemoConf = $linkConfArray['FORM_MEMO.'];
+            }
 
-			$markerArray['###FORM_MEMO###'] =
-				htmlspecialchars(
-					FrontendUtility::getTypoLink_URL(
-						$cObj,
-						$pidMemo,
-						$urlObj->getLinkParams(
-							$excludeList,
-							[],
-							true,
-							$useBackPid,
-							$backPid,
-							$itemTableView->getPivar()
-						),
-						'',
-						$linkMemoConf
-					)
-				);
+            $markerArray['###FORM_MEMO###'] =
+                htmlspecialchars(
+                    FrontendUtility::getTypoLink_URL(
+                        $cObj,
+                        $pidMemo,
+                        $urlObj->getLinkParams(
+                            $excludeList,
+                            [],
+                            true,
+                            $useBackPid,
+                            $backPid,
+                            $itemTableView->getPivar()
+                        ),
+                        '',
+                        $linkMemoConf
+                    )
+                );
 
             $wrappedSubpartArray = [];
-			$urlObj->getWrappedSubpartArray(
-				$wrappedSubpartArray,
-				[],
-				'',
-				$useBackPid
-			);
-			$subpartArray = [];
-			$viewTagArray = $markerObj->getAllMarkers($t['listFrameWork']);
-			$tablesObj->get('fe_users', true)->getWrappedSubpartArray(
-				$viewTagArray,
-				$useBackPid,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            $urlObj->getWrappedSubpartArray(
+                $wrappedSubpartArray,
+                [],
+                '',
+                $useBackPid
+            );
+            $subpartArray = [];
+            $viewTagArray = $markerObj->getAllMarkers($t['listFrameWork']);
+            $tablesObj->get('fe_users', true)->getWrappedSubpartArray(
+                $viewTagArray,
+                $useBackPid,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-			if (is_array($viewConfArray) && count($viewConfArray)) {
-				$controlViewObj = GeneralUtility::makeInstance('tx_ttproducts_control_view');
-				$controlViewObj->getMarkerArray(
-					$markerArray,
-					$viewTagArray,
-					$tableConfArray
-				);
-			}
+            if (is_array($viewConfArray) && count($viewConfArray)) {
+                $controlViewObj = GeneralUtility::makeInstance('tx_ttproducts_control_view');
+                $controlViewObj->getMarkerArray(
+                    $markerArray,
+                    $viewTagArray,
+                    $tableConfArray
+                );
+            }
 
-				// add Global Marker Array
-			$markerArray = array_merge($markerArray, $globalMarkerArray);
+                // add Global Marker Array
+            $markerArray = array_merge($markerArray, $globalMarkerArray);
 
-			$t['listFrameWork'] = $templateService->substituteMarkerArrayCached(
-				$t['listFrameWork'],
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+            $t['listFrameWork'] = $templateService->substituteMarkerArrayCached(
+                $t['listFrameWork'],
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-			$t['categoryAndItemsFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###ITEM_CATEGORY_AND_ITEMS###');
-			$t['categoryFrameWork'] = $templateService->getSubpart(
-				$t['categoryAndItemsFrameWork'],
-				'###ITEM_CATEGORY###'
-			);
-			if ($itemTable->getType() == 'article') {
-				$t['productAndItemsFrameWork'] = $templateService->getSubpart($t['listFrameWork'],'###ITEM_PRODUCT_AND_ITEMS###');
-				$t['productFrameWork'] = $templateService->getSubpart($t['productAndItemsFrameWork'], '###ITEM_PRODUCT###');
-			}
-			$t['itemFrameWork'] = $templateService->getSubpart($t['categoryAndItemsFrameWork'],'###ITEM_LIST###');
-			$t['item'] = $templateService->getSubpart($t['itemFrameWork'], '###ITEM_SINGLE###');
+            $t['categoryAndItemsFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###ITEM_CATEGORY_AND_ITEMS###');
+            $t['categoryFrameWork'] = $templateService->getSubpart(
+                $t['categoryAndItemsFrameWork'],
+                '###ITEM_CATEGORY###'
+            );
+            if ($itemTable->getType() == 'article') {
+                $t['productAndItemsFrameWork'] = $templateService->getSubpart($t['listFrameWork'],'###ITEM_PRODUCT_AND_ITEMS###');
+                $t['productFrameWork'] = $templateService->getSubpart($t['productAndItemsFrameWork'], '###ITEM_PRODUCT###');
+            }
+            $t['itemFrameWork'] = $templateService->getSubpart($t['categoryAndItemsFrameWork'],'###ITEM_LIST###');
+            $t['item'] = $templateService->getSubpart($t['itemFrameWork'], '###ITEM_SINGLE###');
 
-			if (
-				isset($damJoinTableArray) &&
-				is_array($damJoinTableArray) &&
-				in_array('address', $damJoinTableArray)
-			) {
-				$t['itemheader'] = [];
-				$t['itemheader']['address'] = $templateService->getSubpart($t['itemFrameWork'],'###ITEM_ADDRESS###');
-				if ($t['itemheader']['address'] != '') {
-					$headerField = $itemTable->getField('address');
-					$headerFieldIndex = 0;
-					$headerFieldArray[$headerFieldIndex] = $headerField;
-					$headerTableArray[$headerFieldIndex] = 'address';
-					$headerTableObjArray['address'] = $tablesObj->get('address', true);
-					$markerFieldArray = [];
-					$headerViewTagArray[$headerFieldIndex] = [];
-					$headerParentArray[$headerFieldIndex] = [];
+            if (
+                isset($damJoinTableArray) &&
+                is_array($damJoinTableArray) &&
+                in_array('address', $damJoinTableArray)
+            ) {
+                $t['itemheader'] = [];
+                $t['itemheader']['address'] = $templateService->getSubpart($t['itemFrameWork'],'###ITEM_ADDRESS###');
+                if ($t['itemheader']['address'] != '') {
+                    $headerField = $itemTable->getField('address');
+                    $headerFieldIndex = 0;
+                    $headerFieldArray[$headerFieldIndex] = $headerField;
+                    $headerTableArray[$headerFieldIndex] = 'address';
+                    $headerTableObjArray['address'] = $tablesObj->get('address', true);
+                    $markerFieldArray = [];
+                    $headerViewTagArray[$headerFieldIndex] = [];
+                    $headerParentArray[$headerFieldIndex] = [];
 
-					$headerTableFieldsArray[$headerFieldIndex] = $markerObj->getMarkerFields(
-						$t['itemheader']['address'],
-						$tablesObj->get('address')->getTableObj()->tableFieldArray,
-						$tablesObj->get('address')->getTableObj()->requiredFieldArray,
-						$markerFieldArray,
-						$tablesObj->get('tt_products', true)->getMarker(),
-						$headerViewTagArray[$headerFieldIndex],
-						$headerParentArray[$headerFieldIndex]
-					);
-					// $foreignTableInfo = $tablesObj->getForeignTableInfo ($tablename,$itemTable->getField('address'));
-				}
-			}
+                    $headerTableFieldsArray[$headerFieldIndex] = $markerObj->getMarkerFields(
+                        $t['itemheader']['address'],
+                        $tablesObj->get('address')->getTableObj()->tableFieldArray,
+                        $tablesObj->get('address')->getTableObj()->requiredFieldArray,
+                        $markerFieldArray,
+                        $tablesObj->get('tt_products', true)->getMarker(),
+                        $headerViewTagArray[$headerFieldIndex],
+                        $headerParentArray[$headerFieldIndex]
+                    );
+                    // $foreignTableInfo = $tablesObj->getForeignTableInfo ($tablename,$itemTable->getField('address'));
+                }
+            }
 
-			if (
-				isset($articleViewObj) &&
-				is_object($articleViewObj) &&
-				(
-					strpos($t['item'], $articleViewObj->getMarker()) ||
-					strpos($t['item'], 'PRICE')
-				)
-			) {
-				$showArticles = true;
-			}
+            if (
+                isset($articleViewObj) &&
+                is_object($articleViewObj) &&
+                (
+                    strpos($t['item'], $articleViewObj->getMarker()) ||
+                    strpos($t['item'], 'PRICE')
+                )
+            ) {
+                $showArticles = true;
+            }
 
-			if ($t['categoryAndItemsFrameWork'] != '') {
-				$bItemPostHtml = (strpos($t['item'], 'ITEM_SINGLE_POST_HTML') !== false);
-					// Get products count
-				$selectConf = [];
-				$allowedPages = ($pid ? $pid : $this->pidListObj->getPidlist());
+            if ($t['categoryAndItemsFrameWork'] != '') {
+                $bItemPostHtml = (strpos($t['item'], 'ITEM_SINGLE_POST_HTML') !== false);
+                    // Get products count
+                $selectConf = [];
+                $allowedPages = ($pid ? $pid : $this->pidListObj->getPidlist());
 
-				if ($additionalPages) {
-					$allowedPages .= ','.$additionalPages;
-				}
-				$allowedPages = GeneralUtility::uniqueList($allowedPages);
+                if ($additionalPages) {
+                    $allowedPages .= ','.$additionalPages;
+                }
+                $allowedPages = GeneralUtility::uniqueList($allowedPages);
 
-				if (!empty($allowedPages)) {
-					$selectConf['pidInList'] = $allowedPages;
-				}
+                if (!empty($allowedPages)) {
+                    $selectConf['pidInList'] = $allowedPages;
+                }
 
-				if ($allowedItems || $allowedItems == '0') {
-					$allowedItemArray = [];
-					$tempArray = GeneralUtility::trimExplode(',', $allowedItems);
-					$allowedItemArray = $GLOBALS['TYPO3_DB']->cleanIntArray($tempArray);
-					$selectConf['uidInList'] = implode(',', $allowedItemArray);
-				}
+                if ($allowedItems || $allowedItems == '0') {
+                    $allowedItemArray = [];
+                    $tempArray = GeneralUtility::trimExplode(',', $allowedItems);
+                    $allowedItemArray = $GLOBALS['TYPO3_DB']->cleanIntArray($tempArray);
+                    $selectConf['uidInList'] = implode(',', $allowedItemArray);
+                }
 
-				$wherestock = (($conf['showNotinStock'] || !is_array($GLOBALS['TCA'][$tablename]['columns']['inStock'])) ? '' : ' AND (inStock > 0) ');
-				$whereNew = $wherestock . $where;
-				$whereNew = $itemTable->getTableObj()->transformWhere($whereNew);
+                $wherestock = (($conf['showNotinStock'] || !is_array($GLOBALS['TCA'][$tablename]['columns']['inStock'])) ? '' : ' AND (inStock > 0) ');
+                $whereNew = $wherestock . $where;
+                $whereNew = $itemTable->getTableObj()->transformWhere($whereNew);
 
-				$selectConf['where'] = '1=1 ' . $whereNew;
-				$selectConf['from'] = $itemTable->getTableObj()->getAdditionalTables();
+                $selectConf['where'] = '1=1 ' . $whereNew;
+                $selectConf['from'] = $itemTable->getTableObj()->getAdditionalTables();
 
-				if (isset($damJoinTableArray) && is_array($damJoinTableArray) && in_array('address',$damJoinTableArray)) {
-					$addressTable = $tablesObj->get('address', false);
-					$addressAlias = $addressTable->getAlias();
-					$addressTablename = $addressTable->getTablename();
-					$bTableAlreadyPresent = false;
+                if (isset($damJoinTableArray) && is_array($damJoinTableArray) && in_array('address',$damJoinTableArray)) {
+                    $addressTable = $tablesObj->get('address', false);
+                    $addressAlias = $addressTable->getAlias();
+                    $addressTablename = $addressTable->getTablename();
+                    $bTableAlreadyPresent = false;
 
-					foreach ($sqlTableArray['from'] as $fromTables) {
-						if (strpos($fromTables,$addressTablename)!==false) {
-							$bTableAlreadyPresent = true;
-						}
-					}
-					if (!$bTableAlreadyPresent) {
-						$enableFieldArray = $addressTable->getTableObj()->getEnableFieldArray();
-						$foreignTableInfo = $tablesObj->getForeignTableInfo($tablename,$itemTable->fieldArray['address']);
-						$foreignTableInfo['table_field'] = $itemTable->fieldArray['address'];
-						$newSqlTableArray = [];
-						$aliasPostfix=($sqlTableIndex);
-						$tablesObj->prepareSQL($foreignTableInfo,$tableAliasArray,$aliasPostfix,$newSqlTableArray);
-						$sqlTableArray['from'][$sqlTableIndex] = $foreignTableInfo['foreign_table'];
-						if ($foreignTableInfo['where'] != '') {
-							$sqlTableArray['where'][$sqlTableIndex] = $foreignTableInfo['where'];
-						}
-						if (isset($newSqlTableArray) && is_array($newSqlTableArray)) {
-							foreach ($sqlTableArray as $k => $tmpArray) {
-								if (isset($newSqlTableArray[$k])) {
-									$sqlTableArray[$k][$sqlTableIndex] = $newSqlTableArray[$k];
-								}
-							}
-						}
-						$sqlTableIndex++;
-					}
-				}
+                    foreach ($sqlTableArray['from'] as $fromTables) {
+                        if (strpos($fromTables,$addressTablename)!==false) {
+                            $bTableAlreadyPresent = true;
+                        }
+                    }
+                    if (!$bTableAlreadyPresent) {
+                        $enableFieldArray = $addressTable->getTableObj()->getEnableFieldArray();
+                        $foreignTableInfo = $tablesObj->getForeignTableInfo($tablename,$itemTable->fieldArray['address']);
+                        $foreignTableInfo['table_field'] = $itemTable->fieldArray['address'];
+                        $newSqlTableArray = [];
+                        $aliasPostfix=($sqlTableIndex);
+                        $tablesObj->prepareSQL($foreignTableInfo,$tableAliasArray,$aliasPostfix,$newSqlTableArray);
+                        $sqlTableArray['from'][$sqlTableIndex] = $foreignTableInfo['foreign_table'];
+                        if ($foreignTableInfo['where'] != '') {
+                            $sqlTableArray['where'][$sqlTableIndex] = $foreignTableInfo['where'];
+                        }
+                        if (isset($newSqlTableArray) && is_array($newSqlTableArray)) {
+                            foreach ($sqlTableArray as $k => $tmpArray) {
+                                if (isset($newSqlTableArray[$k])) {
+                                    $sqlTableArray[$k][$sqlTableIndex] = $newSqlTableArray[$k];
+                                }
+                            }
+                        }
+                        $sqlTableIndex++;
+                    }
+                }
 
-				if (
+                if (
                     isset($sqlTableArray) && is_array($sqlTableArray) && isset($sqlTableArray['from']) && is_array($sqlTableArray['from'])
                 ) {
-					foreach ($sqlTableArray['from'] as $k => $sqlFrom) {
-						if ($sqlFrom != '') {
-							$delimiter = ',';
-							if ($sqlTableArray['local'][$k] == $tablename) {
-								$delimiter = '';
-							}
-							$selectConf['from'] .= $delimiter . $sqlFrom;
-						}
-					}
-					if (!empty($sqlTableArray['where'])) {
-						$tmpWhere = implode(' AND ', $sqlTableArray['where']);
-						if ($tmpWhere != '') {
-							$selectConf['where'] = '(' . $selectConf['where'] . ') AND ' . $tmpWhere;
-						}
-					}
-				}
-				$displayConf = [];
-					// Get products count
-				$displayConf['columns'] = '';
-				if (isset($tableConfArray[$functablename]['displayColumns.'])) {
-					$displayConf['columns'] = $tableConfArray[$functablename]['displayColumns.'];
-					if (is_array($displayConf['columns'])) {
-						$displayColumns = $displayConf['columns']['1'];
-						ksort($displayConf['columns'],SORT_STRING);
-					}
-				}
-				$displayConf['header'] = '';
-				if (isset($tableConfArray[$functablename]['displayHeader.'])) {
-					$displayConf['header'] = $tableConfArray[$functablename]['displayHeader.'];
-					if (is_array($displayConf['header'])) {
-						ksort($displayConf['header'], SORT_STRING);
-					}
-				}
-				$selectConf['orderBy'] = $tableConfArray[$functablename]['orderBy'];
-					// performing query for display:
-				if (!$selectConf['orderBy']) {
-					$selectConf['orderBy'] = $conf['orderBy'];
-				}
-				$tmpArray = GeneralUtility::trimExplode(',', $selectConf['orderBy']);
-				$orderByArray[$functablename] = $tmpArray[0]; // $orderByProduct
+                    foreach ($sqlTableArray['from'] as $k => $sqlFrom) {
+                        if ($sqlFrom != '') {
+                            $delimiter = ',';
+                            if ($sqlTableArray['local'][$k] == $tablename) {
+                                $delimiter = '';
+                            }
+                            $selectConf['from'] .= $delimiter . $sqlFrom;
+                        }
+                    }
+                    if (!empty($sqlTableArray['where'])) {
+                        $tmpWhere = implode(' AND ', $sqlTableArray['where']);
+                        if ($tmpWhere != '') {
+                            $selectConf['where'] = '(' . $selectConf['where'] . ') AND ' . $tmpWhere;
+                        }
+                    }
+                }
+                $displayConf = [];
+                    // Get products count
+                $displayConf['columns'] = '';
+                if (isset($tableConfArray[$functablename]['displayColumns.'])) {
+                    $displayConf['columns'] = $tableConfArray[$functablename]['displayColumns.'];
+                    if (is_array($displayConf['columns'])) {
+                        $displayColumns = $displayConf['columns']['1'];
+                        ksort($displayConf['columns'],SORT_STRING);
+                    }
+                }
+                $displayConf['header'] = '';
+                if (isset($tableConfArray[$functablename]['displayHeader.'])) {
+                    $displayConf['header'] = $tableConfArray[$functablename]['displayHeader.'];
+                    if (is_array($displayConf['header'])) {
+                        ksort($displayConf['header'], SORT_STRING);
+                    }
+                }
+                $selectConf['orderBy'] = $tableConfArray[$functablename]['orderBy'];
+                    // performing query for display:
+                if (!$selectConf['orderBy']) {
+                    $selectConf['orderBy'] = $conf['orderBy'];
+                }
+                $tmpArray = GeneralUtility::trimExplode(',', $selectConf['orderBy']);
+                $orderByArray[$functablename] = $tmpArray[0]; // $orderByProduct
 
-				if ($useCategories) {
-					$orderByCat = $tableConfArray[$categoryfunctablename]['orderBy'];
-				}
+                if ($useCategories) {
+                    $orderByCat = $tableConfArray[$categoryfunctablename]['orderBy'];
+                }
 
-					// sorting by category not yet possible for articles
-				if ($itemTable->getType() == 'article') { // ($itemTable === $this->tt_products_articles)
-					$orderByCat = '';	// articles do not have a direct category
-					$tmpArray = GeneralUtility::trimExplode(',', $selectConf['orderBy']);
-					$tmpArray = array_diff($tmpArray, ['category']);
-					$selectConf['orderBy'] = implode (',', $tmpArray);
-				}
-				if ($itemTable->fieldArray['itemnumber']) {
-					$selectConf['orderBy'] = str_replace ('itemnumber', $itemTable->fieldArray['itemnumber'], $selectConf['orderBy']);
-				}
-				$selectConf['orderBy'] = $itemTable->getTableObj()->transformOrderby($selectConf['orderBy']);
+                    // sorting by category not yet possible for articles
+                if ($itemTable->getType() == 'article') { // ($itemTable === $this->tt_products_articles)
+                    $orderByCat = '';	// articles do not have a direct category
+                    $tmpArray = GeneralUtility::trimExplode(',', $selectConf['orderBy']);
+                    $tmpArray = array_diff($tmpArray, ['category']);
+                    $selectConf['orderBy'] = implode (',', $tmpArray);
+                }
+                if ($itemTable->fieldArray['itemnumber']) {
+                    $selectConf['orderBy'] = str_replace ('itemnumber', $itemTable->fieldArray['itemnumber'], $selectConf['orderBy']);
+                }
+                $selectConf['orderBy'] = $itemTable->getTableObj()->transformOrderby($selectConf['orderBy']);
 
-				$productMarkerFieldArray = [
-					'BULKILY_WARNING' => 'bulkily',
-					'PRODUCT_SPECIAL_PREP' => 'special_preparation',
-					'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
-					'PRODUCT_LINK_DATASHEET' => 'datasheet'
-				];
-				$markerFieldArray = [];
-				if ($itemTable->getType() == 'product') {
-					$markerFieldArray = $productMarkerFieldArray;
-				}
-				$viewTagArray = [];
-				$parentArray = [];
+                $productMarkerFieldArray = [
+                    'BULKILY_WARNING' => 'bulkily',
+                    'PRODUCT_SPECIAL_PREP' => 'special_preparation',
+                    'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
+                    'PRODUCT_LINK_DATASHEET' => 'datasheet'
+                ];
+                $markerFieldArray = [];
+                if ($itemTable->getType() == 'product') {
+                    $markerFieldArray = $productMarkerFieldArray;
+                }
+                $viewTagArray = [];
+                $parentArray = [];
 
-				$fieldsArray = $markerObj->getMarkerFields(
-					$t['item'],
-					$itemTable->getTableObj()->tableFieldArray,
-					$itemTable->getTableObj()->requiredFieldArray,
-					$markerFieldArray,
-					$itemTableView->getMarker(),
-					$viewTagArray,
-					$parentArray
-				);
+                $fieldsArray = $markerObj->getMarkerFields(
+                    $t['item'],
+                    $itemTable->getTableObj()->tableFieldArray,
+                    $itemTable->getTableObj()->requiredFieldArray,
+                    $markerFieldArray,
+                    $itemTableView->getMarker(),
+                    $viewTagArray,
+                    $parentArray
+                );
 
-				if (
-					$itemTable->getType() == 'product' &&
-					in_array($useArticles, [1, 2, 3])
-				) {
-					$markerFieldArray = [];
-					$articleViewTagArray = [];
-					$articleParentArray = [];
-					$articleFieldsArray = $markerObj->getMarkerFields(
-						$t['item'],
-						$itemTable->getTableObj()->tableFieldArray,
-						$itemTable->getTableObj()->requiredFieldArray,
-						$productMarkerFieldArray,
-						$articleViewObj->getMarker(),
-						$articleViewTagArray,
-						$articleParentArray
-					);
+                if (
+                    $itemTable->getType() == 'product' &&
+                    in_array($useArticles, [1, 2, 3])
+                ) {
+                    $markerFieldArray = [];
+                    $articleViewTagArray = [];
+                    $articleParentArray = [];
+                    $articleFieldsArray = $markerObj->getMarkerFields(
+                        $t['item'],
+                        $itemTable->getTableObj()->tableFieldArray,
+                        $itemTable->getTableObj()->requiredFieldArray,
+                        $productMarkerFieldArray,
+                        $articleViewObj->getMarker(),
+                        $articleViewTagArray,
+                        $articleParentArray
+                    );
 
-					$prodUidField = $cnfObj->getTableDesc($articleTable->getTableObj()->name, 'uid_product');
-					$fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
-					$uidKey = array_search($prodUidField, $fieldsArray);
-					if ($uidKey != '') {
-						unset($fieldsArray[$uidKey]);
-					}
-				} else if ($itemTable->getType() == 'article' || $itemTable->getType() == 'dam') {
-					$viewProductsTagArray = [];
-					$productsParentArray = [];
-					$tmpFramework = ($t['productAndItemsFrameWork'] ? $t['productAndItemsFrameWork'] : $t['categoryAndItemsFrameWork']);
-					$productsFieldsArray = $markerObj->getMarkerFields(
-						$tmpFramework,
-						$tablesObj->get('tt_products')->getTableObj()->tableFieldArray,
-						$tablesObj->get('tt_products')->getTableObj()->requiredFieldArray,
-						$markerFieldArray,
-						$tablesObj->get('tt_products', true)->getMarker(),
-						$viewProductsTagArray,
-						$productsParentArray
-					);
-				} else {
-					$bCheckUnusedArticleMarkers = true;
-				}
-				if (
-					$itemTable->getType() != 'product'
-				) {
-					$defaultFieldsArray = $tablesObj->get($functablename)->getTableObj()->getDefaultFieldArray();
+                    $prodUidField = $cnfObj->getTableDesc($articleTable->getTableObj()->name, 'uid_product');
+                    $fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
+                    $uidKey = array_search($prodUidField, $fieldsArray);
+                    if ($uidKey != '') {
+                        unset($fieldsArray[$uidKey]);
+                    }
+                } else if ($itemTable->getType() == 'article' || $itemTable->getType() == 'dam') {
+                    $viewProductsTagArray = [];
+                    $productsParentArray = [];
+                    $tmpFramework = ($t['productAndItemsFrameWork'] ? $t['productAndItemsFrameWork'] : $t['categoryAndItemsFrameWork']);
+                    $productsFieldsArray = $markerObj->getMarkerFields(
+                        $tmpFramework,
+                        $tablesObj->get('tt_products')->getTableObj()->tableFieldArray,
+                        $tablesObj->get('tt_products')->getTableObj()->requiredFieldArray,
+                        $markerFieldArray,
+                        $tablesObj->get('tt_products', true)->getMarker(),
+                        $viewProductsTagArray,
+                        $productsParentArray
+                    );
+                } else {
+                    $bCheckUnusedArticleMarkers = true;
+                }
+                if (
+                    $itemTable->getType() != 'product'
+                ) {
+                    $defaultFieldsArray = $tablesObj->get($functablename)->getTableObj()->getDefaultFieldArray();
 
-					$tcaFieldsArray = \JambageCom\Div2007\Utility\TableUtility::getFields($tablename);
-					$noTcaFieldsArray = $tablesObj->get($functablename)->getTableObj()->getNoTcaFieldArray();
+                    $tcaFieldsArray = \JambageCom\Div2007\Utility\TableUtility::getFields($tablename);
+                    $noTcaFieldsArray = $tablesObj->get($functablename)->getTableObj()->getNoTcaFieldArray();
 
-					$fieldsArray = array_merge($defaultFieldsArray, $tcaFieldsArray, $noTcaFieldsArray);
-				}
+                    $fieldsArray = array_merge($defaultFieldsArray, $tcaFieldsArray, $noTcaFieldsArray);
+                }
 
-				$itemTableConf = $cnfObj->getTableConf($itemTable->getFuncTablename(), $theCode);
-				$itemTableLangFields = $cnfObj->getTranslationFields($itemTableConf);
-				$fieldsArray = array_merge($fieldsArray, $itemTableLangFields);
-				$itemImageFields = $cnfObj->getImageFields($itemTableConf);
-				$fieldsArray = array_merge($fieldsArray, $itemImageFields);
-				$viewCatTagArray = [];
-				$catParentArray = [];
+                $itemTableConf = $cnfObj->getTableConf($itemTable->getFuncTablename(), $theCode);
+                $itemTableLangFields = $cnfObj->getTranslationFields($itemTableConf);
+                $fieldsArray = array_merge($fieldsArray, $itemTableLangFields);
+                $itemImageFields = $cnfObj->getImageFields($itemTableConf);
+                $fieldsArray = array_merge($fieldsArray, $itemImageFields);
+                $viewCatTagArray = [];
+                $catParentArray = [];
 
-				$columnFields = $cnfObj->getColumnFields($itemTableConf);
+                $columnFields = $cnfObj->getColumnFields($itemTableConf);
 
-				if (isset($columnFields) && is_array($columnFields) && count($columnFields)) {
-					foreach ($columnFields as $field => $value) {
-						$key = array_search($field, $fieldsArray);
-						if ($key !== false) {
-							unset($fieldsArray[$key]);
-							$fieldsArray[] = str_replace($field, $prodAlias . '.' . $field, $value) . ' ' . $field;
-						}
-					}
-				}
+                if (isset($columnFields) && is_array($columnFields) && count($columnFields)) {
+                    foreach ($columnFields as $field => $value) {
+                        $key = array_search($field, $fieldsArray);
+                        if ($key !== false) {
+                            unset($fieldsArray[$key]);
+                            $fieldsArray[] = str_replace($field, $prodAlias . '.' . $field, $value) . ' ' . $field;
+                        }
+                    }
+                }
 
-				$catFramework = '';
-				$mergeTagArray = [];
-				if ($useCategories) {
+                $catFramework = '';
+                $mergeTagArray = [];
+                if ($useCategories) {
                     $tmp = [];
-					$catfieldsArray = $markerObj->getMarkerFields(
-						$t['categoryAndItemsFrameWork'], // categoryAndItemsFrameWork  categoryFrameWork
-						$categoryTable->getTableObj()->tableFieldArray,
-						$categoryTable->getTableObj()->requiredFieldArray,
-						$tmp,
-						$categoryTableView->getMarker(),
-						$viewCatTagArray,
-						$catParentArray
-					);
-					$mergeTagArray = array_merge($viewTagArray, $viewCatTagArray);
-				}
+                    $catfieldsArray = $markerObj->getMarkerFields(
+                        $t['categoryAndItemsFrameWork'], // categoryAndItemsFrameWork  categoryFrameWork
+                        $categoryTable->getTableObj()->tableFieldArray,
+                        $categoryTable->getTableObj()->requiredFieldArray,
+                        $tmp,
+                        $categoryTableView->getMarker(),
+                        $viewCatTagArray,
+                        $catParentArray
+                    );
+                    $mergeTagArray = array_merge($viewTagArray, $viewCatTagArray);
+                }
 
-				$catTitle = '';
-				if (
-					$whereCat != '' ||
-					(
-						$itemTable->getType() == 'product' &&
-						$tablename != 'tt_products' &&
-						$orderByCat != ''
-					)
-				) {
-					$aliasArray = [];
-					$aliasArray['mm1'] = 'mm_cat1';
-					$aliasArray['mm2'] = 'mm_cat2';
-					$itemTable->addConfCat($categoryTable, $selectConf, $aliasArray);
-				}
+                $catTitle = '';
+                if (
+                    $whereCat != '' ||
+                    (
+                        $itemTable->getType() == 'product' &&
+                        $tablename != 'tt_products' &&
+                        $orderByCat != ''
+                    )
+                ) {
+                    $aliasArray = [];
+                    $aliasArray['mm1'] = 'mm_cat1';
+                    $aliasArray['mm2'] = 'mm_cat2';
+                    $itemTable->addConfCat($categoryTable, $selectConf, $aliasArray);
+                }
 
-				if ($orderByCat && ($pageAsCategory < 2 || $itemTable->getType() == 'dam')) {
-					$catOrderBy = $categoryTable->getTableObj()->transformOrderby($orderByCat);
-					$orderByCatFieldArray = GeneralUtility::trimExplode(',', $catOrderBy);
-					$selectConf['orderBy'] = $catOrderBy . ($selectConf['orderBy'] ? ($catOrderBy != '' ? ',' : '') . $selectConf['orderBy'] : '');
-					$catAlias = $categoryTable->getTableObj()->getAlias();
+                if ($orderByCat && ($pageAsCategory < 2 || $itemTable->getType() == 'dam')) {
+                    $catOrderBy = $categoryTable->getTableObj()->transformOrderby($orderByCat);
+                    $orderByCatFieldArray = GeneralUtility::trimExplode(',', $catOrderBy);
+                    $selectConf['orderBy'] = $catOrderBy . ($selectConf['orderBy'] ? ($catOrderBy != '' ? ',' : '') . $selectConf['orderBy'] : '');
+                    $catAlias = $categoryTable->getTableObj()->getAlias();
 
-					if ($itemTable->getType() == 'dam') {
-						// SELECT *
-						// FROM tx_dam LEFT OUTER JOIN  tx_dam_mm_cat ON tx_dam.uid = tx_dam_mm_cat.uid_local
+                    if ($itemTable->getType() == 'dam') {
+                        // SELECT *
+                        // FROM tx_dam LEFT OUTER JOIN  tx_dam_mm_cat ON tx_dam.uid = tx_dam_mm_cat.uid_local
 
-						if ($selectConf['leftjoin'] == '') {
-							$selectConf['leftjoin'] = 'tx_dam_mm_cat mm_cat1 ON ' . $prodAlias . '.uid=mm_cat1.uid_local';
-						}
-					} else {
-						// SELECT *
-						// FROM tt_products
-						// LEFT OUTER JOIN tt_products_cat ON tt_products.category = tt_products_cat.uid
-						$selectConf['leftjoin'] = $categoryTable->getTableObj()->name . ' ' . $catAlias . ' ON ' . $catAlias . '.uid=' . $prodAlias . '.category';
-					}
-					$catTables = $categoryTable->getTableObj()->getAdditionalTables([$categoryTable->getTableObj()->getLangName()]);
+                        if ($selectConf['leftjoin'] == '') {
+                            $selectConf['leftjoin'] = 'tx_dam_mm_cat mm_cat1 ON ' . $prodAlias . '.uid=mm_cat1.uid_local';
+                        }
+                    } else {
+                        // SELECT *
+                        // FROM tt_products
+                        // LEFT OUTER JOIN tt_products_cat ON tt_products.category = tt_products_cat.uid
+                        $selectConf['leftjoin'] = $categoryTable->getTableObj()->name . ' ' . $catAlias . ' ON ' . $catAlias . '.uid=' . $prodAlias . '.category';
+                    }
+                    $catTables = $categoryTable->getTableObj()->getAdditionalTables([$categoryTable->getTableObj()->getLangName()]);
 
-					if (!empty($selectConf['from'])) {
-						$tmpDelim = ',';
-					}
-					if ($catTables!='') {
-						$selectConf['from'] = $catTables . $tmpDelim . $selectConf['from'];
-					}
+                    if (!empty($selectConf['from'])) {
+                        $tmpDelim = ',';
+                    }
+                    if ($catTables!='') {
+                        $selectConf['from'] = $catTables . $tmpDelim . $selectConf['from'];
+                    }
 
-					if ($categoryTable->bUseLanguageTable($tableConfArray[$categoryfunctablename])) {
+                    if ($categoryTable->bUseLanguageTable($tableConfArray[$categoryfunctablename])) {
 
-						$joinTables = $selectConf['leftjoin'];
-						$categoryTable->getTableObj()->transformLanguage($joinTables, $selectConf['where'], true);
-						$selectConf['leftjoin'] = $joinTables;
-					}
-				}
+                        $joinTables = $selectConf['leftjoin'];
+                        $categoryTable->getTableObj()->transformLanguage($joinTables, $selectConf['where'], true);
+                        $selectConf['leftjoin'] = $joinTables;
+                    }
+                }
 
-				$collateConf = [];
-				if (
-					isset($tableConfArray[$functablename]['collate.'])
-				) {
-					$collateConf[$functablename] = $tableConfArray[$functablename]['collate.'];
-				}
+                $collateConf = [];
+                if (
+                    isset($tableConfArray[$functablename]['collate.'])
+                ) {
+                    $collateConf[$functablename] = $tableConfArray[$functablename]['collate.'];
+                }
 
-				$selectFields = implode(',', $fieldsArray);
-				$selectConf['selectFields'] = 'DISTINCT ' . $itemTable->getTableObj()->transformSelect($selectFields, '', $collateConf);
+                $selectFields = implode(',', $fieldsArray);
+                $selectConf['selectFields'] = 'DISTINCT ' . $itemTable->getTableObj()->transformSelect($selectFields, '', $collateConf);
 
-				if (
-					isset($damJoinTableArray) &&
-					is_array($damJoinTableArray) &&
-					in_array('address', $damJoinTableArray) &&
-					$addressAlias != ''
-				) {
-					$addressConf = $addressTable->getTableConf($theCode);
-					if (isset($addressConf['requiredFields'])) {
-						$addressFieldArray = GeneralUtility::trimExplode(',', $addressConf['requiredFields']);
-						foreach ($addressFieldArray as $field) {
-							$selectConf['selectFields'] .= ',' . $addressAlias . $aliasPostfix . '.' . $field . ' address_' . $field;
-						}
-					}
-				}
+                if (
+                    isset($damJoinTableArray) &&
+                    is_array($damJoinTableArray) &&
+                    in_array('address', $damJoinTableArray) &&
+                    $addressAlias != ''
+                ) {
+                    $addressConf = $addressTable->getTableConf($theCode);
+                    if (isset($addressConf['requiredFields'])) {
+                        $addressFieldArray = GeneralUtility::trimExplode(',', $addressConf['requiredFields']);
+                        foreach ($addressFieldArray as $field) {
+                            $selectConf['selectFields'] .= ',' . $addressAlias . $aliasPostfix . '.' . $field . ' address_' . $field;
+                        }
+                    }
+                }
 
-				if (in_array($theCode, $viewedCodeArray) && $limit > 0) {
-					if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
-						$feUserId = intval($GLOBALS['TSFE']->fe_user->user['uid']);
-					}
-					$whereMM = '';
-					$productAlias = $itemTable->getAlias();
-					$whereProducts = '';
+                if (in_array($theCode, $viewedCodeArray) && $limit > 0) {
+                    if (\JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn()) {
+                        $feUserId = intval($GLOBALS['TSFE']->fe_user->user['uid']);
+                    }
+                    $whereMM = '';
+                    $productAlias = $itemTable->getAlias();
+                    $whereProducts = '';
 
-					switch ($theCode) {
-						case 'LISTAFFORDABLE':
-							if ($feUserId) {
-								$whereProducts = ' AND ' . $productAlias . '.creditpoints<=' .
-									$GLOBALS['TYPO3_DB']->fullQuoteStr($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'], $tablename);
-							}
-						break;
-						case 'LISTVIEWEDITEMS':
-							if ($feUserId) {
-								$mmTablename = 'sys_products_fe_users_mm_visited_products mmv';
-								$whereMM = 'mmv.uid_local=' . $feUserId;
-								$orderByProducts = 'mmv.tstamp DESC';
-								$whereProducts = ' AND ' . $productAlias . '.uid=mmv.uid_foreign';
-							}
-						break;
-						case 'LISTVIEWEDMOST':
-							if ($feUserId) {
-								$mmTablename = 'sys_products_fe_users_mm_visited_products mmv';
-								$whereMM = 'mmv.uid_local=' . $feUserId;
-								$orderByProducts = 'mmv.qty DESC';
-								$whereProducts = ' AND ' . $productAlias . '.uid=mmv.uid_foreign';
-							}
-						break;
-						case 'LISTVIEWEDMOSTOTHERS':
-							$viewedTablename = 'sys_products_visited_products visit';
-							$orderByProducts = 'visit.qty DESC';
-							$whereProducts = ' AND ' . $productAlias . '.uid=visit.uid';
-						break;
-					}
+                    switch ($theCode) {
+                        case 'LISTAFFORDABLE':
+                            if ($feUserId) {
+                                $whereProducts = ' AND ' . $productAlias . '.creditpoints<=' .
+                                    $GLOBALS['TYPO3_DB']->fullQuoteStr($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'], $tablename);
+                            }
+                        break;
+                        case 'LISTVIEWEDITEMS':
+                            if ($feUserId) {
+                                $mmTablename = 'sys_products_fe_users_mm_visited_products mmv';
+                                $whereMM = 'mmv.uid_local=' . $feUserId;
+                                $orderByProducts = 'mmv.tstamp DESC';
+                                $whereProducts = ' AND ' . $productAlias . '.uid=mmv.uid_foreign';
+                            }
+                        break;
+                        case 'LISTVIEWEDMOST':
+                            if ($feUserId) {
+                                $mmTablename = 'sys_products_fe_users_mm_visited_products mmv';
+                                $whereMM = 'mmv.uid_local=' . $feUserId;
+                                $orderByProducts = 'mmv.qty DESC';
+                                $whereProducts = ' AND ' . $productAlias . '.uid=mmv.uid_foreign';
+                            }
+                        break;
+                        case 'LISTVIEWEDMOSTOTHERS':
+                            $viewedTablename = 'sys_products_visited_products visit';
+                            $orderByProducts = 'visit.qty DESC';
+                            $whereProducts = ' AND ' . $productAlias . '.uid=visit.uid';
+                        break;
+                    }
 
-					if ($mmTablename != '') {
-						$selectConf['from'] = (!empty($selectConf['from']) ? $selectConf['from'] . ',' . $mmTablename : $mmTablename);
-						$whereProducts = ' AND ' . $whereMM . $whereProducts;
-					}
-					if ($viewedTablename != '') {
-						$selectConf['from'] = (!empty($selectConf['from']) ? $selectConf['from'] . ',' . $viewedTablename : $viewedTablename);
-					}
-					if ($orderByProducts != '') {
-						$selectConf['orderBy'] = $orderByProducts;
-					}
-					if ($whereProducts != '') {
-						$selectConf['where'] .= $whereProducts;
-					}
-				}
+                    if ($mmTablename != '') {
+                        $selectConf['from'] = (!empty($selectConf['from']) ? $selectConf['from'] . ',' . $mmTablename : $mmTablename);
+                        $whereProducts = ' AND ' . $whereMM . $whereProducts;
+                    }
+                    if ($viewedTablename != '') {
+                        $selectConf['from'] = (!empty($selectConf['from']) ? $selectConf['from'] . ',' . $viewedTablename : $viewedTablename);
+                    }
+                    if ($orderByProducts != '') {
+                        $selectConf['orderBy'] = $orderByProducts;
+                    }
+                    if ($whereProducts != '') {
+                        $selectConf['where'] .= $whereProducts;
+                    }
+                }
 
-				$join = '';
-				$tmpTables = $itemTable->getTableObj()->transformTable('', false, $join);
-				// $selectConf['where'] = $join.$itemTable->getTableObj()->transformWhere($selectConf['where']);
-				$selectConf['where'] = $join . ' ' . $selectConf['where'];
+                $join = '';
+                $tmpTables = $itemTable->getTableObj()->transformTable('', false, $join);
+                // $selectConf['where'] = $join.$itemTable->getTableObj()->transformWhere($selectConf['where']);
+                $selectConf['where'] = $join . ' ' . $selectConf['where'];
 
-				if (isset($tableConfArray[$functablename]['filter.']) && is_array($tableConfArray[$functablename]['filter.'])) {
-					$filterConf = $tableConfArray[$functablename]['filter.'];
+                if (isset($tableConfArray[$functablename]['filter.']) && is_array($tableConfArray[$functablename]['filter.'])) {
+                    $filterConf = $tableConfArray[$functablename]['filter.'];
 
-					if (
-						isset($filterConf['regexp.']) &&
-						is_array($filterConf['regexp.']) &&
-						isset($filterConf['regexp.']['field.']) &&
-						is_array($filterConf['regexp.']['field.'])
-					) {
-						foreach ($filterConf['regexp.']['field.'] as $field => $value) {
-							$selectConf['where'] .= ' AND ' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value), $tablename);
-						}
-					}
-					if (
-						isset($filterConf['where.']) &&
-						is_array($filterConf['where.']) &&
-						isset($filterConf['where.']['field.']) &&
-						is_array($filterConf['where.']['field.'])
-					) {
-						foreach ($filterConf['where.']['field.'] as $field => $value) {
-							if (strpos($value, $field) === false) {
-								$selectConf['where'] .= ' AND ' . $field . ' = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value),  $tablename);
-							} else {
-								$selectConf['where'] .= ' AND ' . $value;
-							}
-						}
-					}
-				}
-				$selectConf['groupBy'] = $dam_group_by;
+                    if (
+                        isset($filterConf['regexp.']) &&
+                        is_array($filterConf['regexp.']) &&
+                        isset($filterConf['regexp.']['field.']) &&
+                        is_array($filterConf['regexp.']['field.'])
+                    ) {
+                        foreach ($filterConf['regexp.']['field.'] as $field => $value) {
+                            $selectConf['where'] .= ' AND ' . $field . ' REGEXP ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value), $tablename);
+                        }
+                    }
+                    if (
+                        isset($filterConf['where.']) &&
+                        is_array($filterConf['where.']) &&
+                        isset($filterConf['where.']['field.']) &&
+                        is_array($filterConf['where.']['field.'])
+                    ) {
+                        foreach ($filterConf['where.']['field.'] as $field => $value) {
+                            if (strpos($value, $field) === false) {
+                                $selectConf['where'] .= ' AND ' . $field . ' = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr(quotemeta($value),  $tablename);
+                            } else {
+                                $selectConf['where'] .= ' AND ' . $value;
+                            }
+                        }
+                    }
+                }
+                $selectConf['groupBy'] = $dam_group_by;
 
-					// performing query to count all products (we need to know it for browsing):
-				$selectCountConf = $selectConf;
-				$selectCountConf['selectFields'] = 'count(distinct ' . $itemTable->getAlias() . '.uid)'; // .$catSelect;
+                    // performing query to count all products (we need to know it for browsing):
+                $selectCountConf = $selectConf;
+                $selectCountConf['selectFields'] = 'count(distinct ' . $itemTable->getAlias() . '.uid)'; // .$catSelect;
                 $selectCountConf['leftjoin'] = '';
                 $selectCountConf['orderBy'] = '';
-				$queryParts =
-					$itemTable->getTableObj()->getQueryConf(
-						$cObj,
-						$tablename,
-						$selectCountConf,
-						true
-					);
+                $queryParts =
+                    $itemTable->getTableObj()->getQueryConf(
+                        $cObj,
+                        $tablename,
+                        $selectCountConf,
+                        true
+                    );
 
-				if (!empty($selectCountConf['groupBy'])) {
-					$queryParts['SELECT'] = 'count(DISTINCT ' . $selectCountConf['groupBy'] . ')';
-					unset($queryParts['GROUPBY']);
-				}
+                if (!empty($selectCountConf['groupBy'])) {
+                    $queryParts['SELECT'] = 'count(DISTINCT ' . $selectCountConf['groupBy'] . ')';
+                    unset($queryParts['GROUPBY']);
+                }
 
-				// run the COUNT SELECT
-				$res = $itemTable->getTableObj()->exec_SELECT_queryArray(
-					$queryParts,
-					'',
-					false,
-					$collateConf
-				);
-				$row = $GLOBALS['TYPO3_DB']->sql_fetch_row($res);
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				$productsCount = (is_array($row) ? $row['0'] : 0);
+                // run the COUNT SELECT
+                $res = $itemTable->getTableObj()->exec_SELECT_queryArray(
+                    $queryParts,
+                    '',
+                    false,
+                    $collateConf
+                );
+                $row = $GLOBALS['TYPO3_DB']->sql_fetch_row($res);
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                $productsCount = (is_array($row) ? $row['0'] : 0);
 
-				$browserConf = $this->getBrowserConf($tableConfArray[$functablename]); // needed for the replacement of the method pi_linkTP_keepPIvars by BrowserUtility::linkTPKeepCtrlVars and the page browser
-				$maxPages = 10000;
-				if (isset($browserConf['maxPages'])) {
+                $browserConf = $this->getBrowserConf($tableConfArray[$functablename]); // needed for the replacement of the method pi_linkTP_keepPIvars by BrowserUtility::linkTPKeepCtrlVars and the page browser
+                $maxPages = 10000;
+                if (isset($browserConf['maxPages'])) {
                     $maxPages = intval($browserConf['maxPages']);
-				}
+                }
 
-				$browseObj =
-					$this->getBrowserObj(
-						$conf,
-						$browserConf,
-						$productsCount,
-						$limit,
-						$maxPages
-					);
+                $browseObj =
+                    $this->getBrowserObj(
+                        $conf,
+                        $browserConf,
+                        $productsCount,
+                        $limit,
+                        $maxPages
+                    );
 
-					// range check to current productsCount
-				$begin_at_start = (($begin_at >= $productsCount) ? ($productsCount >= $limit ? $productsCount - $limit : $productsCount) : $begin_at);
-				$begin_at = MathUtility::forceIntegerInRange($begin_at_start, 0);
+                    // range check to current productsCount
+                $begin_at_start = (($begin_at >= $productsCount) ? ($productsCount >= $limit ? $productsCount - $limit : $productsCount) : $begin_at);
+                $begin_at = MathUtility::forceIntegerInRange($begin_at_start, 0);
 
-				if ($latest > 0) {
-					$start = $productsCount - $latest;
-					if ($start <= 0) {
-						$start = 1;
-					}
-					$selectConf['begin'] = $start;
-					$limit = $latest;
-					$productsCount = $latest;
-				}
-				$selectConf['max'] = ($limit + 1);
-				if ($begin_at > 0) {
-					$selectConf['begin'] = $begin_at;
-				}
+                if ($latest > 0) {
+                    $start = $productsCount - $latest;
+                    if ($start <= 0) {
+                        $start = 1;
+                    }
+                    $selectConf['begin'] = $start;
+                    $limit = $latest;
+                    $productsCount = $latest;
+                }
+                $selectConf['max'] = ($limit + 1);
+                if ($begin_at > 0) {
+                    $selectConf['begin'] = $begin_at;
+                }
 
-				if ($selectConf['orderBy']) {
-					$selectConf['orderBy'] =
-						$GLOBALS['TYPO3_DB']->stripOrderBy($selectConf['orderBy']);
-				}
+                if ($selectConf['orderBy']) {
+                    $selectConf['orderBy'] =
+                        $GLOBALS['TYPO3_DB']->stripOrderBy($selectConf['orderBy']);
+                }
 
-				if (isset($tableConfArray[$functablename]['groupBy'])) {
-					$selectConf['groupBy'] = $tableConfArray[$functablename]['groupBy'];
+                if (isset($tableConfArray[$functablename]['groupBy'])) {
+                    $selectConf['groupBy'] = $tableConfArray[$functablename]['groupBy'];
 
-					$selectConf['groupBy'] = $itemTable->getTableObj()->transformOrderby($selectConf['groupBy']);
+                    $selectConf['groupBy'] = $itemTable->getTableObj()->transformOrderby($selectConf['groupBy']);
 
-					if ($selectConf['groupBy']) {
-						$selectConf['groupBy'] = $GLOBALS['TYPO3_DB']->stripGroupBy($selectConf['groupBy']);
-					}
-				}
+                    if ($selectConf['groupBy']) {
+                        $selectConf['groupBy'] = $GLOBALS['TYPO3_DB']->stripGroupBy($selectConf['groupBy']);
+                    }
+                }
 
-				$queryParts = $itemTable->getTableObj()->getQueryConf(
-					$cObj,
-					$tablename,
-					$selectConf,
-					true
-				);
+                $queryParts = $itemTable->getTableObj()->getQueryConf(
+                    $cObj,
+                    $tablename,
+                    $selectConf,
+                    true
+                );
 
-				if (!empty($selectConf['groupBy'])) {
-					$queryParts['SELECT'] .= ',count(' . $selectConf['groupBy'] . ') sql_groupby_count';
-				}
+                if (!empty($selectConf['groupBy'])) {
+                    $queryParts['SELECT'] .= ',count(' . $selectConf['groupBy'] . ') sql_groupby_count';
+                }
 
-				if ($queryParts === false) {
-					return 'ERROR in tt_products';
-				}
+                if ($queryParts === false) {
+                    return 'ERROR in tt_products';
+                }
 
-				// run the big SELECT
-				$res =
-					$itemTable->getTableObj()->exec_SELECT_queryArray(
-						$queryParts,
-						'',
-						false,
-						$collateConf
-					);
-				$iCount = 0;
-				$uidArray = [];
-				while($iCount < $limit && ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
-					$iCount++;
+                // run the big SELECT
+                $res =
+                    $itemTable->getTableObj()->exec_SELECT_queryArray(
+                        $queryParts,
+                        '',
+                        false,
+                        $collateConf
+                    );
+                $iCount = 0;
+                $uidArray = [];
+                while($iCount < $limit && ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
+                    $iCount++;
 
-					if (is_array($itemTableLangFields) && count($itemTableLangFields)) {
-						foreach($itemTableLangFields as $field => $langfield) {
-							$row[$field] = $row[$langfield];
-						}
-					}
+                    if (is_array($itemTableLangFields) && count($itemTableLangFields)) {
+                        foreach($itemTableLangFields as $field => $langfield) {
+                            $row[$field] = $row[$langfield];
+                        }
+                    }
 
-					if (
-						$itemTable->getType() == 'product' &&
-						$useArticles == 3
-					) {
-						$itemTable->fillVariantsFromArticles($row);
-					}
+                    if (
+                        $itemTable->getType() == 'product' &&
+                        $useArticles == 3
+                    ) {
+                        $itemTable->fillVariantsFromArticles($row);
+                    }
 
-					$itemTable->getTableObj()->substituteMarkerArray(
-						$row,
-						$selectableVariantFieldArray
-					);
-					$itemTable->getTableObj()->transformRow(
-						$row,
-						TT_PRODUCTS_EXT
-					);
+                    $itemTable->getTableObj()->substituteMarkerArray(
+                        $row,
+                        $selectableVariantFieldArray
+                    );
+                    $itemTable->getTableObj()->transformRow(
+                        $row,
+                        TT_PRODUCTS_EXT
+                    );
 
-					if (isset($parentRows) && is_array($parentRows)) {
-						foreach ($parentRows as $parentRow) {
-							if (
-								isset($parentRow['childs']) &&
-								is_array($parentRow['childs']) &&
-								in_array($row['uid'], $parentRow['childs'])
-							) {
-								$currentParentRow = $parentRow;
-								foreach ($row as $field => $value) {
-									if (empty($value) && !empty($parentRow[$field])) {
+                    if (isset($parentRows) && is_array($parentRows)) {
+                        foreach ($parentRows as $parentRow) {
+                            if (
+                                isset($parentRow['childs']) &&
+                                is_array($parentRow['childs']) &&
+                                in_array($row['uid'], $parentRow['childs'])
+                            ) {
+                                $currentParentRow = $parentRow;
+                                foreach ($row as $field => $value) {
+                                    if (empty($value) && !empty($parentRow[$field])) {
                                         $prefixArray = ['', FieldInterface::EXTERNAL_FIELD_PREFIX];
                                         foreach ($prefixArray as $prefix) {
                                             if (
@@ -1821,469 +1821,469 @@ class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
                                             ) {
                                                 continue 2;
                                             }
-										}
-										$correspondingField = $field;
-										if (strpos($field, FieldInterface::EXTERNAL_FIELD_PREFIX) === 0) {
-											$correspondingField = substr($field, strlen(FieldInterface::EXTERNAL_FIELD_PREFIX));
-										}
-										$row[$field] = $parentRow[$correspondingField];
-									}
-								}
-							}
-						}
-					}
+                                        }
+                                        $correspondingField = $field;
+                                        if (strpos($field, FieldInterface::EXTERNAL_FIELD_PREFIX) === 0) {
+                                            $correspondingField = substr($field, strlen(FieldInterface::EXTERNAL_FIELD_PREFIX));
+                                        }
+                                        $row[$field] = $parentRow[$correspondingField];
+                                    }
+                                }
+                            }
+                        }
+                    }
 
-					$itemArray[] = $row;
-					if (isset($row['uid'])) {
-						$uidArray[] = $row['uid'];
-					}
-				}
+                    $itemArray[] = $row;
+                    if (isset($row['uid'])) {
+                        $uidArray[] = $row['uid'];
+                    }
+                }
 
-				if (
-					$iCount == $limit &&
-					($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))
-				) {
-					$more = 1;
-				}
+                if (
+                    $iCount == $limit &&
+                    ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))
+                ) {
+                    $more = 1;
+                }
 
-				$GLOBALS['TYPO3_DB']->sql_free_result($res);
-				if ($theCode == 'LISTGIFTS') {
-					$markerArray =
-						tx_ttproducts_gifts_div::addGiftMarkers(
-							$markerArray,
-							$this->giftnumber
-						);
-					$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
-					$javaScriptObj->set($languageObj, 'email');
-				}
-				$markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid; // needed if form starts e.g. between ###ITEM_LIST_TEMPLATE### and ###ITEM_CATEGORY_AND_ITEMS###
+                $GLOBALS['TYPO3_DB']->sql_free_result($res);
+                if ($theCode == 'LISTGIFTS') {
+                    $markerArray =
+                        tx_ttproducts_gifts_div::addGiftMarkers(
+                            $markerArray,
+                            $this->giftnumber
+                        );
+                    $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+                    $javaScriptObj->set($languageObj, 'email');
+                }
+                $markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid; // needed if form starts e.g. between ###ITEM_LIST_TEMPLATE### and ###ITEM_CATEGORY_AND_ITEMS###
 
-				$markerFramework = 'listFrameWork';
-				$t[$markerFramework] =
-					$templateService->substituteMarkerArrayCached(
-						$t[$markerFramework],
-						$markerArray,
-						[],
-						[]
-					);
-				$t['itemFrameWork'] =
-					$templateService->substituteMarkerArrayCached(
-						$t['itemFrameWork'],
-						$markerArray,
-						[],
-						[]
-					);
+                $markerFramework = 'listFrameWork';
+                $t[$markerFramework] =
+                    $templateService->substituteMarkerArrayCached(
+                        $t[$markerFramework],
+                        $markerArray,
+                        [],
+                        []
+                    );
+                $t['itemFrameWork'] =
+                    $templateService->substituteMarkerArrayCached(
+                        $t['itemFrameWork'],
+                        $markerArray,
+                        [],
+                        []
+                    );
 
-				$currentArray = [];
-				$currentArray['category'] = '-1';
-				$currentArray['product'] = '-1';
-				$nextArray = [];
-				$nextArray['category'] = '';
-				$nextArray['product'] = '';
-				$productMarkerArray = [];
-				$out = '';
-				$categoryAndItemsOut = '';
-				$iCount = 0;
-				$iColCount = 0;
-				$productListOut = '';
-				$itemsOut = '';
-				$headerItemsOutArray = [];
-				$currentHeaderRow = [];
-				$itemListOut = '';
-				$categoryOut = '';
-				$tableRowOpen = 0;
-				$itemListSubpart = ($itemTable->getType() == 'article' && $t['productAndItemsFrameWork'] ? '###ITEM_PRODUCT_AND_ITEMS###' : '###ITEM_LIST###');
-				$prodRow = [];
-				if ($itemTable->getType() != 'product') {
-					$prodRow = $parentProductRow;
-				}
-				$formCount = 1;
-				$bFormPerItem = false;
-				$itemLower = strtolower($t['item']);
+                $currentArray = [];
+                $currentArray['category'] = '-1';
+                $currentArray['product'] = '-1';
+                $nextArray = [];
+                $nextArray['category'] = '';
+                $nextArray['product'] = '';
+                $productMarkerArray = [];
+                $out = '';
+                $categoryAndItemsOut = '';
+                $iCount = 0;
+                $iColCount = 0;
+                $productListOut = '';
+                $itemsOut = '';
+                $headerItemsOutArray = [];
+                $currentHeaderRow = [];
+                $itemListOut = '';
+                $categoryOut = '';
+                $tableRowOpen = 0;
+                $itemListSubpart = ($itemTable->getType() == 'article' && $t['productAndItemsFrameWork'] ? '###ITEM_PRODUCT_AND_ITEMS###' : '###ITEM_LIST###');
+                $prodRow = [];
+                if ($itemTable->getType() != 'product') {
+                    $prodRow = $parentProductRow;
+                }
+                $formCount = 1;
+                $bFormPerItem = false;
+                $itemLower = strtolower($t['item']);
                 $cat = '';
 
-				if (strpos($itemLower, '<form') !== false) {
-					$bFormPerItem = true;
-				}
-				$bUseDAM = false;
-				if (strpos($itemLower, '###dam_field_name###') !== false) {
-					$bUseDAM = true;
-				}
+                if (strpos($itemLower, '<form') !== false) {
+                    $bFormPerItem = true;
+                }
+                $bUseDAM = false;
+                if (strpos($itemLower, '###dam_field_name###') !== false) {
+                    $bUseDAM = true;
+                }
 
-				if (count($itemArray)) {	// $itemArray must have numbered indexes to work, because the next item must be determined
+                if (count($itemArray)) {	// $itemArray must have numbered indexes to work, because the next item must be determined
 
-					if ($itemTable->getType() == 'dam') { //
-						$productDAMMarkerArray = $relatedListView->getListMarkerArray(
-							$theCode,
-							$templateCode,
-							$mergeTagArray,
-							$functablename,
-							'',
-							$this->uidArray,
-							$parentProductRow,
-							true,
+                    if ($itemTable->getType() == 'dam') { //
+                        $productDAMMarkerArray = $relatedListView->getListMarkerArray(
+                            $theCode,
+                            $templateCode,
+                            $mergeTagArray,
+                            $functablename,
+                            '',
+                            $this->uidArray,
+                            $parentProductRow,
+                            true,
                             $multiOrderArray,
-							$useArticles,
-							$pageAsCategory,
-							$this->pid,
-							$error_code
-						);
-					}
-					$categoryMarkerArray = [];
-					$categorySubpartArray = [];
-					$categoryWrappedSubpartArray = [];
-					$itemRowWrapArray = [];
+                            $useArticles,
+                            $pageAsCategory,
+                            $this->pid,
+                            $error_code
+                        );
+                    }
+                    $categoryMarkerArray = [];
+                    $categorySubpartArray = [];
+                    $categoryWrappedSubpartArray = [];
+                    $itemRowWrapArray = [];
 
-					$itemRowWrapArray = GeneralUtility::trimExplode('|', $cssConf['itemRowWrap']);
+                    $itemRowWrapArray = GeneralUtility::trimExplode('|', $cssConf['itemRowWrap']);
 
-					foreach ($itemArray as $k2 => $row) {
-						$bHeaderFieldChanged = false;
+                    foreach ($itemArray as $k2 => $row) {
+                        $bHeaderFieldChanged = false;
 
-						if (is_array($headerTableArray) && count($headerTableArray)) {
-							if (is_array($currentHeaderRow) && count($currentHeaderRow)) {
-								foreach($headerTableArray as $headertable) {
-									$headerTableLen = strlen($headertable);
+                        if (is_array($headerTableArray) && count($headerTableArray)) {
+                            if (is_array($currentHeaderRow) && count($currentHeaderRow)) {
+                                foreach($headerTableArray as $headertable) {
+                                    $headerTableLen = strlen($headertable);
 
-									foreach($row as $field => $v) {
-										if (strpos($field, $headertable) === 0) {
-											$headerKey =
-												substr($field, $headerfieldLen + 1, strlen($field) - $headerTableLen - 1);
-											if ($currentHeaderRow[$headertable][$headerKey] != $v) {
-												$bHeaderFieldChanged = true;
-												break;
-											}
-										}
-									}
-								}
-							}
-
-							if ($bHeaderFieldChanged || !count($currentHeaderRow)) {
-								$bHeaderFieldChanged = true;
-								$headerMarkerArray = [];
-								foreach($headerTableArray as $headertable) {
-
-									$headerTableLen = strlen($headertable);
-									foreach($row as $field => $v) {
-
-										if (strpos($field, $headertable) === 0) {
-											$headerKey =
-												substr($field,$headerTableLen + 1, strlen($field) - $headerTableLen - 1);
-											$currentHeaderRow[$headertable][$headerKey] = $v;
-										} // getMarker ()
-									}
-								}
-
-								foreach($currentHeaderRow as $headertable => $headerRow) {
-
-									$headerMarkerArray = [];
-									$tmp = [];
-									$tablesObj->get($headertable, true)->getRowMarkerArray(
-										$headertable,
-										$headerRow,
-										'',
-										$headerMarkerArray,
-										$tmp,
-										$tmp,
-										$headerViewTagArray[$headerFieldIndex],
-										$theCode,
-										$basketExtra,
-										$basketRecs,
-										true,
-										'',
-										0,
-										'image',
-										'',	// id part to be added
-										'', // if false, then no table marker will be added
-										'',	// this could be a number to discern between repeated rows
-										'',
-										$theCode == 'LISTGIFTS'
-									);
-									$headerItemsOutArray[$headertable] = $templateService->substituteMarkerArrayCached(
-										$t['itemheader']['address'],
-										$headerMarkerArray,
-										[],
-										[]
-									);
-								}
-							}
-						}
-						$iColCount++;
-						$iCount++;
-						$childCatWrap = '';
-						$displayCatHeader = '';
-
-						if ($useCategories) {
-							if (
-								empty($tableConfArray[$categoryfunctablename]['onlyDefaultCategory']) &&
-								$categoryTable->getFuncTablename() == 'tt_products_cat'
-							) {
-								$currentCat = $row['category'];
-							}
-
-							$catArray = $categoryTable->getCategoryArray($row, 'sorting');
-
-							if (
-								empty($tableConfArray[$categoryfunctablename]['onlyDefaultCategory']) &&
-								is_array($catArray) &&
-								count($catArray)
-							) {
-								reset($catArray);
-								$this->getCategories(
-									$categoryTable,
-									$catArray,
-									$rootCatArray,
-									$rootLineArray,
-									$cat,
-									$currentCat,
-									$displayCat
-								);
-								$depth = 0;
-								$bFound = false;
-
-								foreach ($rootLineArray as $catVal) {
-									$depth++;
-									if (in_array($catVal, $rootCatArray)) {
-										$bFound = true;
-										break;
-									}
-								}
-								if (!$bFound) {
-									$depth = 0;
-								}
-
-								$catLineArray =
-									$categoryTable->getLineArray(
-										$displayCat,
-										[0 => $currentCat]
-									);
-								$catLineArray = array_reverse($catLineArray);
-								reset($catLineArray);
-								$confDisplayColumns = $this->getDisplayInfo($displayConf, 'columns', $depth, !count($childCatArray));
-								$displayColumns =
-									(
-										MathUtility::canBeInterpretedAsInteger($confDisplayColumns) ?
-											$confDisplayColumns :
-											$displayColumns
-									);
-
-								if (count($childCatArray)) {
-									$linkCat = next($catLineArray);
-
-									if ($linkCat) {
-										$addQueryString = [$categoryPivar => $linkCat];
-										$tempUrl =
-											BrowserUtility::linkTPKeepCtrlVars(
-												$browseObj,
-												$cObj,
-												$prefixId,
-												'|',
-												$addQueryString,
-												1,
-												1,
-												$GLOBALS['TSFE']->id
-											);
-										$childCatWrap = '<a href="' . $tempUrl . '"' . $css . '> | </a>';
-										$imageWrap = false;
-									}
-								}
-							} else {
-								$displayCat = $currentCat;
-							}
-							$displayCatHeader =
-								$this->getDisplayInfo(
-									$displayConf,
-									'header',
-									$depth,
-									!count($childCatArray)
-								);
-
-							if ($displayCatHeader == 'current') {
-								$displayCat = $currentCat;
-							}
-						}
-
-							// print category title
-						if	(
-								$useCategories &&
-								$conf['displayListCatHeader'] &&
-								(
-									($pageAsCategory < 2) && ($displayCat != $currentArray['category']) ||
-									($pageAsCategory == 2) && ($row['pid'] != $currentArray['category']) ||
-									$displayCatHeader == 'always'
-								)
-							) {
-							$catItemsListOut = $itemListOut;
-							if ($itemTable->getType() == 'article' && $productListOut && $t['productAndItemsFrameWork']) {
-								$catItemsListOut = $productListOut;
-							}
-
-							if ($catItemsListOut && $conf['displayListCatHeader']) {
-								$out .= $this->advanceCategory($t['categoryAndItemsFrameWork'], $catItemsListOut, $categoryOut, $itemListSubpart, $oldFormCount, $formCount);
-							}
-							$currentArray['category'] = (($pageAsCategory < 2 || $itemTable->getType() == 'dam') ? $displayCat : $row['pid']);
-							$bCategoryHasChanged = true;
-							$categoryMarkerArray = [];
-							$categorySubpartArray = [];
-							$categoryWrappedSubpartArray = [];
-
-							if ($where != '' || !empty($conf['displayListCatHeader'])) { // Todo: displayListCatHeader is always 1 because of if before
-                                $tmp = [];
-								$categoryTableView->getMarkerArray(
-									$categoryMarkerArray,
-									'',
-									$displayCat,
-									$row['pid'],
-									$config['limitImage'],
-									'listcatImage',
-									$viewCatTagArray,
-									$tmp,
-									$pageAsCategory,
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									'',
-									'',
-									''
-								);
-
-								$catTitle = $categoryTableView->getMarkerArrayCatTitle($categoryMarkerArray);
-								$categoryTableView->getParentMarkerArray(
-									$catParentArray,
-									$row,
-									$categoryMarkerArray,
-									$displayCat,
-									$row['pid'],
-									$config['limitImage'],
-									'listcatImage',
-									$viewCatTagArray,
-									[],
-									$pageAsCategory,
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									1,
-									''
-								);
-
-								if ($t['categoryFrameWork'] && $conf['displayListCatHeader']) {
-									if ($displayCat) {
-										$catRow = $categoryTable->get($displayCat);
-										$categoryTableView->getItemSubpartArrays(
-											$t['categoryAndItemsFrameWork'],
-											$functablename,
-											$catRow,
-											$categorySubpartArray,
-											$categoryWrappedSubpartArray,
-											$viewCatTagArray,
-											$theCode,
-											$basketExtra,
-											$basketRecs
-										);
-									}
-
-									$categoryOut = $templateService->substituteMarkerArrayCached(
-										$t['categoryFrameWork'],
-										$categoryMarkerArray,
-										$categorySubpartArray,
-										$categoryWrappedSubpartArray
-									);
-
-									if ($displayCatHeader != 'always') {
-										$iColCount = 1;
-									}
-								}
-							}
-						} else {
-							$bCategoryHasChanged = false;
-						}
-
-						$subpartArray = [];
-
-						if ($itemTable->getType() == 'article') {
-							// relevant only for article list with articleMode == 0
-							if (
-								isset($row['uid_product']) &&
-								$row['uid_product'] &&
-								$row['uid_product'] != $currentArray['product']
-							) {
-								$productMarkerArray = [];
-								// fetch new product if articles are listed
-								$prodRow = $tablesObj->get('tt_products')->get($row['uid_product']);
-
-								$item = $basketObj->getItem(
-									tx_ttproducts_control_basket::getBasketExt(),
-									$basketExtra,
-									$basketRecs,
-									$prodRow,
-									'firstVariant'
-								);
-
-								$itemTableViewArray['product']->getModelMarkerArray(
-									$prodRow,
-									$itemTableViewArray['product']->getMarker(),
-									$productMarkerArray,
-									$catTitle,
-									$config['limitImage'],
-									'listImage',
-									$viewProductsTagArray,
-									[],
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									$iCount,
-									'',
-									'',
-									$imageWrap,
-									true,
-									'UTF-8',
-									$hiddenFields,
-									$multiOrderArray,
-									$productRowArray,
-									$theCode == 'LISTGIFTS'
-								);
-								$tablesObj->get('tt_products', true)->getItemSubpartArrays(
-									$t['item'],
-									'tt_products',
-									$row,
-									$subpartArray,
-									$wrappedSubpartArray,
-									$viewProductsTagArray,
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									$iCount
-								);
-
-								if ($itemListOut && $t['productAndItemsFrameWork']) {
-									$productListOut .=
-										$this->advanceProduct(
-											$t['productAndItemsFrameWork'],
-											$t['productFrameWork'],
-											$itemListOut,
-											$productMarkerArray,
-											$categoryMarkerArray
-										);
-								}
-							} else {
-								$prodRow = $parentProductRow;
+                                    foreach($row as $field => $v) {
+                                        if (strpos($field, $headertable) === 0) {
+                                            $headerKey =
+                                                substr($field, $headerfieldLen + 1, strlen($field) - $headerTableLen - 1);
+                                            if ($currentHeaderRow[$headertable][$headerKey] != $v) {
+                                                $bHeaderFieldChanged = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                             }
-							$itemTable->mergeAttributeFields(
-								$row,
-								$prodRow,
-								true,
-								false,
-								false,
-								'',
-								false,
-								true
-							);
-							$currentArray['product'] = $row['uid_product'] ?? 0;
-						} else {
-							$currentArray['product'] = $row['uid'];
 
-							if ($itemTable->getType() == 'product') {
-								$prodRow = $row;
-							} else {
+                            if ($bHeaderFieldChanged || !count($currentHeaderRow)) {
+                                $bHeaderFieldChanged = true;
+                                $headerMarkerArray = [];
+                                foreach($headerTableArray as $headertable) {
+
+                                    $headerTableLen = strlen($headertable);
+                                    foreach($row as $field => $v) {
+
+                                        if (strpos($field, $headertable) === 0) {
+                                            $headerKey =
+                                                substr($field,$headerTableLen + 1, strlen($field) - $headerTableLen - 1);
+                                            $currentHeaderRow[$headertable][$headerKey] = $v;
+                                        } // getMarker ()
+                                    }
+                                }
+
+                                foreach($currentHeaderRow as $headertable => $headerRow) {
+
+                                    $headerMarkerArray = [];
+                                    $tmp = [];
+                                    $tablesObj->get($headertable, true)->getRowMarkerArray(
+                                        $headertable,
+                                        $headerRow,
+                                        '',
+                                        $headerMarkerArray,
+                                        $tmp,
+                                        $tmp,
+                                        $headerViewTagArray[$headerFieldIndex],
+                                        $theCode,
+                                        $basketExtra,
+                                        $basketRecs,
+                                        true,
+                                        '',
+                                        0,
+                                        'image',
+                                        '',	// id part to be added
+                                        '', // if false, then no table marker will be added
+                                        '',	// this could be a number to discern between repeated rows
+                                        '',
+                                        $theCode == 'LISTGIFTS'
+                                    );
+                                    $headerItemsOutArray[$headertable] = $templateService->substituteMarkerArrayCached(
+                                        $t['itemheader']['address'],
+                                        $headerMarkerArray,
+                                        [],
+                                        []
+                                    );
+                                }
+                            }
+                        }
+                        $iColCount++;
+                        $iCount++;
+                        $childCatWrap = '';
+                        $displayCatHeader = '';
+
+                        if ($useCategories) {
+                            if (
+                                empty($tableConfArray[$categoryfunctablename]['onlyDefaultCategory']) &&
+                                $categoryTable->getFuncTablename() == 'tt_products_cat'
+                            ) {
+                                $currentCat = $row['category'];
+                            }
+
+                            $catArray = $categoryTable->getCategoryArray($row, 'sorting');
+
+                            if (
+                                empty($tableConfArray[$categoryfunctablename]['onlyDefaultCategory']) &&
+                                is_array($catArray) &&
+                                count($catArray)
+                            ) {
+                                reset($catArray);
+                                $this->getCategories(
+                                    $categoryTable,
+                                    $catArray,
+                                    $rootCatArray,
+                                    $rootLineArray,
+                                    $cat,
+                                    $currentCat,
+                                    $displayCat
+                                );
+                                $depth = 0;
+                                $bFound = false;
+
+                                foreach ($rootLineArray as $catVal) {
+                                    $depth++;
+                                    if (in_array($catVal, $rootCatArray)) {
+                                        $bFound = true;
+                                        break;
+                                    }
+                                }
+                                if (!$bFound) {
+                                    $depth = 0;
+                                }
+
+                                $catLineArray =
+                                    $categoryTable->getLineArray(
+                                        $displayCat,
+                                        [0 => $currentCat]
+                                    );
+                                $catLineArray = array_reverse($catLineArray);
+                                reset($catLineArray);
+                                $confDisplayColumns = $this->getDisplayInfo($displayConf, 'columns', $depth, !count($childCatArray));
+                                $displayColumns =
+                                    (
+                                        MathUtility::canBeInterpretedAsInteger($confDisplayColumns) ?
+                                            $confDisplayColumns :
+                                            $displayColumns
+                                    );
+
+                                if (count($childCatArray)) {
+                                    $linkCat = next($catLineArray);
+
+                                    if ($linkCat) {
+                                        $addQueryString = [$categoryPivar => $linkCat];
+                                        $tempUrl =
+                                            BrowserUtility::linkTPKeepCtrlVars(
+                                                $browseObj,
+                                                $cObj,
+                                                $prefixId,
+                                                '|',
+                                                $addQueryString,
+                                                1,
+                                                1,
+                                                $GLOBALS['TSFE']->id
+                                            );
+                                        $childCatWrap = '<a href="' . $tempUrl . '"' . $css . '> | </a>';
+                                        $imageWrap = false;
+                                    }
+                                }
+                            } else {
+                                $displayCat = $currentCat;
+                            }
+                            $displayCatHeader =
+                                $this->getDisplayInfo(
+                                    $displayConf,
+                                    'header',
+                                    $depth,
+                                    !count($childCatArray)
+                                );
+
+                            if ($displayCatHeader == 'current') {
+                                $displayCat = $currentCat;
+                            }
+                        }
+
+                            // print category title
+                        if	(
+                                $useCategories &&
+                                $conf['displayListCatHeader'] &&
+                                (
+                                    ($pageAsCategory < 2) && ($displayCat != $currentArray['category']) ||
+                                    ($pageAsCategory == 2) && ($row['pid'] != $currentArray['category']) ||
+                                    $displayCatHeader == 'always'
+                                )
+                            ) {
+                            $catItemsListOut = $itemListOut;
+                            if ($itemTable->getType() == 'article' && $productListOut && $t['productAndItemsFrameWork']) {
+                                $catItemsListOut = $productListOut;
+                            }
+
+                            if ($catItemsListOut && $conf['displayListCatHeader']) {
+                                $out .= $this->advanceCategory($t['categoryAndItemsFrameWork'], $catItemsListOut, $categoryOut, $itemListSubpart, $oldFormCount, $formCount);
+                            }
+                            $currentArray['category'] = (($pageAsCategory < 2 || $itemTable->getType() == 'dam') ? $displayCat : $row['pid']);
+                            $bCategoryHasChanged = true;
+                            $categoryMarkerArray = [];
+                            $categorySubpartArray = [];
+                            $categoryWrappedSubpartArray = [];
+
+                            if ($where != '' || !empty($conf['displayListCatHeader'])) { // Todo: displayListCatHeader is always 1 because of if before
+                                $tmp = [];
+                                $categoryTableView->getMarkerArray(
+                                    $categoryMarkerArray,
+                                    '',
+                                    $displayCat,
+                                    $row['pid'],
+                                    $config['limitImage'],
+                                    'listcatImage',
+                                    $viewCatTagArray,
+                                    $tmp,
+                                    $pageAsCategory,
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    '',
+                                    '',
+                                    ''
+                                );
+
+                                $catTitle = $categoryTableView->getMarkerArrayCatTitle($categoryMarkerArray);
+                                $categoryTableView->getParentMarkerArray(
+                                    $catParentArray,
+                                    $row,
+                                    $categoryMarkerArray,
+                                    $displayCat,
+                                    $row['pid'],
+                                    $config['limitImage'],
+                                    'listcatImage',
+                                    $viewCatTagArray,
+                                    [],
+                                    $pageAsCategory,
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    1,
+                                    ''
+                                );
+
+                                if ($t['categoryFrameWork'] && $conf['displayListCatHeader']) {
+                                    if ($displayCat) {
+                                        $catRow = $categoryTable->get($displayCat);
+                                        $categoryTableView->getItemSubpartArrays(
+                                            $t['categoryAndItemsFrameWork'],
+                                            $functablename,
+                                            $catRow,
+                                            $categorySubpartArray,
+                                            $categoryWrappedSubpartArray,
+                                            $viewCatTagArray,
+                                            $theCode,
+                                            $basketExtra,
+                                            $basketRecs
+                                        );
+                                    }
+
+                                    $categoryOut = $templateService->substituteMarkerArrayCached(
+                                        $t['categoryFrameWork'],
+                                        $categoryMarkerArray,
+                                        $categorySubpartArray,
+                                        $categoryWrappedSubpartArray
+                                    );
+
+                                    if ($displayCatHeader != 'always') {
+                                        $iColCount = 1;
+                                    }
+                                }
+                            }
+                        } else {
+                            $bCategoryHasChanged = false;
+                        }
+
+                        $subpartArray = [];
+
+                        if ($itemTable->getType() == 'article') {
+                            // relevant only for article list with articleMode == 0
+                            if (
+                                isset($row['uid_product']) &&
+                                $row['uid_product'] &&
+                                $row['uid_product'] != $currentArray['product']
+                            ) {
+                                $productMarkerArray = [];
+                                // fetch new product if articles are listed
+                                $prodRow = $tablesObj->get('tt_products')->get($row['uid_product']);
+
+                                $item = $basketObj->getItem(
+                                    tx_ttproducts_control_basket::getBasketExt(),
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $prodRow,
+                                    'firstVariant'
+                                );
+
+                                $itemTableViewArray['product']->getModelMarkerArray(
+                                    $prodRow,
+                                    $itemTableViewArray['product']->getMarker(),
+                                    $productMarkerArray,
+                                    $catTitle,
+                                    $config['limitImage'],
+                                    'listImage',
+                                    $viewProductsTagArray,
+                                    [],
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $iCount,
+                                    '',
+                                    '',
+                                    $imageWrap,
+                                    true,
+                                    'UTF-8',
+                                    $hiddenFields,
+                                    $multiOrderArray,
+                                    $productRowArray,
+                                    $theCode == 'LISTGIFTS'
+                                );
+                                $tablesObj->get('tt_products', true)->getItemSubpartArrays(
+                                    $t['item'],
+                                    'tt_products',
+                                    $row,
+                                    $subpartArray,
+                                    $wrappedSubpartArray,
+                                    $viewProductsTagArray,
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $iCount
+                                );
+
+                                if ($itemListOut && $t['productAndItemsFrameWork']) {
+                                    $productListOut .=
+                                        $this->advanceProduct(
+                                            $t['productAndItemsFrameWork'],
+                                            $t['productFrameWork'],
+                                            $itemListOut,
+                                            $productMarkerArray,
+                                            $categoryMarkerArray
+                                        );
+                                }
+                            } else {
+                                $prodRow = $parentProductRow;
+                            }
+                            $itemTable->mergeAttributeFields(
+                                $row,
+                                $prodRow,
+                                true,
+                                false,
+                                false,
+                                '',
+                                false,
+                                true
+                            );
+                            $currentArray['product'] = $row['uid_product'] ?? 0;
+                        } else {
+                            $currentArray['product'] = $row['uid'];
+
+                            if ($itemTable->getType() == 'product') {
+                                $prodRow = $row;
+                            } else {
                                 $prodRow = $parentProductRow;
                                 $prefixArray = ['', FieldInterface::EXTERNAL_FIELD_PREFIX];
                                 foreach ($prefixArray as $prefix) {
@@ -2297,636 +2297,636 @@ class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
                                     }
                                 }
                             }
-						}
-						$temp = $cssConf['default'] ?? '';
-						$css_current = ($temp ? $temp : $conf['CSSListDefault'] ?? '');	// only for backwards compatibility
+                        }
+                        $temp = $cssConf['default'] ?? '';
+                        $css_current = ($temp ? $temp : $conf['CSSListDefault'] ?? '');	// only for backwards compatibility
 
-						if (
+                        if (
                             isset($this->uidArray[$itemTable->getType()]) &&
                             $row['uid'] == $this->uidArray[$itemTable->getType()]
                         ) {
-							$temp = $cssConf['current'] ?? '';
-							$css_current = ($temp ? $temp : $conf['CSSListCurrent'] ?? '');
-						}
-						$css_current = ($css_current ? ' class="' . $css_current . '"' : '');
+                            $temp = $cssConf['current'] ?? '';
+                            $css_current = ($temp ? $temp : $conf['CSSListCurrent'] ?? '');
+                        }
+                        $css_current = ($css_current ? ' class="' . $css_current . '"' : '');
 
-							// Print Item Title
-						$wrappedSubpartArray = [];
-						$addQueryString = [];
-						$pagesObj = $tablesObj->get('pages');
-						$pid = $pagesObj->getPID($conf['PIDitemDisplay'] ?? '', $conf['PIDitemDisplay.'] ?? '', $row);
+                            // Print Item Title
+                        $wrappedSubpartArray = [];
+                        $addQueryString = [];
+                        $pagesObj = $tablesObj->get('pages');
+                        $pid = $pagesObj->getPID($conf['PIDitemDisplay'] ?? '', $conf['PIDitemDisplay.'] ?? '', $row);
 
-						$parentUid = 0;
-						if (
-							isset($parentDataArray) &&
-							is_array($parentDataArray) &&
-							isset($parentDataArray['functablename']) &&
-							isset($parentDataArray['uid'])
-						) {
-							if (
-								$parentDataArray['functablename'] == 'tt_products' &&
-								(
-									$conf['noArticleSingleView'] ||
-									$itemTable->getType() != 'article'
-								)
-							) {
-								$parentUid = intval($parentDataArray['uid']);
-							}
-						}
+                        $parentUid = 0;
+                        if (
+                            isset($parentDataArray) &&
+                            is_array($parentDataArray) &&
+                            isset($parentDataArray['functablename']) &&
+                            isset($parentDataArray['uid'])
+                        ) {
+                            if (
+                                $parentDataArray['functablename'] == 'tt_products' &&
+                                (
+                                    $conf['noArticleSingleView'] ||
+                                    $itemTable->getType() != 'article'
+                                )
+                            ) {
+                                $parentUid = intval($parentDataArray['uid']);
+                            }
+                        }
 
-						if (
-							$conf['noArticleSingleView'] &&
-							!$parentUid &&
-							$itemTable->getType() == 'article'
-						) {
-							$parentUid = $prodRow['uid'];
-						}
+                        if (
+                            $conf['noArticleSingleView'] &&
+                            !$parentUid &&
+                            $itemTable->getType() == 'article'
+                        ) {
+                            $parentUid = $prodRow['uid'];
+                        }
 
-						if ($parentUid) {
-							$addQueryString[$itemTableViewArray['product']->getPivar()] = $parentUid;
-						}
+                        if ($parentUid) {
+                            $addQueryString[$itemTableViewArray['product']->getPivar()] = $parentUid;
+                        }
 
-						$addQueryString[$itemTableView->getPivar()] = intval($row['uid']);
-						$piVarCat = $piVars[$categoryPivar] ?? '';
-						$useBackPid = $useBackPid && ($pid != $GLOBALS['TSFE']->id);
-						$nextcat = $cat;
+                        $addQueryString[$itemTableView->getPivar()] = intval($row['uid']);
+                        $piVarCat = $piVars[$categoryPivar] ?? '';
+                        $useBackPid = $useBackPid && ($pid != $GLOBALS['TSFE']->id);
+                        $nextcat = $cat;
 
-						if (
-							$useCategories &&
-							isset($viewParamConf) &&
-							is_array($viewParamConf) &&
-							isset($viewParamConf['item']) &&
-							GeneralUtility::inList($viewParamConf['item'], $categoryPivar)
-						) {
-							$nextcat = $row['category'];
-						} else if ($piVarCat) {
-							if (
-								!empty($conf['PIDlistDisplay']) &&
-								!PluginApi::isRelatedCode($theCode)
-							) {
-								$useBackPid = false;
-							}
-							$cat = $piVarCat;
-						}
+                        if (
+                            $useCategories &&
+                            isset($viewParamConf) &&
+                            is_array($viewParamConf) &&
+                            isset($viewParamConf['item']) &&
+                            GeneralUtility::inList($viewParamConf['item'], $categoryPivar)
+                        ) {
+                            $nextcat = $row['category'];
+                        } else if ($piVarCat) {
+                            if (
+                                !empty($conf['PIDlistDisplay']) &&
+                                !PluginApi::isRelatedCode($theCode)
+                            ) {
+                                $useBackPid = false;
+                            }
+                            $cat = $piVarCat;
+                        }
 
-						if ($nextcat) {
-							$addQueryString[$categoryPivar] = $nextcat;
-						}
+                        if ($nextcat) {
+                            $addQueryString[$categoryPivar] = $nextcat;
+                        }
 
-						$excludeList = '';
+                        $excludeList = '';
 
-						if (
-							isset($viewParamConf) &&
-							is_array($viewParamConf) &&
-							!empty($viewParamConf['ignore'])
-						) {
-							$excludeList = $viewParamConf['ignore'];
-						}
+                        if (
+                            isset($viewParamConf) &&
+                            is_array($viewParamConf) &&
+                            !empty($viewParamConf['ignore'])
+                        ) {
+                            $excludeList = $viewParamConf['ignore'];
+                        }
 
-						$queryString = $urlObj->getLinkParams(
-							$excludeList,
-							$addQueryString,
-							true,
-							$useBackPid,
-							$backPid,
-							$itemTableView->getPivar(),
-							$categoryPivar
-						);
+                        $queryString = $urlObj->getLinkParams(
+                            $excludeList,
+                            $addQueryString,
+                            true,
+                            $useBackPid,
+                            $backPid,
+                            $itemTableView->getPivar(),
+                            $categoryPivar
+                        );
 
-						$linkConf = [];
-						if (
-							isset($linkConfArray) &&
-							is_array($linkConfArray) &&
-							isset($linkConfArray['LINK_ITEM.'])
-						) {
-							$linkConf = $linkConfArray['LINK_ITEM.'];
-						}
+                        $linkConf = [];
+                        if (
+                            isset($linkConfArray) &&
+                            is_array($linkConfArray) &&
+                            isset($linkConfArray['LINK_ITEM.'])
+                        ) {
+                            $linkConf = $linkConfArray['LINK_ITEM.'];
+                        }
 
-						$target = '';
-						$pageLink = FrontendUtility::getTypoLink_URL(
-							$cObj,
-							$pid,
-							$queryString,
-							$target,
-							$linkConf
-						);
+                        $target = '';
+                        $pageLink = FrontendUtility::getTypoLink_URL(
+                            $cObj,
+                            $pid,
+                            $queryString,
+                            $target,
+                            $linkConf
+                        );
 
-						if ($childCatWrap) {
-							$wrappedSubpartArray['###LINK_ITEM###'] = GeneralUtility::trimExplode('|', $childCatWrap);
-						} else {
-							$wrappedSubpartArray['###LINK_ITEM###'] =
-								[
-									'<a class="singlelink" href="' . htmlspecialchars($pageLink) . '"' .
-										$css_current .
-										'>',
-									'</a>'
-								];
-						}
+                        if ($childCatWrap) {
+                            $wrappedSubpartArray['###LINK_ITEM###'] = GeneralUtility::trimExplode('|', $childCatWrap);
+                        } else {
+                            $wrappedSubpartArray['###LINK_ITEM###'] =
+                                [
+                                    '<a class="singlelink" href="' . htmlspecialchars($pageLink) . '"' .
+                                        $css_current .
+                                        '>',
+                                    '</a>'
+                                ];
+                        }
 
-						tx_ttproducts_control_memo::getWrappedSubpartArray(
-							$wrappedSubpartArray,
-							$pidMemo,
-							$row['uid'],
-							$cObj,
-							$urlObj,
-							$excludeList,
-							[],
-							'',
-							$useBackPid
-						);
+                        tx_ttproducts_control_memo::getWrappedSubpartArray(
+                            $wrappedSubpartArray,
+                            $pidMemo,
+                            $row['uid'],
+                            $cObj,
+                            $urlObj,
+                            $excludeList,
+                            [],
+                            '',
+                            $useBackPid
+                        );
 
-						if (is_array($mergeRow) && count($mergeRow)) {
-							$row = array_merge($row, $mergeRow);
-						}
+                        if (is_array($mergeRow) && count($mergeRow)) {
+                            $row = array_merge($row, $mergeRow);
+                        }
 
-						if ($itemTable->getType() != 'product') {
-							$externalRowArray[$itemTable->getFuncTablename()] = $row;
-						}
+                        if ($itemTable->getType() != 'product') {
+                            $externalRowArray[$itemTable->getFuncTablename()] = $row;
+                        }
 
-						$markerArray = [];
-						$item = $basketObj->getItem(
-							tx_ttproducts_control_basket::getBasketExt(),
-							$basketExtra,
-							$basketRecs,
-							$prodRow,
-							'firstVariant',
-							$itemTable->getFuncTablename(),
-							$externalRowArray,
-							$theCode == 'LISTGIFTS'
-						);
+                        $markerArray = [];
+                        $item = $basketObj->getItem(
+                            tx_ttproducts_control_basket::getBasketExt(),
+                            $basketExtra,
+                            $basketRecs,
+                            $prodRow,
+                            'firstVariant',
+                            $itemTable->getFuncTablename(),
+                            $externalRowArray,
+                            $theCode == 'LISTGIFTS'
+                        );
 
-						if (!empty($item)) {
-							$prodRow = $item['rec'];
-						}
+                        if (!empty($item)) {
+                            $prodRow = $item['rec'];
+                        }
 
-						$image = ($childCatWrap ? 'listImageHasChilds' : 'listImage');
+                        $image = ($childCatWrap ? 'listImageHasChilds' : 'listImage');
 
-						if (
-							isset($categoryArray) &&
-							is_array($categoryArray) &&
-							!isset($categoryArray[$currentCat]) &&
-							isset($conf['listImageRoot.']) &&
-							is_array($conf['listImageRoot.'])
-						) {
-							$image = 'listImageRoot';
-						}
-						$markerArray['###SQL_GROUPBY_COUNT###'] = $row['sql_groupby_count'] ?? 0;
-						$allVariants = '';
-						$prodVariantRow = $prodRow;
+                        if (
+                            isset($categoryArray) &&
+                            is_array($categoryArray) &&
+                            !isset($categoryArray[$currentCat]) &&
+                            isset($conf['listImageRoot.']) &&
+                            is_array($conf['listImageRoot.'])
+                        ) {
+                            $image = 'listImageRoot';
+                        }
+                        $markerArray['###SQL_GROUPBY_COUNT###'] = $row['sql_groupby_count'] ?? 0;
+                        $allVariants = '';
+                        $prodVariantRow = $prodRow;
 
-						if (
-							in_array(
-								$itemTable->getType(),
-								['product', 'article']
-							)
-						) {
-							if (
-								in_array($useArticles, [1, 2, 3]) &&
-								$showArticles
-							) {
-								$articleRow = '';
-								if ($itemTable->getType() == 'product') {
-									// get the article uid with these colors, sizes and gradings
-									$articleRow = $itemTable->getArticleRow($row, $theCode, true);
-								} else  if ($itemTable->getType() == 'article') {
-									$articleRow = $row;
-								}
+                        if (
+                            in_array(
+                                $itemTable->getType(),
+                                ['product', 'article']
+                            )
+                        ) {
+                            if (
+                                in_array($useArticles, [1, 2, 3]) &&
+                                $showArticles
+                            ) {
+                                $articleRow = '';
+                                if ($itemTable->getType() == 'product') {
+                                    // get the article uid with these colors, sizes and gradings
+                                    $articleRow = $itemTable->getArticleRow($row, $theCode, true);
+                                } else  if ($itemTable->getType() == 'article') {
+                                    $articleRow = $row;
+                                }
 
-									// use the product if no article row has been found
-								if ($articleRow) {
-									$prodVariantRow = tx_ttproducts_field_price::getWithoutTaxedPrices($prodVariantRow);
-									if ($itemTable->getType() == 'product') {
-										$itemTable->mergeAttributeFields(
-											$prodVariantRow,
-											$articleRow,
-											false,
-											($useArticles == 3),
-											false,
-											'',
-											false,
-											false
-										);
-									}
+                                    // use the product if no article row has been found
+                                if ($articleRow) {
+                                    $prodVariantRow = tx_ttproducts_field_price::getWithoutTaxedPrices($prodVariantRow);
+                                    if ($itemTable->getType() == 'product') {
+                                        $itemTable->mergeAttributeFields(
+                                            $prodVariantRow,
+                                            $articleRow,
+                                            false,
+                                            ($useArticles == 3),
+                                            false,
+                                            '',
+                                            false,
+                                            false
+                                        );
+                                    }
 
-									$prodVariantRow['ext']['tt_products_articles'][] = $articleRow;
-								} else {
-									$prodVariantRow['ext']['tt_products_articles'] = [];
-								}
-							}
-						}
+                                    $prodVariantRow['ext']['tt_products_articles'][] = $articleRow;
+                                } else {
+                                    $prodVariantRow['ext']['tt_products_articles'] = [];
+                                }
+                            }
+                        }
 
-						$allVariants =
-							$basketObj->getAllVariants(
-								$functablename,
-								$row,
-								$prodVariantRow
-							);
+                        $allVariants =
+                            $basketObj->getAllVariants(
+                                $functablename,
+                                $row,
+                                $prodVariantRow
+                            );
 
-						if (
-							in_array(
-								$itemTable->getType(),
-								['product', 'article', 'fal']
-							)
-						) {
-							if (
-								$showArticles &&
-								$itemTable->getType() == 'product'
-							) {
-								$currRow = $basketObj->getItemRow(
-									$prodVariantRow,
-									$allVariants,
-									$useArticles,
-									$itemTable->getFuncTablename(),
-									false
-								);
-							} else {
-								$currRow = $prodVariantRow;
-							}
+                        if (
+                            in_array(
+                                $itemTable->getType(),
+                                ['product', 'article', 'fal']
+                            )
+                        ) {
+                            if (
+                                $showArticles &&
+                                $itemTable->getType() == 'product'
+                            ) {
+                                $currRow = $basketObj->getItemRow(
+                                    $prodVariantRow,
+                                    $allVariants,
+                                    $useArticles,
+                                    $itemTable->getFuncTablename(),
+                                    false
+                                );
+                            } else {
+                                $currRow = $prodVariantRow;
+                            }
 
-							$basketExt1 = tx_ttproducts_control_basket::generatedBasketExtFromRow($currRow, '1');
+                            $basketExt1 = tx_ttproducts_control_basket::generatedBasketExtFromRow($currRow, '1');
 
-							$basketItemArray = $basketObj->getItemArrayFromRow(
-								$currRow,
-								$basketExt1,
-								$basketExtra,
-								$basketRecs,
-								$functablename,
-								$externalRowArray,
-								$theCode == 'LISTGIFTS'
-							);
+                            $basketItemArray = $basketObj->getItemArrayFromRow(
+                                $currRow,
+                                $basketExt1,
+                                $basketExtra,
+                                $basketRecs,
+                                $functablename,
+                                $externalRowArray,
+                                $theCode == 'LISTGIFTS'
+                            );
 
-							if (!empty($basketItemArray)) {
-								$basketObj->calculate($basketItemArray); // get the calculated arrays
-								$prodVariantRow = $basketObj->getMergedRowFromItemArray($basketItemArray, $basketExtra);
-							}
-							$currPriceMarkerArray = [];
-							$articleTablename = (is_object($itemTableArray['article']) ? $itemTableArray['article']->getTablename() : '');
-							$itemTableViewArray['product']->getCurrentPriceMarkerArray(
-								$currPriceMarkerArray,
-								'',
-								$itemTableArray['product']->getTablename(),
-								$prodRow,
-								$articleTablename,
-								$prodVariantRow,
-								'',
-								$theCode,
-								$basketExtra,
-								$basketRecs,
+                            if (!empty($basketItemArray)) {
+                                $basketObj->calculate($basketItemArray); // get the calculated arrays
+                                $prodVariantRow = $basketObj->getMergedRowFromItemArray($basketItemArray, $basketExtra);
+                            }
+                            $currPriceMarkerArray = [];
+                            $articleTablename = (is_object($itemTableArray['article']) ? $itemTableArray['article']->getTablename() : '');
+                            $itemTableViewArray['product']->getCurrentPriceMarkerArray(
+                                $currPriceMarkerArray,
+                                '',
+                                $itemTableArray['product']->getTablename(),
+                                $prodRow,
+                                $articleTablename,
+                                $prodVariantRow,
+                                '',
+                                $theCode,
+                                $basketExtra,
+                                $basketRecs,
                                 false, // $enableTaxZero neu
                                 $notOverwritePriceIfSet
-							);
-							$markerArray = array_merge($markerArray, $currPriceMarkerArray);
-							$bInputDisabled = ($row['inStock'] <= 0);
+                            );
+                            $markerArray = array_merge($markerArray, $currPriceMarkerArray);
+                            $bInputDisabled = ($row['inStock'] <= 0);
 
-							$basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
+                            $basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
 
-							$mergedProdRowWithoutVariants = $prodVariantRow;
-							$itemTable->mergeVariantFields(
-								$mergedProdRowWithoutVariants,
-								$row,
-								false
-							);
+                            $mergedProdRowWithoutVariants = $prodVariantRow;
+                            $itemTable->mergeVariantFields(
+                                $mergedProdRowWithoutVariants,
+                                $row,
+                                false
+                            );
 
-							if ($itemTable->getType() == 'product') {
-								$item['rec'] = $mergedProdRowWithoutVariants;
-							} else {
-								$item['rec'] = $prodRow;
-							}
+                            if ($itemTable->getType() == 'product') {
+                                $item['rec'] = $mergedProdRowWithoutVariants;
+                            } else {
+                                $item['rec'] = $prodRow;
+                            }
 
-							$basketItemView->getItemMarkerArray(
-								$functablename,
-								true,
-								$item,
-								$markerArray,
-								$viewTagArray,
-								$tmpHidden,
-								$theCode,
-								$bInputDisabled,
-								$iCount,
-								true,
-								'UTF-8',
-								$row,
-								$parentFuncTablename,
-								$currentParentRow,
-								$callFunctableArray,
-								$multiOrderArray
-							);
+                            $basketItemView->getItemMarkerArray(
+                                $functablename,
+                                true,
+                                $item,
+                                $markerArray,
+                                $viewTagArray,
+                                $tmpHidden,
+                                $theCode,
+                                $bInputDisabled,
+                                $iCount,
+                                true,
+                                'UTF-8',
+                                $row,
+                                $parentFuncTablename,
+                                $currentParentRow,
+                                $callFunctableArray,
+                                $multiOrderArray
+                            );
 
-							$listMarkerArray = $relatedListView->getListMarkerArray(
-								$theCode,
-								$templateCode,
-								$viewTagArray,
-								$functablename,
-								$row['uid'],
-								$this->uidArray,
-								$prodRow,
-								true,
+                            $listMarkerArray = $relatedListView->getListMarkerArray(
+                                $theCode,
+                                $templateCode,
+                                $viewTagArray,
+                                $functablename,
+                                $row['uid'],
+                                $this->uidArray,
+                                $prodRow,
+                                true,
                                 $multiOrderArray,
- 								$useArticles,
-								$pageAsCategory,
-								$this->pid,
-								$error_code
-							);
+                                $useArticles,
+                                $pageAsCategory,
+                                $this->pid,
+                                $error_code
+                            );
 
-							if ($listMarkerArray && is_array($listMarkerArray)) {
-								$quantityMarkerArray = [];
+                            if ($listMarkerArray && is_array($listMarkerArray)) {
+                                $quantityMarkerArray = [];
 
-								foreach ($listMarkerArray as $marker => $markerValue) {
-									$markerValue = $templateService->substituteMarkerArray($markerValue, $markerArray);
-									$markerValue = $templateService->substituteMarkerArray($markerValue, $quantityMarkerArray);
-									$markerArray[$marker] = $markerValue;
-								}
-							}
-						}
+                                foreach ($listMarkerArray as $marker => $markerValue) {
+                                    $markerValue = $templateService->substituteMarkerArray($markerValue, $markerArray);
+                                    $markerValue = $templateService->substituteMarkerArray($markerValue, $quantityMarkerArray);
+                                    $markerArray[$marker] = $markerValue;
+                                }
+                            }
+                        }
 
-						$itemTableView->getModelMarkerArray(
-							$row,
-							$itemTableViewArray[$itemTable->getType()]->getMarker(),
-							$markerArray,
-							$catTitle,
-							$config['limitImage'],
-							$image,
-							$viewTagArray,
-							[],
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							'',
-							'',
-							'',
-							$imageWrap,
-							true,
-							'UTF-8',
-							$hiddenFields,
-							$multiOrderArray,
-							$productRowArray,
-							$theCode == 'LISTGIFTS'
-						);
+                        $itemTableView->getModelMarkerArray(
+                            $row,
+                            $itemTableViewArray[$itemTable->getType()]->getMarker(),
+                            $markerArray,
+                            $catTitle,
+                            $config['limitImage'],
+                            $image,
+                            $viewTagArray,
+                            [],
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            '',
+                            '',
+                            '',
+                            $imageWrap,
+                            true,
+                            'UTF-8',
+                            $hiddenFields,
+                            $multiOrderArray,
+                            $productRowArray,
+                            $theCode == 'LISTGIFTS'
+                        );
 
-						if (
-							$itemTable->getType() == 'product' &&
-							$useCategories &&
-							isset($tableConfArray[$categoryfunctablename]) &&
-							isset($tableConfArray[$categoryfunctablename]['tagmark.'])
-						) {
-							$tagArray = [];
-							$tagConf = $tableConfArray[$categoryfunctablename]['tagmark.'];
-							foreach ($catArray as $loopCategory) {
-								$catRow =
-									$categoryTable->get(
-										$loopCategory,
-										0,
-										false,
-										'',
-										'',
-										'',
-										'',
-										'catid'
-									);
-								if (!empty($catRow['catid'])) {
-									$tagArray[] = $catRow['catid'];
-								}
+                        if (
+                            $itemTable->getType() == 'product' &&
+                            $useCategories &&
+                            isset($tableConfArray[$categoryfunctablename]) &&
+                            isset($tableConfArray[$categoryfunctablename]['tagmark.'])
+                        ) {
+                            $tagArray = [];
+                            $tagConf = $tableConfArray[$categoryfunctablename]['tagmark.'];
+                            foreach ($catArray as $loopCategory) {
+                                $catRow =
+                                    $categoryTable->get(
+                                        $loopCategory,
+                                        0,
+                                        false,
+                                        '',
+                                        '',
+                                        '',
+                                        '',
+                                        'catid'
+                                    );
+                                if (!empty($catRow['catid'])) {
+                                    $tagArray[] = $catRow['catid'];
+                                }
 
-								if (!empty($tagConf['parents']) && !empty($catRow['parent_category'])) {
-									$parentRow =
-										$categoryTable->get(
-											$catRow['parent_category'],
-											0,
-											false,
-											'',
-											'',
-											'',
-											'',
-											'catid'
-										);
-									if (
-										isset($parentRow) &&
-										is_array($parentRow) &&
-										!empty($parentRow['catid'])
-									) {
-										$tagArray[] = $parentRow['catid'];
-									}
-								}
-							}
-							$tagArray = array_unique($tagArray);
-							sort($tagArray, SORT_NUMERIC);
-							$categoryTableView->addAllCatTagsMarker(
-								$markerArray,
-								$tagArray,
-								$tagConf['prefix']
-							);
-						}
+                                if (!empty($tagConf['parents']) && !empty($catRow['parent_category'])) {
+                                    $parentRow =
+                                        $categoryTable->get(
+                                            $catRow['parent_category'],
+                                            0,
+                                            false,
+                                            '',
+                                            '',
+                                            '',
+                                            '',
+                                            'catid'
+                                        );
+                                    if (
+                                        isset($parentRow) &&
+                                        is_array($parentRow) &&
+                                        !empty($parentRow['catid'])
+                                    ) {
+                                        $tagArray[] = $parentRow['catid'];
+                                    }
+                                }
+                            }
+                            $tagArray = array_unique($tagArray);
+                            sort($tagArray, SORT_NUMERIC);
+                            $categoryTableView->addAllCatTagsMarker(
+                                $markerArray,
+                                $tagArray,
+                                $tagConf['prefix']
+                            );
+                        }
 
-						if ($itemTable->getType() == 'product') {
-							if (
-								in_array($useArticles, [1, 2, 3]) &&
-								$showArticles
-							) {
-								// use the fields of the article instead of the product
-								//
-								$itemTableView->getModelMarkerArray(
-									$prodVariantRow, // must have the getMergedRowFromItemArray function called before. Otherwise the product will not show the first variant selection at the first start time
-									$itemTableViewArray['article']->getMarker(),
-									$markerArray,
-									$catTitle,
-									$config['limitImage'],
-									$image,
-									$articleViewTagArray,
-									[],
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									'from-tt-products-articles',
-									'',
-									'',
-									$imageWrap,
-									true,
+                        if ($itemTable->getType() == 'product') {
+                            if (
+                                in_array($useArticles, [1, 2, 3]) &&
+                                $showArticles
+                            ) {
+                                // use the fields of the article instead of the product
+                                //
+                                $itemTableView->getModelMarkerArray(
+                                    $prodVariantRow, // must have the getMergedRowFromItemArray function called before. Otherwise the product will not show the first variant selection at the first start time
+                                    $itemTableViewArray['article']->getMarker(),
+                                    $markerArray,
+                                    $catTitle,
+                                    $config['limitImage'],
+                                    $image,
+                                    $articleViewTagArray,
+                                    [],
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    'from-tt-products-articles',
+                                    '',
+                                    '',
+                                    $imageWrap,
+                                    true,
                                     'UTF-8',
-									$hiddenFields,
-									$multiOrderArray,
-									$productRowArray,
-									$theCode == 'LISTGIFTS'
-								);
-								$articleViewObj->getItemSubpartArrays(
-									$t['item'],
-									'tt_products_articles',
-									$prodRow, // $row
-									$subpartArray,
-									$wrappedSubpartArray,
-									$articleViewTagArray,
-									$theCode,
-									$basketExtra,
-									$basketRecs,
-									$iCount
-								);
-							}
+                                    $hiddenFields,
+                                    $multiOrderArray,
+                                    $productRowArray,
+                                    $theCode == 'LISTGIFTS'
+                                );
+                                $articleViewObj->getItemSubpartArrays(
+                                    $t['item'],
+                                    'tt_products_articles',
+                                    $prodRow, // $row
+                                    $subpartArray,
+                                    $wrappedSubpartArray,
+                                    $articleViewTagArray,
+                                    $theCode,
+                                    $basketExtra,
+                                    $basketRecs,
+                                    $iCount
+                                );
+                            }
 
-							$itemTableView->getItemMarkerSubpartArrays(
-								$t['item'],
-								'tt_products',
-								$prodRow,
-								$markerArray,
-								$subpartArray,
-								$wrappedSubpartArray,
-								$viewTagArray,
-								$multiOrderArray,
-								$productRowArray,
-								$theCode,
-								$basketExtra,
-								$basketRecs,
-								$iCount
-							);
+                            $itemTableView->getItemMarkerSubpartArrays(
+                                $t['item'],
+                                'tt_products',
+                                $prodRow,
+                                $markerArray,
+                                $subpartArray,
+                                $wrappedSubpartArray,
+                                $viewTagArray,
+                                $multiOrderArray,
+                                $productRowArray,
+                                $theCode,
+                                $basketExtra,
+                                $basketRecs,
+                                $iCount
+                            );
 
-							$basketItemView->getItemMarkerSubpartArrays(
-								$t['item'],
-								$functablename,
-								$row,
-								$theCode,
-								$viewTagArray,
-								$bEditableVariants,
-								$productRowArray,
-								$markerArray,
-								$subpartArray,
-								$wrappedSubpartArray
-							);
-						} else {
-							$itemTableView->getItemSubpartArrays(
-								$t['item'],
-								'tt_products',
-								$row,
-								$subpartArray,
-								$wrappedSubpartArray,
-								$viewTagArray,
-								$theCode,
-								$basketExtra,
-								$basketRecs,
-								$iCount
-							);
-						}
+                            $basketItemView->getItemMarkerSubpartArrays(
+                                $t['item'],
+                                $functablename,
+                                $row,
+                                $theCode,
+                                $viewTagArray,
+                                $bEditableVariants,
+                                $productRowArray,
+                                $markerArray,
+                                $subpartArray,
+                                $wrappedSubpartArray
+                            );
+                        } else {
+                            $itemTableView->getItemSubpartArrays(
+                                $t['item'],
+                                'tt_products',
+                                $row,
+                                $subpartArray,
+                                $wrappedSubpartArray,
+                                $viewTagArray,
+                                $theCode,
+                                $basketExtra,
+                                $basketRecs,
+                                $iCount
+                            );
+                        }
 
-						if ($itemTable->getType() == 'article') {
-							$productMarkerArray = array_merge ($productMarkerArray, $markerArray);
-							$markerArray = array_merge ($productMarkerArray, $markerArray);
-						} else if (
-							$itemTable->getType() == 'dam' &&
-							$productDAMMarkerArray &&
-							is_array($productDAMMarkerArray)
-						) {
-							$tmpMarkerArray = [];
-							$tmpMarkerArray['###DAM_UID###'] = $row['uid'];
+                        if ($itemTable->getType() == 'article') {
+                            $productMarkerArray = array_merge ($productMarkerArray, $markerArray);
+                            $markerArray = array_merge ($productMarkerArray, $markerArray);
+                        } else if (
+                            $itemTable->getType() == 'dam' &&
+                            $productDAMMarkerArray &&
+                            is_array($productDAMMarkerArray)
+                        ) {
+                            $tmpMarkerArray = [];
+                            $tmpMarkerArray['###DAM_UID###'] = $row['uid'];
 
-							foreach ($productDAMMarkerArray as $marker => $v) {
-								$markerArray[$marker] = $templateService->substituteMarkerArray(
-									$v,
-									$tmpMarkerArray
-								);
-							}
-						}
+                            foreach ($productDAMMarkerArray as $marker => $v) {
+                                $markerArray[$marker] = $templateService->substituteMarkerArray(
+                                    $v,
+                                    $tmpMarkerArray
+                                );
+                            }
+                        }
 
-						if ($linkCat) {
-							$linkCategoryMarkerArray = [];
-							$categoryTableView->getMarkerArray(
-								$linkCategoryMarkerArray,
-								$linkCat,
-								$row['pid'],
-								$config['limitImage'],
-								'listcatImage',
-								$viewCatTagArray,
-								[],
-								$pageAsCategory,
-								$theCode,
-								$basketExtra,
-								$basketRecs,
-								'',
-								''
-							);
-							$productMarkerArray = array_merge($productMarkerArray, $linkCategoryMarkerArray);
-						}
-						$markerArray = array_merge($productMarkerArray, $categoryMarkerArray, $markerArray);
+                        if ($linkCat) {
+                            $linkCategoryMarkerArray = [];
+                            $categoryTableView->getMarkerArray(
+                                $linkCategoryMarkerArray,
+                                $linkCat,
+                                $row['pid'],
+                                $config['limitImage'],
+                                'listcatImage',
+                                $viewCatTagArray,
+                                [],
+                                $pageAsCategory,
+                                $theCode,
+                                $basketExtra,
+                                $basketRecs,
+                                '',
+                                ''
+                            );
+                            $productMarkerArray = array_merge($productMarkerArray, $linkCategoryMarkerArray);
+                        }
+                        $markerArray = array_merge($productMarkerArray, $categoryMarkerArray, $markerArray);
 
-						if (isset($memoViewObj) && is_object($memoViewObj)) {
-							$memoViewObj->getFieldMarkerArray(
-								$row,
-								'MEMODAM',
-								$markerArray,
-								$mergeTagArray,
-								$bUseCheckBox
-							);
-						}
-						$jsMarkerArray = array_merge($jsMarkerArray, $productMarkerArray);
-						if ($theCode == 'LISTGIFTS') {
-							$markerArray =
-								tx_ttproducts_gifts_div::addGiftMarkers(
-									$markerArray,
-									$basketObj->giftnumber
-								);
-						}
+                        if (isset($memoViewObj) && is_object($memoViewObj)) {
+                            $memoViewObj->getFieldMarkerArray(
+                                $row,
+                                'MEMODAM',
+                                $markerArray,
+                                $mergeTagArray,
+                                $bUseCheckBox
+                            );
+                        }
+                        $jsMarkerArray = array_merge($jsMarkerArray, $productMarkerArray);
+                        if ($theCode == 'LISTGIFTS') {
+                            $markerArray =
+                                tx_ttproducts_gifts_div::addGiftMarkers(
+                                    $markerArray,
+                                    $basketObj->giftnumber
+                                );
+                        }
 
-						// $markerArray['###FORM_URL###']=$this->formUrl; // Applied later as well.
-						$addQueryString = [];
-						$addQueryString = $this->uidArray;
-						$this->getSearchParams($addQueryString);
-						$markerArray =
-							$urlObj->addURLMarkers(
-								$this->pid,
-								$markerArray,
-								$addQueryString,
-								'',
-								$useBackPid,
-								$backPid
-							); // clickIntoBasket
-						$oldFormCount = $formCount;
+                        // $markerArray['###FORM_URL###']=$this->formUrl; // Applied later as well.
+                        $addQueryString = [];
+                        $addQueryString = $this->uidArray;
+                        $this->getSearchParams($addQueryString);
+                        $markerArray =
+                            $urlObj->addURLMarkers(
+                                $this->pid,
+                                $markerArray,
+                                $addQueryString,
+                                '',
+                                $useBackPid,
+                                $backPid
+                            ); // clickIntoBasket
+                        $oldFormCount = $formCount;
 
-						$markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid . ($bFormPerItem ? '_' . $formCount : '');
-						$markerArray['###FORM_INDEX###'] = $formCount - 1;
+                        $markerArray['###FORM_NAME###'] = $formName . '_' . $contentUid . ($bFormPerItem ? '_' . $formCount : '');
+                        $markerArray['###FORM_INDEX###'] = $formCount - 1;
 
-						if ($bFormPerItem) {
-							$formCount++;
-						}
+                        if ($bFormPerItem) {
+                            $formCount++;
+                        }
 
-						$markerArray['###ITEM_NAME###'] = 'item_' . $contentUid . '_' . $iCount;
-						if (!$displayColumns) {
-							$markerArray['###FORM_NAME###'] = $markerArray['###ITEM_NAME###'];
-						}
-						if ($bUseDAM) {
-							$damUid = $this->uidArray['dam'];
-							if ($damUid) {
-								$tablesObj->get('tx_dam')->setFormMarkerArray($damUid, $markerArray);
-							}
-						}
-						$markerArray['###FORM_ONSUBMIT###'] = 'return checkParams (document.'.$markerArray['###FORM_NAME###'].');';
-						$rowEven = $cssConf['row.']['even'] ?? '';
-						$rowEven = (!empty($rowEven) ? $rowEven : $conf['CSSRowEven'] ?? ''); // backwards compatible
-						$rowUneven = $cssConf['row.']['uneven'] ?? '';
-						$rowUneven = (!empty($rowUneven) ? $rowUneven : $conf['CSSRowUneven'] ?? ''); // backwards compatible
-						// alternating css-class eg. for different background-colors
-						$evenUneven = (($iCount & 1) == 0 ? $rowEven : $rowUneven);
-						$temp='';
-						if ($iColCount == 1) {
-							if ($evenUneven) {
-								$temp = str_replace('###UNEVEN###', $evenUneven, $itemRowWrapArray[0] ?? '');
-							} else {
-								$temp = $itemRowWrapArray[0] ?? '';
-							}
-							$tableRowOpen = 1;
-						}
-	//
-						$itemSingleWrapArray = GeneralUtility::trimExplode('|', $cssConf['itemSingleWrap']);
-						if ($itemSingleWrapArray[0]) {
-							$temp .= str_replace('###UNEVEN###', $evenUneven, $itemSingleWrapArray[0]);
-						}
+                        $markerArray['###ITEM_NAME###'] = 'item_' . $contentUid . '_' . $iCount;
+                        if (!$displayColumns) {
+                            $markerArray['###FORM_NAME###'] = $markerArray['###ITEM_NAME###'];
+                        }
+                        if ($bUseDAM) {
+                            $damUid = $this->uidArray['dam'];
+                            if ($damUid) {
+                                $tablesObj->get('tx_dam')->setFormMarkerArray($damUid, $markerArray);
+                            }
+                        }
+                        $markerArray['###FORM_ONSUBMIT###'] = 'return checkParams (document.'.$markerArray['###FORM_NAME###'].');';
+                        $rowEven = $cssConf['row.']['even'] ?? '';
+                        $rowEven = (!empty($rowEven) ? $rowEven : $conf['CSSRowEven'] ?? ''); // backwards compatible
+                        $rowUneven = $cssConf['row.']['uneven'] ?? '';
+                        $rowUneven = (!empty($rowUneven) ? $rowUneven : $conf['CSSRowUneven'] ?? ''); // backwards compatible
+                        // alternating css-class eg. for different background-colors
+                        $evenUneven = (($iCount & 1) == 0 ? $rowEven : $rowUneven);
+                        $temp='';
+                        if ($iColCount == 1) {
+                            if ($evenUneven) {
+                                $temp = str_replace('###UNEVEN###', $evenUneven, $itemRowWrapArray[0] ?? '');
+                            } else {
+                                $temp = $itemRowWrapArray[0] ?? '';
+                            }
+                            $tableRowOpen = 1;
+                        }
+    //
+                        $itemSingleWrapArray = GeneralUtility::trimExplode('|', $cssConf['itemSingleWrap']);
+                        if ($itemSingleWrapArray[0]) {
+                            $temp .= str_replace('###UNEVEN###', $evenUneven, $itemSingleWrapArray[0]);
+                        }
 
-						$markerArray['###ITEM_SINGLE_PRE_HTML###'] = $temp;
-						$temp = $itemSingleWrapArray[1];
+                        $markerArray['###ITEM_SINGLE_PRE_HTML###'] = $temp;
+                        $temp = $itemSingleWrapArray[1];
 
-						if (!$displayColumns || $iColCount == $displayColumns) {
-							$temp .= $itemRowWrapArray[1] ?? '';
-							$tableRowOpen = 0;
-						}
+                        if (!$displayColumns || $iColCount == $displayColumns) {
+                            $temp .= $itemRowWrapArray[1] ?? '';
+                            $tableRowOpen = 0;
+                        }
 
-						$markerArray['###ITEM_SINGLE_POST_HTML###'] = $temp;
+                        $markerArray['###ITEM_SINGLE_POST_HTML###'] = $temp;
 
-						// cuts note in list view
+                        // cuts note in list view
                         if (!isset($itemTableConf['field.']['note.'])) {
 
                             if (
@@ -2941,80 +2941,80 @@ class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
                             }
                         }
 
-						if (is_object($itemTableView->variant)) {
+                        if (is_object($itemTableView->variant)) {
 
-							$itemTableView->variant->removeEmptyMarkerSubpartArray(
-								$markerArray,
-								$subpartArray,
-								$wrappedSubpartArray,
-								$row,
-								$conf,
-								$itemTable->hasAdditional($row, 'isSingle'),
-								!$itemTable->hasAdditional($row, 'noGiftService')
-							);
-						}
-						$tempContent = '';
+                            $itemTableView->variant->removeEmptyMarkerSubpartArray(
+                                $markerArray,
+                                $subpartArray,
+                                $wrappedSubpartArray,
+                                $row,
+                                $conf,
+                                $itemTable->hasAdditional($row, 'isSingle'),
+                                !$itemTable->hasAdditional($row, 'noGiftService')
+                            );
+                        }
+                        $tempContent = '';
 
-						if ($t['item'] != '') {
-							$tempContent .= $templateService->substituteMarkerArrayCached(
-								$t['item'],
-								$markerArray,
-								$subpartArray,
-								$wrappedSubpartArray
-							);
-						}
-						$itemsOut .= $tempContent;
+                        if ($t['item'] != '') {
+                            $tempContent .= $templateService->substituteMarkerArrayCached(
+                                $t['item'],
+                                $markerArray,
+                                $subpartArray,
+                                $wrappedSubpartArray
+                            );
+                        }
+                        $itemsOut .= $tempContent;
 
-						// max. number of columns reached?
-						if (
-							!$displayColumns ||
-							$iColCount == $displayColumns ||
-							$displayCatHeader == 'always'
-						) {
-							if ($t['itemFrameWork']) {
-								// complete the last table row
-								if (!$displayColumns || $iColCount == $displayColumns) {
-									$itemsOut .= $this->finishHTMLRow($cssConf, $iColCount, $tableRowOpen, $displayColumns);
-								}
+                        // max. number of columns reached?
+                        if (
+                            !$displayColumns ||
+                            $iColCount == $displayColumns ||
+                            $displayCatHeader == 'always'
+                        ) {
+                            if ($t['itemFrameWork']) {
+                                // complete the last table row
+                                if (!$displayColumns || $iColCount == $displayColumns) {
+                                    $itemsOut .= $this->finishHTMLRow($cssConf, $iColCount, $tableRowOpen, $displayColumns);
+                                }
 
-								$markerArray = array_merge($productMarkerArray, $categoryMarkerArray, $markerArray);
-								$subpartArray = [];
+                                $markerArray = array_merge($productMarkerArray, $categoryMarkerArray, $markerArray);
+                                $subpartArray = [];
 
-								if ($bHeaderFieldChanged) {
-									foreach ($headerItemsOutArray as $headerTable => $headerItemsOut) {
-										$marker = $headerTableObjArray['address']->getMarker();
-										$subpartArray['###ITEM_' . $marker . '###'] = $templateService->substituteMarkerArrayCached($headerItemsOut, $markerArray);
-									}
-								}
-								$subpartArray['###ITEM_SINGLE###'] = $itemsOut;
-								$itemListOut .= $templateService->substituteMarkerArrayCached($t['itemFrameWork'], $markerArray, $subpartArray, $wrappedSubpartArray);
-								$itemsOut = '';
-							}
-							$iColCount = 0; // restart in the first column
-						}
-						$nextCat = 0;
-						$nextRow = [];
-						$catArray = [];
-						if (isset($itemArray[$iCount])) {
-							$nextRow = $itemArray[$iCount];
-							if ($useCategories) {
-								$nextCat = $nextRow['category'];
-								$catArray = $categoryTable->getCategoryArray($nextRow);
-							}
-						}
+                                if ($bHeaderFieldChanged) {
+                                    foreach ($headerItemsOutArray as $headerTable => $headerItemsOut) {
+                                        $marker = $headerTableObjArray['address']->getMarker();
+                                        $subpartArray['###ITEM_' . $marker . '###'] = $templateService->substituteMarkerArrayCached($headerItemsOut, $markerArray);
+                                    }
+                                }
+                                $subpartArray['###ITEM_SINGLE###'] = $itemsOut;
+                                $itemListOut .= $templateService->substituteMarkerArrayCached($t['itemFrameWork'], $markerArray, $subpartArray, $wrappedSubpartArray);
+                                $itemsOut = '';
+                            }
+                            $iColCount = 0; // restart in the first column
+                        }
+                        $nextCat = 0;
+                        $nextRow = [];
+                        $catArray = [];
+                        if (isset($itemArray[$iCount])) {
+                            $nextRow = $itemArray[$iCount];
+                            if ($useCategories) {
+                                $nextCat = $nextRow['category'];
+                                $catArray = $categoryTable->getCategoryArray($nextRow);
+                            }
+                        }
 
-						if (is_array($catArray) && count($catArray)) {
-							reset($catArray);
-							$this->getCategories(
-								$categoryTable,
-								$catArray,
-								$rootCatArray,
-								$rootLineArray,
-								$cat,
-								$nextCurrentCat,
-								$nextCat
-							);
-						}
+                        if (is_array($catArray) && count($catArray)) {
+                            reset($catArray);
+                            $this->getCategories(
+                                $categoryTable,
+                                $catArray,
+                                $rootCatArray,
+                                $rootLineArray,
+                                $cat,
+                                $nextCurrentCat,
+                                $nextCat
+                            );
+                        }
 
                         if (empty($nextRow)) {
                             $nextArray['category'] = 0;
@@ -3028,285 +3028,285 @@ class tx_ttproducts_list_view implements \TYPO3\CMS\Core\SingletonInterface {
                             }
                         }
 
-						// multiple columns display and ITEM_SINGLE_POST_HTML is in the item's template?
-						if (
-							$displayCatHeader != 'always' && $displayCatHeader != 'current' && (
-								(
-									$nextArray['category'] != $currentArray['category'] &&
-									$itemsOut &&
-									$t['categoryFrameWork']
-								) ||
-								(
-									$nextArray['product'] != $currentArray['product'] &&
-									$itemTable->getType() != 'product' &&
-									$t['productAndItemsFrameWork']
-								)
-							) ||
-							$nextRow == ''
-						) {
-							if ($bItemPostHtml && (
-								$nextArray['category']  !=  $currentArray['category'] && $itemsOut && $t['categoryFrameWork'] || // && $t['categoryFrameWork'] != ''
-								$nextArray['product']   !=  $currentArray['product']  && $itemTable->getType() == 'article' && $t['productAndItemsFrameWork']) ) {
-								// complete the last table row
-								$itemsOut .=
-									$this->finishHTMLRow(
-										$cssConf,
-										$iColCount,
-										$tableRowOpen,
-										$displayColumns
-									);
-							}
+                        // multiple columns display and ITEM_SINGLE_POST_HTML is in the item's template?
+                        if (
+                            $displayCatHeader != 'always' && $displayCatHeader != 'current' && (
+                                (
+                                    $nextArray['category'] != $currentArray['category'] &&
+                                    $itemsOut &&
+                                    $t['categoryFrameWork']
+                                ) ||
+                                (
+                                    $nextArray['product'] != $currentArray['product'] &&
+                                    $itemTable->getType() != 'product' &&
+                                    $t['productAndItemsFrameWork']
+                                )
+                            ) ||
+                            $nextRow == ''
+                        ) {
+                            if ($bItemPostHtml && (
+                                $nextArray['category']  !=  $currentArray['category'] && $itemsOut && $t['categoryFrameWork'] || // && $t['categoryFrameWork'] != ''
+                                $nextArray['product']   !=  $currentArray['product']  && $itemTable->getType() == 'article' && $t['productAndItemsFrameWork']) ) {
+                                // complete the last table row
+                                $itemsOut .=
+                                    $this->finishHTMLRow(
+                                        $cssConf,
+                                        $iColCount,
+                                        $tableRowOpen,
+                                        $displayColumns
+                                    );
+                            }
 
-							if (
-								(
-									$nextArray['category'] != $currentArray['category'] && $t['categoryFrameWork'] ||
-									$nextRow == ''
-								) &&
-								$itemsOut &&
-								$t['itemFrameWork']
-							) {
-								$subpartArray = [];
-								$subpartArray['###ITEM_SINGLE###'] = $itemsOut;
+                            if (
+                                (
+                                    $nextArray['category'] != $currentArray['category'] && $t['categoryFrameWork'] ||
+                                    $nextRow == ''
+                                ) &&
+                                $itemsOut &&
+                                $t['itemFrameWork']
+                            ) {
+                                $subpartArray = [];
+                                $subpartArray['###ITEM_SINGLE###'] = $itemsOut;
 
-								$itemListNewOut = $templateService->substituteMarkerArrayCached(
-									$t['itemFrameWork'],
-									$markerArray,
-									$subpartArray,
-									$wrappedSubpartArray
-								);
-								$itemListOut .= $itemListNewOut;
-								$itemsOut = '';
-							}
-						}
-					}	// foreach ($itemArray as $k1 => $productList) {
-				} else {
-					if (isset($catTableConf['subpart.'])) {
-						$displayCat = $cat;
-						$tmp = [];
-						$categoryTableView->getMarkerArray(
-							$categoryMarkerArray,
-							$displayCat,
-							$GLOBALS['TSFE']->id,
-							$config['limitImage'],
-							'listcatImage',
-							$viewCatTagArray,
-							$tmp,
-							$pageAsCategory,
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							$iCount,
-							'',
-							''
-						);
+                                $itemListNewOut = $templateService->substituteMarkerArrayCached(
+                                    $t['itemFrameWork'],
+                                    $markerArray,
+                                    $subpartArray,
+                                    $wrappedSubpartArray
+                                );
+                                $itemListOut .= $itemListNewOut;
+                                $itemsOut = '';
+                            }
+                        }
+                    }	// foreach ($itemArray as $k1 => $productList) {
+                } else {
+                    if (isset($catTableConf['subpart.'])) {
+                        $displayCat = $cat;
+                        $tmp = [];
+                        $categoryTableView->getMarkerArray(
+                            $categoryMarkerArray,
+                            $displayCat,
+                            $GLOBALS['TSFE']->id,
+                            $config['limitImage'],
+                            'listcatImage',
+                            $viewCatTagArray,
+                            $tmp,
+                            $pageAsCategory,
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            $iCount,
+                            '',
+                            ''
+                        );
 
-						foreach($catTableConf['subpart.'] as $subpart => $subpartConfig) {
+                        foreach($catTableConf['subpart.'] as $subpart => $subpartConfig) {
 
-							if (
-								is_array($subpartConfig) &&
-								$subpartConfig['show'] == 'default'
-							)	{
-								if (
-									$subpart == 'ITEM_CATEGORY.' &&
-									$t['categoryFrameWork']
-								)	{
-									$catTitle = $categoryTableView->getMarkerArrayCatTitle($categoryMarkerArray);
-									$categoryOut = $templateService->substituteMarkerArray($t['categoryFrameWork'], $categoryMarkerArray);
-								}
+                            if (
+                                is_array($subpartConfig) &&
+                                $subpartConfig['show'] == 'default'
+                            )	{
+                                if (
+                                    $subpart == 'ITEM_CATEGORY.' &&
+                                    $t['categoryFrameWork']
+                                )	{
+                                    $catTitle = $categoryTableView->getMarkerArrayCatTitle($categoryMarkerArray);
+                                    $categoryOut = $templateService->substituteMarkerArray($t['categoryFrameWork'], $categoryMarkerArray);
+                                }
 
-								if (
-									$subpart == 'ITEM_LIST.' &&
-									$t['itemFrameWork']
-								) {
-									$markerArray = $categoryMarkerArray;
-									$subpartArray = [];
-									$markerArray['###ITEM_SINGLE_PRE_HTML###'] = '';
-									$markerArray['###ITEM_SINGLE_POST_HTML###'] = '';
-									$subpartArray['###ITEM_SINGLE###'] = '';
-									$itemListOut =
-										$templateService->substituteMarkerArrayCached(
-											$t['itemFrameWork'],
-											$categoryMarkerArray,
-											$subpartArray,
-											$wrappedSubpartArray
-										);
-								}
-							}
-						}
-					} else {
-						// keine Produkte gefunden
-					}
-				}
+                                if (
+                                    $subpart == 'ITEM_LIST.' &&
+                                    $t['itemFrameWork']
+                                ) {
+                                    $markerArray = $categoryMarkerArray;
+                                    $subpartArray = [];
+                                    $markerArray['###ITEM_SINGLE_PRE_HTML###'] = '';
+                                    $markerArray['###ITEM_SINGLE_POST_HTML###'] = '';
+                                    $subpartArray['###ITEM_SINGLE###'] = '';
+                                    $itemListOut =
+                                        $templateService->substituteMarkerArrayCached(
+                                            $t['itemFrameWork'],
+                                            $categoryMarkerArray,
+                                            $subpartArray,
+                                            $wrappedSubpartArray
+                                        );
+                                }
+                            }
+                        }
+                    } else {
+                        // keine Produkte gefunden
+                    }
+                }
 
-				if ($itemListOut || $categoryOut || $productListOut) {
-					$catItemsListOut = $itemListOut;
-					if ($itemTable->getType() == 'article' && $productListOut && $t['productAndItemsFrameWork']) {
-						$productListOut .=
-							$this->advanceProduct(
-								$t['productAndItemsFrameWork'],
-								$t['productFrameWork'],
-								$itemListOut,
-								$productMarkerArray,
-								$categoryMarkerArray
-							);
-						$catItemsListOut = $productListOut;
-					}
-					if ($conf['displayListCatHeader']) {
-						$out .=
-							$this->advanceCategory(
-								$t['categoryAndItemsFrameWork'],
-								$catItemsListOut,
-								$categoryOut,
-								$itemListSubpart,
-								$oldFormCount,
-								$formCount
-							);
-					} else {
-						$out .= $itemListOut;
-					}
-				}
-			}	// if ($theCode != 'SEARCH' || ($theCode == 'SEARCH' && $sword))	{
-		} // if ($t['categoryAndItemsFrameWork'] != '') {
+                if ($itemListOut || $categoryOut || $productListOut) {
+                    $catItemsListOut = $itemListOut;
+                    if ($itemTable->getType() == 'article' && $productListOut && $t['productAndItemsFrameWork']) {
+                        $productListOut .=
+                            $this->advanceProduct(
+                                $t['productAndItemsFrameWork'],
+                                $t['productFrameWork'],
+                                $itemListOut,
+                                $productMarkerArray,
+                                $categoryMarkerArray
+                            );
+                        $catItemsListOut = $productListOut;
+                    }
+                    if ($conf['displayListCatHeader']) {
+                        $out .=
+                            $this->advanceCategory(
+                                $t['categoryAndItemsFrameWork'],
+                                $catItemsListOut,
+                                $categoryOut,
+                                $itemListSubpart,
+                                $oldFormCount,
+                                $formCount
+                            );
+                    } else {
+                        $out .= $itemListOut;
+                    }
+                }
+            }	// if ($theCode != 'SEARCH' || ($theCode == 'SEARCH' && $sword))	{
+        } // if ($t['categoryAndItemsFrameWork'] != '') {
 
-		$contentEmpty = '';
+        $contentEmpty = '';
 
-		if ($t['categoryAndItemsFrameWork'] == '') {
-			// nothing is shown
-		} else if (count($itemArray)) {
+        if ($t['categoryAndItemsFrameWork'] == '') {
+            // nothing is shown
+        } else if (count($itemArray)) {
 
-			// next / prev:
-			// $url = $this->getLinkUrl('','begin_at');
-				// Reset:
-			$subpartArray= [];
-			$wrappedSubpartArray= [];
-			$markerArray=$globalMarkerArray;
-			$splitMark = md5(microtime());
-			$addQueryString= [];
-			$addQueryString['addmemo'] = '';
-			$addQueryString['delmemo'] = '';
+            // next / prev:
+            // $url = $this->getLinkUrl('','begin_at');
+                // Reset:
+            $subpartArray= [];
+            $wrappedSubpartArray= [];
+            $markerArray=$globalMarkerArray;
+            $splitMark = md5(microtime());
+            $addQueryString= [];
+            $addQueryString['addmemo'] = '';
+            $addQueryString['delmemo'] = '';
 
-			if ($sword) {
-				$addQueryString['sword'] = $sword;
-			}
-			$bUseCache = $bUseCache && (count($basketObj->itemArray) == 0);
+            if ($sword) {
+                $addQueryString['sword'] = $sword;
+            }
+            $bUseCache = $bUseCache && (count($basketObj->itemArray) == 0);
 
-			$this->getBrowserMarkers(
-				$browseObj,
-				$browserConf,
-				$t,
-				$addQueryString,
-				$productsCount,
-				$more,
-				$limit,
-				$begin_at,
-				$bUseCache,
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
-			$subpartArray['###ITEM_CATEGORY_AND_ITEMS###'] = $out;
-			$addQueryString = [];
-			$addQueryString = $this->uidArray;
-			$excludeList = ($theCode == 'SEARCH' ? 'sword' : '');
-			$this->getSearchParams($addQueryString);
-			$markerArray =
-				$urlObj->addURLMarkers(
-					$this->pid,
-					$markerArray,
-					$addQueryString,
-					$excludeList,
-					$useBackPid,
-					$backPid
-				); // clickIntoBasket
+            $this->getBrowserMarkers(
+                $browseObj,
+                $browserConf,
+                $t,
+                $addQueryString,
+                $productsCount,
+                $more,
+                $limit,
+                $begin_at,
+                $bUseCache,
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
+            $subpartArray['###ITEM_CATEGORY_AND_ITEMS###'] = $out;
+            $addQueryString = [];
+            $addQueryString = $this->uidArray;
+            $excludeList = ($theCode == 'SEARCH' ? 'sword' : '');
+            $this->getSearchParams($addQueryString);
+            $markerArray =
+                $urlObj->addURLMarkers(
+                    $this->pid,
+                    $markerArray,
+                    $addQueryString,
+                    $excludeList,
+                    $useBackPid,
+                    $backPid
+                ); // clickIntoBasket
 
-			$markerArray['###AMOUNT_CREDITPOINTS###'] = number_format($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] ?? 0, 0);
-			$markerArray['###ITEMS_SELECT_COUNT###'] = $productsCount;
-			$javaScriptMarker->getMarkerArray($jsMarkerArray, $markerArray, $cObj);
-			$markerArray = array_merge($jsMarkerArray, $markerArray);
+            $markerArray['###AMOUNT_CREDITPOINTS###'] = number_format($GLOBALS['TSFE']->fe_user->user['tt_products_creditpoints'] ?? 0, 0);
+            $markerArray['###ITEMS_SELECT_COUNT###'] = $productsCount;
+            $javaScriptMarker->getMarkerArray($jsMarkerArray, $markerArray, $cObj);
+            $markerArray = array_merge($jsMarkerArray, $markerArray);
 
-			if ($calllevel == 0) {
-				$hiddenCount = 0;
-				if ($itemTable->getType() == 'dam') {
-					$hiddenFields .= '<input type="hidden" name="' . $prefixId . '[type][' . $hiddenCount . ']" value="product" />';
-					$hiddenCount++;
-				}
-				$hiddenFields .= '<input type="hidden" name="' . $prefixId . '[type][' . $hiddenCount . ']" value="' . $itemTable->getType() . '" />';
-			}
+            if ($calllevel == 0) {
+                $hiddenCount = 0;
+                if ($itemTable->getType() == 'dam') {
+                    $hiddenFields .= '<input type="hidden" name="' . $prefixId . '[type][' . $hiddenCount . ']" value="product" />';
+                    $hiddenCount++;
+                }
+                $hiddenFields .= '<input type="hidden" name="' . $prefixId . '[type][' . $hiddenCount . ']" value="' . $itemTable->getType() . '" />';
+            }
 
-			$markerArray['###HIDDENFIELDS###'] = $hiddenFields; // TODO
+            $markerArray['###HIDDENFIELDS###'] = $hiddenFields; // TODO
 
-			if (isset($memoViewObj) && is_object($memoViewObj)) {
-				$memoViewObj->getHiddenFields($uidArray, $markerArray, $bUseCheckBox);
-			}
+            if (isset($memoViewObj) && is_object($memoViewObj)) {
+                $memoViewObj->getHiddenFields($uidArray, $markerArray, $bUseCheckBox);
+            }
 
-			$out = $templateService->substituteMarkerArrayCached(
-				$t['listFrameWork'],
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
-			$content .= $out;
-		} else if ($theCode == 'SEARCH') {
-			if ($conf['listViewOnSearch'] == '1' && $sword && $allowedItems != '0') {
-				$templateArea = 'ITEM_SEARCH_EMPTY';
+            $out = $templateService->substituteMarkerArrayCached(
+                $t['listFrameWork'],
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
+            $content .= $out;
+        } else if ($theCode == 'SEARCH') {
+            if ($conf['listViewOnSearch'] == '1' && $sword && $allowedItems != '0') {
+                $templateArea = 'ITEM_SEARCH_EMPTY';
 
-				$contentEmpty =
-					$subpartmarkerObj->getSubpart(
-						$templateCode,
-						$subpartmarkerObj->spMarker('###' . $templateArea . '###'), $error_code
-					);
+                $contentEmpty =
+                    $subpartmarkerObj->getSubpart(
+                        $templateCode,
+                        $subpartmarkerObj->spMarker('###' . $templateArea . '###'), $error_code
+                    );
 
-			} else {
-				// nothing is shown
-			}
-		} else if ($out) {
-			$content .= $out;
-		} else if ($whereCat != '' || $allowedItems != '0' || !$bListStartEmpty) {
-			$subpartArray = [];
-			$subpartArray['###ITEM_CATEGORY_AND_ITEMS###'] = '';
-			$subpartArray['###LINK_PREV###'] = '';
-			$subpartArray['###LINK_NEXT###'] = '';
+            } else {
+                // nothing is shown
+            }
+        } else if ($out) {
+            $content .= $out;
+        } else if ($whereCat != '' || $allowedItems != '0' || !$bListStartEmpty) {
+            $subpartArray = [];
+            $subpartArray['###ITEM_CATEGORY_AND_ITEMS###'] = '';
+            $subpartArray['###LINK_PREV###'] = '';
+            $subpartArray['###LINK_NEXT###'] = '';
             $subpartArray['###LINK_BROWSE###'] = '';
 
-			$markerArray['###BROWSE_LINKS###'] = '';
+            $markerArray['###BROWSE_LINKS###'] = '';
 
-			$out =
-				$templateService->substituteMarkerArrayCached(
-					$t['listFrameWork'],
-					$markerArray,
-					$subpartArray
-				);
-			$content .= $out;
-			$contentEmpty =
-				$subpartmarkerObj->getSubpart(
-					$templateCode,
-					$subpartmarkerObj->spMarker('###ITEM_LIST_EMPTY###'),
-					$error_code
-				);
-		} else {
-			// nothing is shown
-		} // if (count ($itemArray))
+            $out =
+                $templateService->substituteMarkerArrayCached(
+                    $t['listFrameWork'],
+                    $markerArray,
+                    $subpartArray
+                );
+            $content .= $out;
+            $contentEmpty =
+                $subpartmarkerObj->getSubpart(
+                    $templateCode,
+                    $subpartmarkerObj->spMarker('###ITEM_LIST_EMPTY###'),
+                    $error_code
+                );
+        } else {
+            // nothing is shown
+        } // if (count ($itemArray))
 
-		if ($bCheckUnusedArticleMarkers) {
-			$markerFieldArray = [];
-			$articleViewTagArray = [];
-			$articleParentArray = [];
-			$articleViewObj = $tablesObj->get('tt_products_articles', true);
+        if ($bCheckUnusedArticleMarkers) {
+            $markerFieldArray = [];
+            $articleViewTagArray = [];
+            $articleParentArray = [];
+            $articleViewObj = $tablesObj->get('tt_products_articles', true);
 
-			$searchString = '###' . $articleViewObj->getMarker() . '_';
-			if (strpos($t['item'], $searchString) > 0) {
-				$error_code[0] = 'article_markers_unsubstituted';
-				$error_code[1] = '###' . $articleViewObj->getMarker() . '_...###';
-				$error_code[2] = $useArticles;
-			}
-		}
+            $searchString = '###' . $articleViewObj->getMarker() . '_';
+            if (strpos($t['item'], $searchString) > 0) {
+                $error_code[0] = 'article_markers_unsubstituted';
+                $error_code[1] = '###' . $articleViewObj->getMarker() . '_...###';
+                $error_code[2] = $useArticles;
+            }
+        }
 
-		if ($contentEmpty != '') {
-			$contentEmpty = $templateService->substituteMarkerArray($contentEmpty, $globalMarkerArray);
-		}
-		$content .= $contentEmpty;
+        if ($contentEmpty != '') {
+            $contentEmpty = $templateService->substituteMarkerArray($contentEmpty, $globalMarkerArray);
+        }
+        $content .= $contentEmpty;
 
-		return $content;
-	}
+        return $content;
+    }
 }
 

--- a/view/class.tx_ttproducts_memo_view.php
+++ b/view/class.tx_ttproducts_memo_view.php
@@ -42,169 +42,169 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_memo_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pid_list;
-	public $pid; // pid where to go
-	public $useArticles;
-	public $memoItems;
+    public $pid_list;
+    public $pid; // pid where to go
+    public $useArticles;
+    public $memoItems;
 
 
-	public function init (
-			$theCode,
-			$pid_list,
-			$conf,
-			$useArticles
-		) {
-		$cObj = FrontendUtility::getContentObjectRenderer();
+    public function init (
+            $theCode,
+            $pid_list,
+            $conf,
+            $useArticles
+        ) {
+        $cObj = FrontendUtility::getContentObjectRenderer();
 
-		$this->pid_list = $pid_list;
-		$this->useArticles = $useArticles;
+        $this->pid_list = $pid_list;
+        $this->useArticles = $useArticles;
 // 		$fe_user_uid = $GLOBALS['TSFE']->fe_user->user['uid'];
 
-		$this->memoItems = [];
+        $this->memoItems = [];
 
-		if (
-			tx_ttproducts_control_memo::bUseFeuser($conf) ||
-			tx_ttproducts_control_memo::bUseSession($conf)
-		) {
-			$functablename = 'tt_products';
-			if (strpos($theCode, 'DAM') !== false) {
-				$functablename = 'tx_dam';
-			}
-			$this->memoItems = tx_ttproducts_control_memo::getMemoItems($functablename);
-		}
-	}
+        if (
+            tx_ttproducts_control_memo::bUseFeuser($conf) ||
+            tx_ttproducts_control_memo::bUseSession($conf)
+        ) {
+            $functablename = 'tt_products';
+            if (strpos($theCode, 'DAM') !== false) {
+                $functablename = 'tx_dam';
+            }
+            $this->memoItems = tx_ttproducts_control_memo::getMemoItems($functablename);
+        }
+    }
 
 
-	/**
-	 * Displays the memo
-	 */
-	public function printView (
-		$templateCode,
-		$theCode,
-		$conf,
-		$pid,
-		&$errorCode
-	) {
+    /**
+     * Displays the memo
+     */
+    public function printView (
+        $templateCode,
+        $theCode,
+        $conf,
+        $pid,
+        &$errorCode
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$content = '';
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$config = $cnf->getConfig();
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $content = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $config = $cnf->getConfig();
 
-		if (
-			tx_ttproducts_control_memo::bUseFeuser($conf) ||
-			tx_ttproducts_control_memo::bUseSession($conf)
-		) {
-			if ($this->memoItems) {
+        if (
+            tx_ttproducts_control_memo::bUseFeuser($conf) ||
+            tx_ttproducts_control_memo::bUseSession($conf)
+        ) {
+            if ($this->memoItems) {
 
-				// List all products:
-				$listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
-				$listView->init(
-					$pid,
-					[],
-					$this->pid_list,
-					99
-				);
-				if ($theCode == 'MEMO') {
-					$theTable = 'tt_products';
-					$templateArea = 'MEMO_TEMPLATE';
-				} else if ($theCode == 'MEMODAM') {
-					$theTable = 'tx_dam';
-					$templateArea = 'MEMODAM_TEMPLATE';
-				} else if ($theCode == 'MEMODAMOVERVIEW') {
-					$theTable = 'tx_dam';
-					$templateArea = 'MEMODAM_OVERVIEW_TEMPLATE';
-				} else {
-					return 'error';
-				}
+                // List all products:
+                $listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
+                $listView->init(
+                    $pid,
+                    [],
+                    $this->pid_list,
+                    99
+                );
+                if ($theCode == 'MEMO') {
+                    $theTable = 'tt_products';
+                    $templateArea = 'MEMO_TEMPLATE';
+                } else if ($theCode == 'MEMODAM') {
+                    $theTable = 'tx_dam';
+                    $templateArea = 'MEMODAM_TEMPLATE';
+                } else if ($theCode == 'MEMODAMOVERVIEW') {
+                    $theTable = 'tx_dam';
+                    $templateArea = 'MEMODAM_OVERVIEW_TEMPLATE';
+                } else {
+                    return 'error';
+                }
 
-				$content = $listView->printView(
-					$templateCode,
-					$theCode,
-					$theTable,
-					($this->memoItems ? implode(',', $this->memoItems) : []),
-					false,
-					'',
-					$errorCode,
-					$templateArea,
-					$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
-					tx_ttproducts_control_basket::getBasketExtra(),
-					tx_ttproducts_control_basket::getRecs(),
-					[],
-					0
-				);
-			} else {
-				$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-				$cObj = FrontendUtility::getContentObjectRenderer();
+                $content = $listView->printView(
+                    $templateCode,
+                    $theCode,
+                    $theTable,
+                    ($this->memoItems ? implode(',', $this->memoItems) : []),
+                    false,
+                    '',
+                    $errorCode,
+                    $templateArea,
+                    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'],
+                    tx_ttproducts_control_basket::getBasketExtra(),
+                    tx_ttproducts_control_basket::getRecs(),
+                    [],
+                    0
+                );
+            } else {
+                $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+                $cObj = FrontendUtility::getContentObjectRenderer();
 
-				$templateArea = 'MEMO_EMPTY';
-				$content = $templateService->getSubpart($templateCode,$subpartmarkerObj->spMarker('###'.$templateArea.'###'));
-				$content = $markerObj->replaceGlobalMarkers($content);
-			}
-		} else if (tx_ttproducts_control_memo::bIsAllowed('fe_users', $conf)) {
-			$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+                $templateArea = 'MEMO_EMPTY';
+                $content = $templateService->getSubpart($templateCode,$subpartmarkerObj->spMarker('###'.$templateArea.'###'));
+                $content = $markerObj->replaceGlobalMarkers($content);
+            }
+        } else if (tx_ttproducts_control_memo::bIsAllowed('fe_users', $conf)) {
+            $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
 
-			$templateArea = 'MEMO_NOT_LOGGED_IN';
+            $templateArea = 'MEMO_NOT_LOGGED_IN';
 // 			$templateAreaMarker = $subpartmarkerObj->spMarker('###'.$templateArea.'###');
 
-			$content = tx_ttproducts_api::getErrorOut(
-				$theCode,
-				$templateCode,
-				$subpartmarkerObj->spMarker('###' . $templateArea . $config['templateSuffix'] . '###'),
-				$subpartmarkerObj->spMarker('###' . $templateArea . '###'),
-				$errorCode
-			) ;
+            $content = tx_ttproducts_api::getErrorOut(
+                $theCode,
+                $templateCode,
+                $subpartmarkerObj->spMarker('###' . $templateArea . $config['templateSuffix'] . '###'),
+                $subpartmarkerObj->spMarker('###' . $templateArea . '###'),
+                $errorCode
+            ) ;
 
-			$content = $markerObj->replaceGlobalMarkers($content);
-		}
+            $content = $markerObj->replaceGlobalMarkers($content);
+        }
 
-		if (!$content && empty($errorCode)) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$errorCode[0] = 'no_subtemplate';
-			$errorCode[1] = '###' . $templateArea . $templateObj->getTemplateSuffix() . '###';
-			$errorCode[2] = $templateObj->getTemplateFile();
-			$content = false;
-		}
-		return $content;
-	}
-
-
-	public function getFieldMarkerArray (
-		$row,
-		$markerKey,
-		&$markerArray,
-		$tagArray,
-		&$bUseCheckBox
-	)	{
-		$fieldKey = 'FIELD_' . $markerKey . '_NAME';
-		if (isset($tagArray[$fieldKey])) {
-			$markerArray['###'.$fieldKey.'###'] = tx_ttproducts_model_control::getPrefixId() . '[memo][' . $row['uid'] . ']';
-		}
-		$fieldKey = 'FIELD_'.$markerKey.'_CHECK';
-
-		if (isset($tagArray[$fieldKey])) {
-			$bUseCheckBox = true;
-			if (in_array($row['uid'], $this->memoItems)) {
-				$value = 1;
-			} else {
-				$value = 0;
-			}
-			$checkString = ($value ? 'checked="checked"':'');
-			$markerArray['###'.$fieldKey.'###'] = $checkString;
-		} else {
-			$bUseCheckBox = false;
-		}
-	}
+        if (!$content && empty($errorCode)) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $errorCode[0] = 'no_subtemplate';
+            $errorCode[1] = '###' . $templateArea . $templateObj->getTemplateSuffix() . '###';
+            $errorCode[2] = $templateObj->getTemplateFile();
+            $content = false;
+        }
+        return $content;
+    }
 
 
-	public function getHiddenFields (
-		$uidArray,
-		&$markerArray,
-		$bUseCheckBox
-	) {
-		if ($bUseCheckBox) {
-			$markerArray['###HIDDENFIELDS###'] .= '<input type="hidden" name="' . tx_ttproducts_model_control::getPrefixId() . '[memo][uids]" value="' . implode(',',$uidArray) . '" />';
-		}
-	}
+    public function getFieldMarkerArray (
+        $row,
+        $markerKey,
+        &$markerArray,
+        $tagArray,
+        &$bUseCheckBox
+    )	{
+        $fieldKey = 'FIELD_' . $markerKey . '_NAME';
+        if (isset($tagArray[$fieldKey])) {
+            $markerArray['###'.$fieldKey.'###'] = tx_ttproducts_model_control::getPrefixId() . '[memo][' . $row['uid'] . ']';
+        }
+        $fieldKey = 'FIELD_'.$markerKey.'_CHECK';
+
+        if (isset($tagArray[$fieldKey])) {
+            $bUseCheckBox = true;
+            if (in_array($row['uid'], $this->memoItems)) {
+                $value = 1;
+            } else {
+                $value = 0;
+            }
+            $checkString = ($value ? 'checked="checked"':'');
+            $markerArray['###'.$fieldKey.'###'] = $checkString;
+        } else {
+            $bUseCheckBox = false;
+        }
+    }
+
+
+    public function getHiddenFields (
+        $uidArray,
+        &$markerArray,
+        $bUseCheckBox
+    ) {
+        if ($bUseCheckBox) {
+            $markerArray['###HIDDENFIELDS###'] .= '<input type="hidden" name="' . tx_ttproducts_model_control::getPrefixId() . '[memo][uids]" value="' . implode(',',$uidArray) . '" />';
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_menucat_view.php
+++ b/view/class.tx_ttproducts_menucat_view.php
@@ -42,268 +42,268 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_menucat_view extends tx_ttproducts_catlist_view_base {
-	protected $htmlTagMain = 'ul';	// main HTML tag
-	protected $htmlTagElement = 'li'; // HTML tag element
+    protected $htmlTagMain = 'ul';	// main HTML tag
+    protected $htmlTagElement = 'li'; // HTML tag element
 
-	// returns the products list view
-	public function printView (
-		$functablename,
-		&$templateCode,
-		$theCode,
-		&$error_code,
-		$templateArea = 'ITEM_CATLIST_TEMPLATE',
-		$pageAsCategory,
-		$templateSuffix = '',
-		$basketExtra,
-		$basketRecs
-	) {
-		$t = [];
-		$ctrlArray = [];
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
-		$javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
-		$cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
+    // returns the products list view
+    public function printView (
+        $functablename,
+        &$templateCode,
+        $theCode,
+        &$error_code,
+        $templateArea = 'ITEM_CATLIST_TEMPLATE',
+        $pageAsCategory,
+        $templateSuffix = '',
+        $basketExtra,
+        $basketRecs
+    ) {
+        $t = [];
+        $ctrlArray = [];
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $pibaseObj = GeneralUtility::makeInstance('' . $this->pibaseClass);
+        $javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
+        $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
 
-		parent::getPrintViewArrays(
-			$functablename,
-			$templateCode,
-			$t,
-			$htmlParts,
-			$theCode,
-			$error_code,
-			$templateArea,
-			$pageAsCategory,
-			$templateSuffix,
-			$basketExtra,
-			$basketRecs,
-			$currentCat,
-			$categoryArray,
-			$catArray,
-			$activeRootline,
-			$rootpathArray,
-			$subCategoryMarkers,
-			$ctrlArray
-		);
+        parent::getPrintViewArrays(
+            $functablename,
+            $templateCode,
+            $t,
+            $htmlParts,
+            $theCode,
+            $error_code,
+            $templateArea,
+            $pageAsCategory,
+            $templateSuffix,
+            $basketExtra,
+            $basketRecs,
+            $currentCat,
+            $categoryArray,
+            $catArray,
+            $activeRootline,
+            $rootpathArray,
+            $subCategoryMarkers,
+            $ctrlArray
+        );
 
-		if (empty($error_code)) {
-			$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        if (empty($error_code)) {
+            $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-			$categoryTableView = $tablesObj->get($functablename, true);
-			$categoryTable = $categoryTableView->getModelObj();
-			$maxDepth = $categoryTable->getDepth($theCode);
+            $categoryTableView = $tablesObj->get($functablename, true);
+            $categoryTable = $categoryTableView->getModelObj();
+            $maxDepth = $categoryTable->getDepth($theCode);
 
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
             $conf = $cnf->getConf();
             $config = $cnf->getConfig();
 
-			$content='';
-			$out='';
-			$where='';
-			$bFinished = false;
-			$iCount = 0;
-			$mainCount = 1;
-			$depth = 1;
-			$countArray = [];
-			$countArray[0] = 0;
-			$countArray[1] = 0;
-			$tabArray = [];
-			$catConf = $categoryTable->getTableConf($theCode);
+            $content='';
+            $out='';
+            $where='';
+            $bFinished = false;
+            $iCount = 0;
+            $mainCount = 1;
+            $depth = 1;
+            $countArray = [];
+            $countArray[0] = 0;
+            $countArray[1] = 0;
+            $tabArray = [];
+            $catConf = $categoryTable->getTableConf($theCode);
             $catConf['cssMode'] = $catConf['cssMode'] ?? 0;
 
-			$cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
-			$cssConf = $cssObj->getConf($functablename, $theCode);
-			$fill = '';
-			$menu = 'm' . $depth;
-			$idMain = $categoryTableView->getPivar() . $mainCount;
-			$tabArray[$depth] = $this->getTabs($depth * 2);
-			$parentArray = [];
-			$viewCatTagArray = [];
-			$tmp = [];
-			$catfieldsArray = $markerObj->getMarkerFields(
-				$t['linkCategoryFrameWork'],
-				$categoryTable->getTableObj()->tableFieldArray,
-				$categoryTable->getTableObj()->requiredFieldArray,
-				$tmp,
-				$categoryTableView->getMarker(),
-				$viewCatTagArray,
-				$parentArray
-			);
+            $cssObj = GeneralUtility::makeInstance('tx_ttproducts_css');
+            $cssConf = $cssObj->getConf($functablename, $theCode);
+            $fill = '';
+            $menu = 'm' . $depth;
+            $idMain = $categoryTableView->getPivar() . $mainCount;
+            $tabArray[$depth] = $this->getTabs($depth * 2);
+            $parentArray = [];
+            $viewCatTagArray = [];
+            $tmp = [];
+            $catfieldsArray = $markerObj->getMarkerFields(
+                $t['linkCategoryFrameWork'],
+                $categoryTable->getTableObj()->tableFieldArray,
+                $categoryTable->getTableObj()->requiredFieldArray,
+                $tmp,
+                $categoryTableView->getMarker(),
+                $viewCatTagArray,
+                $parentArray
+            );
 
-			$out = chr(13) . $tabArray[$depth] . '<' . $this->htmlTagMain . ' id="' . $idMain . '"' . '  class="' . $menu . '" ' . $fill . '>' . chr(13);
-			$out = str_replace($this->htmlPartsMarkers[0], $out, $htmlParts[0]);
+            $out = chr(13) . $tabArray[$depth] . '<' . $this->htmlTagMain . ' id="' . $idMain . '"' . '  class="' . $menu . '" ' . $fill . '>' . chr(13);
+            $out = str_replace($this->htmlPartsMarkers[0], $out, $htmlParts[0]);
 
-			while ($depth > 0 && $iCount < 500) {
-				$iCount++;
-				$cssClassArray = ['w' . $iCount];
+            while ($depth > 0 && $iCount < 500) {
+                $iCount++;
+                $cssClassArray = ['w' . $iCount];
 
-				if (
+                if (
                     !isset($catArray[$depth]) ||
                     !is_array($catArray[$depth])
                 ) {
                     continue;
                 }
 
-				if($countArray[$depth] < count($catArray[$depth])) {
-					$markerArray = [];
-					$actCategory = $catArray[$depth][$countArray[$depth]];
-					$row = $categoryArray[$actCategory];
-					$subCategories = $row['child_category'] ?? [];
+                if($countArray[$depth] < count($catArray[$depth])) {
+                    $markerArray = [];
+                    $actCategory = $catArray[$depth][$countArray[$depth]];
+                    $row = $categoryArray[$actCategory];
+                    $subCategories = $row['child_category'] ?? [];
 
-					if ($catConf['cssMode'] == '1' && isset($subCategories) && is_array($subCategories) && count($subCategories)) {
-						$cssClassArray[] = 'parent';
-					}
-					$countArray[$depth]++;
-					$isNormal = true;
-					if ($actCategory == $currentCat) {
-						$cssClassArray[] = 'cur';
-						$isNormal = false;
-					}
+                    if ($catConf['cssMode'] == '1' && isset($subCategories) && is_array($subCategories) && count($subCategories)) {
+                        $cssClassArray[] = 'parent';
+                    }
+                    $countArray[$depth]++;
+                    $isNormal = true;
+                    if ($actCategory == $currentCat) {
+                        $cssClassArray[] = 'cur';
+                        $isNormal = false;
+                    }
 
-					if ($catConf['cssMode'] == '1' && isset($rootpathArray) && is_array($rootpathArray)) {
-						foreach ($rootpathArray as $lineRow) {
-							if ($actCategory == $lineRow['uid']) {
-								$cssClassArray[] = 'act';
-								$isNormal = false;
-							}
-						}
-					}
-					if ($catConf['cssMode'] == '1' && $isNormal) {
-						$cssClassArray[] = 'no';
-					}
-					$css = 'class="' . implode(' ', $cssClassArray) . '"';
+                    if ($catConf['cssMode'] == '1' && isset($rootpathArray) && is_array($rootpathArray)) {
+                        foreach ($rootpathArray as $lineRow) {
+                            if ($actCategory == $lineRow['uid']) {
+                                $cssClassArray[] = 'act';
+                                $isNormal = false;
+                            }
+                        }
+                    }
+                    if ($catConf['cssMode'] == '1' && $isNormal) {
+                        $cssClassArray[] = 'no';
+                    }
+                    $css = 'class="' . implode(' ', $cssClassArray) . '"';
 
-					$preOut = $tabArray[$depth] . chr(9) . '<' . $this->htmlTagElement . ($css ? ' ' . $css : '') . ' value="' . $actCategory . '">' . chr(13);
-					$out .= str_replace($this->htmlPartsMarkers[0], $preOut, $htmlParts[0]);
+                    $preOut = $tabArray[$depth] . chr(9) . '<' . $this->htmlTagElement . ($css ? ' ' . $css : '') . ' value="' . $actCategory . '">' . chr(13);
+                    $out .= str_replace($this->htmlPartsMarkers[0], $preOut, $htmlParts[0]);
 
-					if ($pageAsCategory > 0) {
-						$pid = $row['pid'];
-					} else {
-						$pageObj = $tablesObj->get('pages');
-						$pid = $pageObj->getPID(
-							$conf['PIDlistDisplay'] ?? 0,
-							$conf['PIDlistDisplay.'] ?? [],
-							$row
-						);
-					}
-					$addQueryString = [$categoryTableView->getPivar() => $actCategory];
+                    if ($pageAsCategory > 0) {
+                        $pid = $row['pid'];
+                    } else {
+                        $pageObj = $tablesObj->get('pages');
+                        $pid = $pageObj->getPID(
+                            $conf['PIDlistDisplay'] ?? 0,
+                            $conf['PIDlistDisplay.'] ?? [],
+                            $row
+                        );
+                    }
+                    $addQueryString = [$categoryTableView->getPivar() => $actCategory];
 
-					$markerArray = [];
-					$categoryTableView->getMarkerArray (
-						$markerArray,
-						$categoryTableView->getMarker(),
-						$actCategory,
-						$row['pid'],
-						$config['limitImage'],
-						'listcatImage',
-						$viewCatTagArray,
-						[],
-						$pageAsCategory,
-						$theCode,
-						$basketExtra,
-						$basketRecs,
-						'',
-						'',
-						''
-					);
+                    $markerArray = [];
+                    $categoryTableView->getMarkerArray (
+                        $markerArray,
+                        $categoryTableView->getMarker(),
+                        $actCategory,
+                        $row['pid'],
+                        $config['limitImage'],
+                        'listcatImage',
+                        $viewCatTagArray,
+                        [],
+                        $pageAsCategory,
+                        $theCode,
+                        $basketExtra,
+                        $basketRecs,
+                        '',
+                        '',
+                        ''
+                    );
 
-					$urlParameters = [$prefixId => $addQueryString];
+                    $urlParameters = [$prefixId => $addQueryString];
 
-					$linkConf = [];
-					$linkConf['parameter'] = $pid;
-					$linkConf['additionalParams'] = GeneralUtility::implodeArrayForUrl('', $urlParameters);
-					$linkConf['ATagParams'] = $pibaseObj->cObj->getATagParams($linkConf);
+                    $linkConf = [];
+                    $linkConf['parameter'] = $pid;
+                    $linkConf['additionalParams'] = GeneralUtility::implodeArrayForUrl('', $urlParameters);
+                    $linkConf['ATagParams'] = $pibaseObj->cObj->getATagParams($linkConf);
 
-					$theLinkWrap = $pibaseObj->cObj->typolink('|', $linkConf);
-					$tagArray = $markerObj->getAllMarkers($theLinkWrap);
-					$linkMarkerArray = [];
+                    $theLinkWrap = $pibaseObj->cObj->typolink('|', $linkConf);
+                    $tagArray = $markerObj->getAllMarkers($theLinkWrap);
+                    $linkMarkerArray = [];
 
-					foreach ($tagArray as $tag => $v) {
-						$marker = '###' . $tag. '###';
-						if (isset($markerArray[$marker])) {
-							$linkMarkerArray[$marker] = htmlspecialchars($markerArray[$marker]);
-						}
-					}
+                    foreach ($tagArray as $tag => $v) {
+                        $marker = '###' . $tag. '###';
+                        if (isset($markerArray[$marker])) {
+                            $linkMarkerArray[$marker] = htmlspecialchars($markerArray[$marker]);
+                        }
+                    }
 
-					$theLinkWrap =
-						$templateService->substituteMarkerArray(
-							$theLinkWrap,
-							$linkMarkerArray
-						);
+                    $theLinkWrap =
+                        $templateService->substituteMarkerArray(
+                            $theLinkWrap,
+                            $linkMarkerArray
+                        );
 
-					$linkOutArray = explode('|', $theLinkWrap);
-					$linkOut =
-						$linkOutArray[0] .
-							htmlentities(
-								$row[$categoryTable->getLabelFieldname()], ENT_QUOTES, 'UTF-8'
-							) . $linkOutArray[1];
+                    $linkOutArray = explode('|', $theLinkWrap);
+                    $linkOut =
+                        $linkOutArray[0] .
+                            htmlentities(
+                                $row[$categoryTable->getLabelFieldname()], ENT_QUOTES, 'UTF-8'
+                            ) . $linkOutArray[1];
 
-					$markerArray['###LIST_LINK###'] = $linkOut;
+                    $markerArray['###LIST_LINK###'] = $linkOut;
 
-					if ($t['linkCategoryFrameWork']) {
-						$categoryOut =
-							$templateService->substituteMarkerArray(
-								$t['linkCategoryFrameWork'],
-								$markerArray
-							);
-						$out .= $categoryOut . chr(13);
-					}
+                    if ($t['linkCategoryFrameWork']) {
+                        $categoryOut =
+                            $templateService->substituteMarkerArray(
+                                $t['linkCategoryFrameWork'],
+                                $markerArray
+                            );
+                        $out .= $categoryOut . chr(13);
+                    }
 
-					if (
-						$depth < $maxDepth &&
-						is_array($subCategories) &&
-						(
-							!$catConf['onlyChildsOfCurrent'] ||
-							isset($activeRootline[$actCategory])
-						)
-					) {
-						$depth++;
-						$mainCount++;
-						$idMain = $categoryTableView->getPivar() . $mainCount;
-						$menu = 'm' . $depth;
-						$tabArray[$depth] = $this->getTabs($depth * 2);
+                    if (
+                        $depth < $maxDepth &&
+                        is_array($subCategories) &&
+                        (
+                            !$catConf['onlyChildsOfCurrent'] ||
+                            isset($activeRootline[$actCategory])
+                        )
+                    ) {
+                        $depth++;
+                        $mainCount++;
+                        $idMain = $categoryTableView->getPivar() . $mainCount;
+                        $menu = 'm' . $depth;
+                        $tabArray[$depth] = $this->getTabs($depth * 2);
 
-						$preOut = $tabArray[$depth] . '<' . $this->htmlTagMain . ' id="' . $idMain . '"' . ' class="' . $menu . '" ' . $fill .  ' >' . chr(13);
-						$countArray[(int) $depth] = 0;
-						$catArray[(int) $depth] = $subCategories;
-						$out .= str_replace($this->htmlPartsMarkers[0], $preOut, $htmlParts[0]);
-					} else if($countArray[$depth] <= count ($catArray[$depth])) {	// several elements at same depth
-						$postOut = $tabArray[$depth] . chr(9) . '</' . $this->htmlTagElement . '>' . chr(13);
-						$tmp = str_replace($this->htmlPartsMarkers[1], $postOut, $htmlParts[1]);
-						$out .= $tmp;
-					}
-				} else {
-					$postOut = $tabArray[$depth] . '</' . $this->htmlTagMain . '>' . chr(13);
-					$depth--;
-					if ($depth) {
-						$postOut .= $tabArray[$depth] . chr(9) . '</' . $this->htmlTagElement . '>' . chr(13);
-					}
-					$out .= str_replace($this->htmlPartsMarkers[1], $postOut, $htmlParts[1]);
-				}
-			}
+                        $preOut = $tabArray[$depth] . '<' . $this->htmlTagMain . ' id="' . $idMain . '"' . ' class="' . $menu . '" ' . $fill .  ' >' . chr(13);
+                        $countArray[(int) $depth] = 0;
+                        $catArray[(int) $depth] = $subCategories;
+                        $out .= str_replace($this->htmlPartsMarkers[0], $preOut, $htmlParts[0]);
+                    } else if($countArray[$depth] <= count ($catArray[$depth])) {	// several elements at same depth
+                        $postOut = $tabArray[$depth] . chr(9) . '</' . $this->htmlTagElement . '>' . chr(13);
+                        $tmp = str_replace($this->htmlPartsMarkers[1], $postOut, $htmlParts[1]);
+                        $out .= $tmp;
+                    }
+                } else {
+                    $postOut = $tabArray[$depth] . '</' . $this->htmlTagMain . '>' . chr(13);
+                    $depth--;
+                    if ($depth) {
+                        $postOut .= $tabArray[$depth] . chr(9) . '</' . $this->htmlTagElement . '>' . chr(13);
+                    }
+                    $out .= str_replace($this->htmlPartsMarkers[1], $postOut, $htmlParts[1]);
+                }
+            }
 
-			$markerArray = [];
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
+            $markerArray = [];
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
 
-			$jsMarkerArray = [];
-			$javaScriptMarker->getMarkerArray($jsMarkerArray, $markerArray, $cObj);
-			$markerArray = array_merge($jsMarkerArray, $markerArray);
+            $jsMarkerArray = [];
+            $javaScriptMarker->getMarkerArray($jsMarkerArray, $markerArray, $cObj);
+            $markerArray = array_merge($jsMarkerArray, $markerArray);
 
-			$this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
-			$subpartArray['###CATEGORY_SINGLE###'] = $out;
-			$out = $templateService->substituteMarkerArrayCached(
-				$t['listFrameWork'],
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
-			$content = $out;
-		}
+            $this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
+            $subpartArray['###CATEGORY_SINGLE###'] = $out;
+            $out = $templateService->substituteMarkerArrayCached(
+                $t['listFrameWork'],
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
+            $content = $out;
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 }
 

--- a/view/class.tx_ttproducts_order_view.php
+++ b/view/class.tx_ttproducts_order_view.php
@@ -46,1022 +46,1022 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_order_view extends tx_ttproducts_table_base_view {
-	public $marker = 'ORDER';
+    public $marker = 'ORDER';
 
 
-	protected function init2 (
-		$bValidUpdateCode,
-		$theCode,
-		&$pid_list,
-		$recursive,
-		$orderObj,
-		$cnf,
-		&$itemTable,
-		&$functablename,
-		&$tableconf,
-		&$feusers_uid,
-		&$validFeUser,
-		&$pid,
-		&$markerArray,
-		&$orderMarker,
-		&$feuserMarker,
-		&$piVars,
-		&$prefix
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+    protected function init2 (
+        $bValidUpdateCode,
+        $theCode,
+        &$pid_list,
+        $recursive,
+        $orderObj,
+        $cnf,
+        &$itemTable,
+        &$functablename,
+        &$tableconf,
+        &$feusers_uid,
+        &$validFeUser,
+        &$pid,
+        &$markerArray,
+        &$orderMarker,
+        &$feuserMarker,
+        &$piVars,
+        &$prefix
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
 
-		$pidListObj->applyRecursive($recursive, $pid_list, true);
-		$pidListObj->setPageArray();
-		$feusers_uid = 0;
+        $pidListObj->applyRecursive($recursive, $pid_list, true);
+        $pidListObj->setPageArray();
+        $feusers_uid = 0;
 
-		if (!$bValidUpdateCode) {
-			$feusers_uid = tx_div2007::getFrontEndUser('uid');
-		}
+        if (!$bValidUpdateCode) {
+            $feusers_uid = tx_div2007::getFrontEndUser('uid');
+        }
 
-		$functablename = $orderObj->getFuncTablename();
+        $functablename = $orderObj->getFuncTablename();
 
-		$tableconf = $cnf->getTableConf($functablename, $theCode);
-		$validFeUser = false;
-		if ($theCode == 'DOWNLOAD') {
-			$downloadAuthorization = $cnf->getDownloadConf('authorization');
-			if (
-				$downloadAuthorization == 'FE' &&
-				$feusers_uid > 0
-			) {
-				$validFeUser = true;
-			}
-		}
+        $tableconf = $cnf->getTableConf($functablename, $theCode);
+        $validFeUser = false;
+        if ($theCode == 'DOWNLOAD') {
+            $downloadAuthorization = $cnf->getDownloadConf('authorization');
+            if (
+                $downloadAuthorization == 'FE' &&
+                $feusers_uid > 0
+            ) {
+                $validFeUser = true;
+            }
+        }
 
-		$orderMarker = $this->getMarker();
-		$feusersViewObj = $tablesObj->get('fe_users', true);
-		$feuserMarker = $feusersViewObj->getMarker();
-		$productFunctablename = 'tt_products';
-		$itemTable = $tablesObj->get($productFunctablename); // order
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$prefix = tx_ttproducts_model_control::getPrefixId();
+        $orderMarker = $this->getMarker();
+        $feusersViewObj = $tablesObj->get('fe_users', true);
+        $feuserMarker = $feusersViewObj->getMarker();
+        $productFunctablename = 'tt_products';
+        $itemTable = $tablesObj->get($productFunctablename); // order
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $prefix = tx_ttproducts_model_control::getPrefixId();
 
-		$pid = $GLOBALS['TSFE']->id;
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-		$addQueryString = '';
-		$excludeList = '';
-		$globalMarkerArray = $markerObj->getGlobalMarkerArray();
-		$markerArray = $urlObj->addURLMarkers(
-			$pid,
-			$globalMarkerArray,
-			$addQueryString,
-			$excludeList,
-			false,
-			0
-		);
-	}
-
-
-	static public function setFeuserMarker ($feuserMarker, $row, &$markerArray) {
-		$markerArray['###' . $feuserMarker . '_NUMBER###'] = $row['uid'];
-		$markerArray['###' . $feuserMarker . '_NAME###'] = $row['name'];
-	}
+        $pid = $GLOBALS['TSFE']->id;
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $addQueryString = '';
+        $excludeList = '';
+        $globalMarkerArray = $markerObj->getGlobalMarkerArray();
+        $markerArray = $urlObj->addURLMarkers(
+            $pid,
+            $globalMarkerArray,
+            $addQueryString,
+            $excludeList,
+            false,
+            0
+        );
+    }
 
 
-	/** add the markers for uid, date and the tracking number which is stored in the basket recs */
-	public function getBasketRecsMarkerArray (
-		&$markerArray,
-		$orderArray
-	) {
+    static public function setFeuserMarker ($feuserMarker, $row, &$markerArray) {
+        $markerArray['###' . $feuserMarker . '_NUMBER###'] = $row['uid'];
+        $markerArray['###' . $feuserMarker . '_NAME###'] = $row['name'];
+    }
+
+
+    /** add the markers for uid, date and the tracking number which is stored in the basket recs */
+    public function getBasketRecsMarkerArray (
+        &$markerArray,
+        $orderArray
+    ) {
         $cObj = FrontendUtility::getContentObjectRenderer();
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->conf;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->conf;
 
-		if (
-			isset($orderArray) &&
-			is_array($orderArray) &&
-			isset($orderArray['uid']) &&
-			isset($orderArray['crdate']) &&
-			isset($orderArray['tracking_code'])
-		) {
-				// order
-			$orderObj = $this->getModelObj();
+        if (
+            isset($orderArray) &&
+            is_array($orderArray) &&
+            isset($orderArray['uid']) &&
+            isset($orderArray['crdate']) &&
+            isset($orderArray['tracking_code'])
+        ) {
+                // order
+            $orderObj = $this->getModelObj();
 
             $markerArray['###ORDER_UID###'] = $orderArray['uid'];
-			$markerArray['###ORDER_ORDER_NO###'] = $orderObj->getNumber($orderArray['uid']);
+            $markerArray['###ORDER_ORDER_NO###'] = $orderObj->getNumber($orderArray['uid']);
 
             $markerArray['###ORDER_DATE###'] =
-				$cObj->stdWrap(
-					$orderArray['crdate'],
-					$conf['orderDate_stdWrap.'] ?? ''
-				);
-			$markerArray['###ORDER_TRACKING_NO###'] = htmlspecialchars($orderArray['tracking_code']);
-			$markerArray['###ORDER_BILL_NO###'] = $orderArray['bill_no'] ?? '';
-		} else {
-			$markerArray['###ORDER_UID###'] = '';
-			$markerArray['###ORDER_ORDER_NO###'] = '';
-			$markerArray['###ORDER_DATE###'] = '';
-			$markerArray['###ORDER_TRACKING_NO###'] = '';
-			$markerArray['###ORDER_BILL_NO###'] = '';
-		}
-	}
+                $cObj->stdWrap(
+                    $orderArray['crdate'],
+                    $conf['orderDate_stdWrap.'] ?? ''
+                );
+            $markerArray['###ORDER_TRACKING_NO###'] = htmlspecialchars($orderArray['tracking_code']);
+            $markerArray['###ORDER_BILL_NO###'] = $orderArray['bill_no'] ?? '';
+        } else {
+            $markerArray['###ORDER_UID###'] = '';
+            $markerArray['###ORDER_ORDER_NO###'] = '';
+            $markerArray['###ORDER_DATE###'] = '';
+            $markerArray['###ORDER_TRACKING_NO###'] = '';
+            $markerArray['###ORDER_BILL_NO###'] = '';
+        }
+    }
 
 
-	public function getOrderMarkerSubpartArrays (
-		$pibaseClass,
-		$templateCode,
-		$frameWork,
-		$theCode,
-		$pageAsCategory,
-		$pid,
-		$pid_list,
-		$from,
-		$where,
-		$orderBy,
-		&$markerArray,
-		&$subpartArray,
-		&$error_code
-	) {
-		if ($from == '') {
-			$from = 'sys_products_orders';
-		}
-		$templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->conf;
+    public function getOrderMarkerSubpartArrays (
+        $pibaseClass,
+        $templateCode,
+        $frameWork,
+        $theCode,
+        $pageAsCategory,
+        $pid,
+        $pid_list,
+        $from,
+        $where,
+        $orderBy,
+        &$markerArray,
+        &$subpartArray,
+        &$error_code
+    ) {
+        if ($from == '') {
+            $from = 'sys_products_orders';
+        }
+        $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->conf;
 
         $res =
-			$GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'*',
-				$from,
-				$where . ($orderBy != '' ? ' ORDER BY ' . $orderBy : '')
-			);
-		$count = $GLOBALS['TYPO3_DB']->sql_num_rows($res);
+            $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                '*',
+                $from,
+                $where . ($orderBy != '' ? ' ORDER BY ' . $orderBy : '')
+            );
+        $count = $GLOBALS['TYPO3_DB']->sql_num_rows($res);
 
-		if ($count) {
-			$orderObj = $this->getModelObj();
-			$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        if ($count) {
+            $orderObj = $this->getModelObj();
+            $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
-			// Fill marker arrays
-			$tot_creditpoints_saved = 0;
-			$tot_creditpoints_changed = 0;
-			$tot_creditpoints_spended = 0;
-			$tot_creditpoints_gifts = 0;
-			$orderlistc = '';
-			$this->orders = [];
-			$orderitem = $templateService->getSubpart($frameWork, '###ORDER_ITEM###');
-			$tablename = 'fe_users';
+            // Fill marker arrays
+            $tot_creditpoints_saved = 0;
+            $tot_creditpoints_changed = 0;
+            $tot_creditpoints_spended = 0;
+            $tot_creditpoints_gifts = 0;
+            $orderlistc = '';
+            $this->orders = [];
+            $orderitem = $templateService->getSubpart($frameWork, '###ORDER_ITEM###');
+            $tablename = 'fe_users';
 
-			while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-				$markerArray['###TRACKING_CODE###'] = $row['tracking_code'];
-				$markerArray['###ORDER_DATE###'] = $cObj->stdWrap($row['crdate'], $conf['orderDate_stdWrap.'] ?? '');
+            while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+                $markerArray['###TRACKING_CODE###'] = $row['tracking_code'];
+                $markerArray['###ORDER_DATE###'] = $cObj->stdWrap($row['crdate'], $conf['orderDate_stdWrap.'] ?? '');
 
-				$markerArray['###ORDER_NUMBER###'] = $orderObj->getNumber($row['uid']);
-				$markerArray['###ORDER_CREDITS###'] = $row['creditpoints_saved'] + $row['creditpoints_gifts'] - $row['creditpoints_spended'] - $row['creditpoints'];
-				$markerArray['###ORDER_AMOUNT###'] = $priceViewObj->printPrice($priceViewObj->priceFormat($row['amount']));
+                $markerArray['###ORDER_NUMBER###'] = $orderObj->getNumber($row['uid']);
+                $markerArray['###ORDER_CREDITS###'] = $row['creditpoints_saved'] + $row['creditpoints_gifts'] - $row['creditpoints_spended'] - $row['creditpoints'];
+                $markerArray['###ORDER_AMOUNT###'] = $priceViewObj->printPrice($priceViewObj->priceFormat($row['amount']));
 
-				// total amount of saved creditpoints
-				$tot_creditpoints_saved += $row['creditpoints_saved'];
+                // total amount of saved creditpoints
+                $tot_creditpoints_saved += $row['creditpoints_saved'];
 
-				// total amount of changed creditpoints
-				$tot_creditpoints_changed += $row['creditpoints'];
+                // total amount of changed creditpoints
+                $tot_creditpoints_changed += $row['creditpoints'];
 
-				// total amount of spended creditpoints
-				$tot_creditpoints_spended += $row['creditpoints_spended'];
+                // total amount of spended creditpoints
+                $tot_creditpoints_spended += $row['creditpoints_spended'];
 
-				// total amount of creditpoints from gifts
-				$tot_creditpoints_gifts += $row['creditpoints_gifts'];
-				$orderlistc .= $templateService->substituteMarkerArray($orderitem, $markerArray);
-			}
+                // total amount of creditpoints from gifts
+                $tot_creditpoints_gifts += $row['creditpoints_gifts'];
+                $orderlistc .= $templateService->substituteMarkerArray($orderitem, $markerArray);
+            }
 
-			if (strpos($frameWork, '###CREDIT_POINTS_VOUCHER###') !== false) {
+            if (strpos($frameWork, '###CREDIT_POINTS_VOUCHER###') !== false) {
 
-				$res2 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-					'username',
-					$tablename,
-					'tt_products_vouchercode=' .
-						$GLOBALS['TYPO3_DB']->fullQuoteStr(
-							$username, $tablename
-						)
-				);
-				$num_rows = $GLOBALS['TYPO3_DB']->sql_num_rows($res2) * 5;
-				$GLOBALS['TYPO3_DB']->sql_free_result($res2);
-			} else {
-				$num_rows = 0;
-			}
+                $res2 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                    'username',
+                    $tablename,
+                    'tt_products_vouchercode=' .
+                        $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                            $username, $tablename
+                        )
+                );
+                $num_rows = $GLOBALS['TYPO3_DB']->sql_num_rows($res2) * 5;
+                $GLOBALS['TYPO3_DB']->sql_free_result($res2);
+            } else {
+                $num_rows = 0;
+            }
 
-			if (strpos($frameWork, '###CREDIT_POINTS_TOTAL###') !== false) {
+            if (strpos($frameWork, '###CREDIT_POINTS_TOTAL###') !== false) {
 
-				$res3 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-					'tt_products_creditpoints ',
-					$tablename,
-					'uid=' . intval($feusers_uid) . ' AND NOT deleted'
-				);
-				$totalcreditpoints = 0;
+                $res3 = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                    'tt_products_creditpoints ',
+                    $tablename,
+                    'uid=' . intval($feusers_uid) . ' AND NOT deleted'
+                );
+                $totalcreditpoints = 0;
 
-				if ($res3 !== false) {
-					while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res3)) {
-						$totalcreditpoints = $row['tt_products_creditpoints'];
-					}
-					$GLOBALS['TYPO3_DB']->sql_free_result($res3);
-				}
-			}
+                if ($res3 !== false) {
+                    while($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res3)) {
+                        $totalcreditpoints = $row['tt_products_creditpoints'];
+                    }
+                    $GLOBALS['TYPO3_DB']->sql_free_result($res3);
+                }
+            }
 
-			$markerArray['###CREDIT_POINTS_SAVED###'] = number_format($tot_creditpoints_saved, 0);
-			$markerArray['###CREDIT_POINTS_SPENT###'] = number_format($tot_creditpoints_spended, 0);
-			$markerArray['###CREDIT_POINTS_CHANGED###'] = number_format($tot_creditpoints_changed, 0);
-			$markerArray['###CREDIT_POINTS_USED###'] = number_format($tot_creditpoints_spended, 0) + number_format($tot_creditpoints_changed, 0);
-			$markerArray['###CREDIT_POINTS_GIFTS###'] = number_format($tot_creditpoints_gifts, 0);
-			$markerArray['###CREDIT_POINTS_TOTAL###'] = number_format($totalcreditpoints, 0);
-			$markerArray['###CREDIT_POINTS_VOUCHER###'] = $num_rows;
-			$markerArray['###CALC_DATE###'] = date('d M Y');
-			$listFrameWork = $templateService->getSubpart($frameWork, '###ORDER_LIST###');
+            $markerArray['###CREDIT_POINTS_SAVED###'] = number_format($tot_creditpoints_saved, 0);
+            $markerArray['###CREDIT_POINTS_SPENT###'] = number_format($tot_creditpoints_spended, 0);
+            $markerArray['###CREDIT_POINTS_CHANGED###'] = number_format($tot_creditpoints_changed, 0);
+            $markerArray['###CREDIT_POINTS_USED###'] = number_format($tot_creditpoints_spended, 0) + number_format($tot_creditpoints_changed, 0);
+            $markerArray['###CREDIT_POINTS_GIFTS###'] = number_format($tot_creditpoints_gifts, 0);
+            $markerArray['###CREDIT_POINTS_TOTAL###'] = number_format($totalcreditpoints, 0);
+            $markerArray['###CREDIT_POINTS_VOUCHER###'] = $num_rows;
+            $markerArray['###CALC_DATE###'] = date('d M Y');
+            $listFrameWork = $templateService->getSubpart($frameWork, '###ORDER_LIST###');
 
-			$listSubpartArray = [];
-			$listSubpartArray['###ORDER_ITEM###'] = $orderlistc;
-			$listContent = $templateService->substituteMarkerArrayCached(
-				$listFrameWork,
-				$markerArray,
-				$listSubpartArray
-			);
-			$subpartArray['###ORDER_LIST###'] = $listContent;
-			$subpartArray['###ORDER_NOROWS###'] = '';
-		} else {
-			$subpartArray['###ORDER_LIST###'] = '';
-			$wrappedSubpartArray['###ORDER_NOROWS###'] = '';
-		}
+            $listSubpartArray = [];
+            $listSubpartArray['###ORDER_ITEM###'] = $orderlistc;
+            $listContent = $templateService->substituteMarkerArrayCached(
+                $listFrameWork,
+                $markerArray,
+                $listSubpartArray
+            );
+            $subpartArray['###ORDER_LIST###'] = $listContent;
+            $subpartArray['###ORDER_NOROWS###'] = '';
+        } else {
+            $subpartArray['###ORDER_LIST###'] = '';
+            $wrappedSubpartArray['###ORDER_NOROWS###'] = '';
+        }
 
-		if ($res !== false) {
-			$GLOBALS['TYPO3_DB']->sql_free_result($res);
-		}
-	}
+        if ($res !== false) {
+            $GLOBALS['TYPO3_DB']->sql_free_result($res);
+        }
+    }
 
 
-	public function getProductMarkerSubpartArrays (
-		$pibaseClass,
-		$templateCode,
-		$frameWork,
-		$subpartMarker,
-		$theCode,
-		$pageAsCategory,
-		$pid,
-		$pid_list,
-		$from,
-		$where,
-		$orderBy,
-		$whereProducts,
-		$onlyProductsWithFalOrders,
-		$hiddenFields,
-		&$markerArray,
-		&$subpartArray,
-		&$error_code
-	) {
-		$content = '';
-		$orderObj = $this->getModelObj(); // order
+    public function getProductMarkerSubpartArrays (
+        $pibaseClass,
+        $templateCode,
+        $frameWork,
+        $subpartMarker,
+        $theCode,
+        $pageAsCategory,
+        $pid,
+        $pid_list,
+        $from,
+        $where,
+        $orderBy,
+        $whereProducts,
+        $onlyProductsWithFalOrders,
+        $hiddenFields,
+        &$markerArray,
+        &$subpartArray,
+        &$error_code
+    ) {
+        $content = '';
+        $orderObj = $this->getModelObj(); // order
 
-		$orderObj->getOrderedAndGainedProducts(
-			$from,
-			$where,
-			$orderBy,
-			$whereProducts,
-			$onlyProductsWithFalOrders,
-			$pid_list,
-			$productRowArray,
-			$multiOrderArray
-		);
+        $orderObj->getOrderedAndGainedProducts(
+            $from,
+            $where,
+            $orderBy,
+            $whereProducts,
+            $onlyProductsWithFalOrders,
+            $pid_list,
+            $productRowArray,
+            $multiOrderArray
+        );
 
-		if (
+        if (
             is_array($productRowArray) &&
-			count($productRowArray) &&
-			strpos($frameWork, '###ORDER_PRODUCT_UID###') !== false
-		) {
-			$productUidArray = [];
-			foreach ($productRowArray as $productRow) {
-				$productUidArray[$productRow['uid']] = $productRow['uid'];
-			}
+            count($productRowArray) &&
+            strpos($frameWork, '###ORDER_PRODUCT_UID###') !== false
+        ) {
+            $productUidArray = [];
+            foreach ($productRowArray as $productRow) {
+                $productUidArray[$productRow['uid']] = $productRow['uid'];
+            }
 
-			$allowedItems = implode(',', $productUidArray);
-			$listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
-			$listView->init(
-				$pid,
-				[],
-				$pid_list,
-				0
-			);
+            $allowedItems = implode(',', $productUidArray);
+            $listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
+            $listView->init(
+                $pid,
+                [],
+                $pid_list,
+                0
+            );
 
             $notOverwritePriceIfSet = false;
-			$content = $listView->printView(
-				$templateCode,
-				$theCode,
-				'tt_products',
-				$allowedItems,
-				$pid_list,
-				$hiddenFields,
-				$error_code,
-				$subpartMarker,
-				$pageAsCategory,
-				[],
-				[],
-				[],
-				0,
-				[],
-				[],
-				[],
-				'',
-				[],
-				$notOverwritePriceIfSet,
-				$multiOrderArray,
-				$productRowArray,
-				false
-			);
-		}
+            $content = $listView->printView(
+                $templateCode,
+                $theCode,
+                'tt_products',
+                $allowedItems,
+                $pid_list,
+                $hiddenFields,
+                $error_code,
+                $subpartMarker,
+                $pageAsCategory,
+                [],
+                [],
+                [],
+                0,
+                [],
+                [],
+                [],
+                '',
+                [],
+                $notOverwritePriceIfSet,
+                $multiOrderArray,
+                $productRowArray,
+                false
+            );
+        }
 
-		$markerArray['###ORDER_PRODUCT_UID###'] = $content;
-	}
+        $markerArray['###ORDER_PRODUCT_UID###'] = $content;
+    }
 
 
-	public function getFrameWork (
-		$templateCode,
-		$subPartMarker,
-		$bValidUpdateCode,
-		$trackingCode,
-		$bNeedTrackingInfo,
-		$feusers_uid,
-		$validFeUser,
-		&$error_code
-	) {
+    public function getFrameWork (
+        $templateCode,
+        $subPartMarker,
+        $bValidUpdateCode,
+        $trackingCode,
+        $bNeedTrackingInfo,
+        $feusers_uid,
+        $validFeUser,
+        &$error_code
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
 
-		if (
-			$bValidUpdateCode ||
-			$trackingCode ||
-			$validFeUser
-		) {
-			// nothing
-		} else if ($bNeedTrackingInfo) {
-			$subPartMarker = 'TRACKING_ENTER_NUMBER';
-		} elseif (!$feusers_uid) {
-			$subPartMarker = 'MEMO_NOT_LOGGED_IN';
-		} else {
-			// nothing
-		}
+        if (
+            $bValidUpdateCode ||
+            $trackingCode ||
+            $validFeUser
+        ) {
+            // nothing
+        } else if ($bNeedTrackingInfo) {
+            $subPartMarker = 'TRACKING_ENTER_NUMBER';
+        } elseif (!$feusers_uid) {
+            $subPartMarker = 'MEMO_NOT_LOGGED_IN';
+        } else {
+            // nothing
+        }
 
-		$frameWork = $templateService->getSubpart(
-			$templateCode,
-			$subpartmarkerObj->spMarker('###' . $subPartMarker . '###')
-		);
+        $frameWork = $templateService->getSubpart(
+            $templateCode,
+            $subpartmarkerObj->spMarker('###' . $subPartMarker . '###')
+        );
 
-		if (!$frameWork) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$error_code[0] = 'no_subtemplate';
-			$error_code[1] = '###' . $subPartMarker . '###';
-			$error_code[2] = $templateObj->getTemplateFile();
-		}
+        if (!$frameWork) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $error_code[0] = 'no_subtemplate';
+            $error_code[1] = '###' . $subPartMarker . '###';
+            $error_code[2] = $templateObj->getTemplateFile();
+        }
 
-		return $frameWork;
-	}
-
-
-	public function processFeuserSelect (
-		$piVars,
-		$prefix,
-		$tableconf,
-		$pid_list,
-		&$feusers_uid,
-		&$hiddenFields
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$feusersObj = $tablesObj->get('fe_users', false);
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-
-		$result = '';
-
-		$orderBy = $tableconf['orderBy'];
-		if ($orderBy == '') {
-			$orderBy = 'uid';
-		}
-
-		$feuserRowArray = $feusersObj->get('', $pid_list . ',' . intval($feusersObj->getPid()));
-
-		if (is_array($feuserRowArray) && count($feuserRowArray)) {
-			$valueArray = [];
-			$valueArray[] = '';
-
-			foreach ($feuserRowArray as $uid => $row) {
-				$valueArray[] = [$row['uid'] . ' - ' . $row['name'] . ' - ' . $row['city'], $uid];
-			}
-
-			$piVar = tx_ttproducts_model_control::getPiVar('orderaddress');
-
-			$selectedKey = $piVars[$piVar] ?? 0;
-			$type = 'select';
-			$tagName = $prefix . '[' . $piVar . ']';
-			$text = tx_ttproducts_form_div::createSelect(
-				$languageObj,
-				$valueArray,
-				$tagName,
-				$selectedKey,
-				true,
-				false,
-				[],
-				$type
-			);
-			$result = $text;
-			$feusers_uid = $selectedKey;
-			$hiddenFields .= tx_ttproducts_form_div::createTag(
-				'input',
-				$tagName,
-				$selectedKey,
-				'type="hidden"'
-			);
-		} else {
-			$result = $languageObj->getLabel('no_feusers');
-		}
-
-		return $result;
-	}
+        return $frameWork;
+    }
 
 
-	public function printView (
-		$pibaseClass,
-		$templateCode,
-		$theCode,
-		$pid_list,
-		$recursive,
-		$pageAsCategory,
-		$updateCode,
-		$bIsAllowed,
-		$bValidUpdateCode,
-		$trackingCode,
-		&$error_code
-	) {
+    public function processFeuserSelect (
+        $piVars,
+        $prefix,
+        $tableconf,
+        $pid_list,
+        &$feusers_uid,
+        &$hiddenFields
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $feusersObj = $tablesObj->get('fe_users', false);
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+
+        $result = '';
+
+        $orderBy = $tableconf['orderBy'];
+        if ($orderBy == '') {
+            $orderBy = 'uid';
+        }
+
+        $feuserRowArray = $feusersObj->get('', $pid_list . ',' . intval($feusersObj->getPid()));
+
+        if (is_array($feuserRowArray) && count($feuserRowArray)) {
+            $valueArray = [];
+            $valueArray[] = '';
+
+            foreach ($feuserRowArray as $uid => $row) {
+                $valueArray[] = [$row['uid'] . ' - ' . $row['name'] . ' - ' . $row['city'], $uid];
+            }
+
+            $piVar = tx_ttproducts_model_control::getPiVar('orderaddress');
+
+            $selectedKey = $piVars[$piVar] ?? 0;
+            $type = 'select';
+            $tagName = $prefix . '[' . $piVar . ']';
+            $text = tx_ttproducts_form_div::createSelect(
+                $languageObj,
+                $valueArray,
+                $tagName,
+                $selectedKey,
+                true,
+                false,
+                [],
+                $type
+            );
+            $result = $text;
+            $feusers_uid = $selectedKey;
+            $hiddenFields .= tx_ttproducts_form_div::createTag(
+                'input',
+                $tagName,
+                $selectedKey,
+                'type="hidden"'
+            );
+        } else {
+            $result = $languageObj->getLabel('no_feusers');
+        }
+
+        return $result;
+    }
+
+
+    public function printView (
+        $pibaseClass,
+        $templateCode,
+        $theCode,
+        $pid_list,
+        $recursive,
+        $pageAsCategory,
+        $updateCode,
+        $bIsAllowed,
+        $bValidUpdateCode,
+        $trackingCode,
+        &$error_code
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$orderObj = $this->getModelObj(); // order
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$feusers_uid = 0;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $orderObj = $this->getModelObj(); // order
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $feusers_uid = 0;
         $itemTable = null;
-		$functablename = '';
-		$tableconf = [];
-		$validFeUser = false;
-		$pid = 0;
+        $functablename = '';
+        $tableconf = [];
+        $validFeUser = false;
+        $pid = 0;
         $markerArray = [];
         $orderMarker = [];
         $feuserMarker = '';
         $piVars = [];
         $prefix = '';
 
-		self::init2(
-			$bValidUpdateCode,
-			$theCode,
-			$pid_list,
-			$recursive,
-			$orderObj,
-			$cnf,
-			$itemTable,
-			$functablename,
-			$tableconf,
-			$feusers_uid,
-			$validFeUser,
-			$pid,
-			$markerArray,
-			$orderMarker,
-			$feuserMarker,
-			$piVars,
-			$prefix
-		);
+        self::init2(
+            $bValidUpdateCode,
+            $theCode,
+            $pid_list,
+            $recursive,
+            $orderObj,
+            $cnf,
+            $itemTable,
+            $functablename,
+            $tableconf,
+            $feusers_uid,
+            $validFeUser,
+            $pid,
+            $markerArray,
+            $orderMarker,
+            $feuserMarker,
+            $piVars,
+            $prefix
+        );
 
-		$idPrefix = str_replace('_', '-', $prefix);
-		$fegroups_uid = 0;
-		$fegroupMarker = 'FEGROUP';
-		$viewType = 0;
+        $idPrefix = str_replace('_', '-', $prefix);
+        $fegroups_uid = 0;
+        $fegroupMarker = 'FEGROUP';
+        $viewType = 0;
 
-		tx_ttproducts_admin_control_view::getSubpartArrays(
-			$bIsAllowed,
-			$bValidUpdateCode,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
+        tx_ttproducts_admin_control_view::getSubpartArrays(
+            $bIsAllowed,
+            $bValidUpdateCode,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
 
-		$hiddenFields = tx_ttproducts_admin_control_view::getHiddenField($updateCode);
-		$markerArray['###ADMIN_HIDDENFIELDS###'] = $hiddenFields;
-		$subPartMarker = 'ORDERS_LIST_TEMPLATE';
-		$bNeedTrackingInfo = $bIsAllowed;
-		if ($feusers_uid > 0 && !$bValidUpdateCode) {
-			$bNeedTrackingInfo = false;
-		}
+        $hiddenFields = tx_ttproducts_admin_control_view::getHiddenField($updateCode);
+        $markerArray['###ADMIN_HIDDENFIELDS###'] = $hiddenFields;
+        $subPartMarker = 'ORDERS_LIST_TEMPLATE';
+        $bNeedTrackingInfo = $bIsAllowed;
+        if ($feusers_uid > 0 && !$bValidUpdateCode) {
+            $bNeedTrackingInfo = false;
+        }
 
-		$frameWork = $this->getFrameWork(
-			$templateCode,
-			$subPartMarker,
-			$bValidUpdateCode,
-			$trackingCode,
-			$bNeedTrackingInfo,
-			$feusers_uid,
-			$validFeUser,
-			$error_code
-		);
+        $frameWork = $this->getFrameWork(
+            $templateCode,
+            $subPartMarker,
+            $bValidUpdateCode,
+            $trackingCode,
+            $bNeedTrackingInfo,
+            $feusers_uid,
+            $validFeUser,
+            $error_code
+        );
 
-		if (!$frameWork) {
-			$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-			$error_code[0] = 'no_subtemplate';
-			$error_code[1] = '###' . $subPartMarker . '###';
-			$error_code[2] = $templateObj->getTemplateFile();
-			return '';
-		}
+        if (!$frameWork) {
+            $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+            $error_code[0] = 'no_subtemplate';
+            $error_code[1] = '###' . $subPartMarker . '###';
+            $error_code[2] = $templateObj->getTemplateFile();
+            return '';
+        }
 
-		$bUnlock = false;
+        $bUnlock = false;
 
-		if ($bIsAllowed) {
-			$bUnlock = true;
-		}
+        if ($bIsAllowed) {
+            $bUnlock = true;
+        }
 
-		if ($bUnlock && $bValidUpdateCode) {
+        if ($bUnlock && $bValidUpdateCode) {
 
-			$markerKey = $feuserMarker . '_SELECT';
+            $markerKey = $feuserMarker . '_SELECT';
 
-			if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
+            if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
 
-				$markerArray['###' . $markerKey . '###'] =
-					$this->processFeuserSelect(
-						$piVars,
-						$prefix,
-						$tableconf,
-						$pid_list,
-						$feusers_uid,
-						$hiddenFields
-					);
-			}
+                $markerArray['###' . $markerKey . '###'] =
+                    $this->processFeuserSelect(
+                        $piVars,
+                        $prefix,
+                        $tableconf,
+                        $pid_list,
+                        $feusers_uid,
+                        $hiddenFields
+                    );
+            }
 
-			$markerKey = $fegroupMarker . '_SELECT';
+            $markerKey = $fegroupMarker . '_SELECT';
 
-			if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
-				$pidArray = GeneralUtility::trimExplode(',', $pid_list);
-				foreach ($pidArray as $k => $v) {
-					$pidArray[$k] = intval($v);
-				}
+            if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
+                $pidArray = GeneralUtility::trimExplode(',', $pid_list);
+                foreach ($pidArray as $k => $v) {
+                    $pidArray[$k] = intval($v);
+                }
                 $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields('fe_groups');
                 $where = 'pid IN (' . implode(',', $pidArray) . ')' . $enableFields;
 
-				$feGroupArray =
-					$GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-						'uid,title',
-						'fe_groups',
-						$where
-					);
-				$valueArray = [];
-				$valueArray[] = '';
+                $feGroupArray =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+                        'uid,title',
+                        'fe_groups',
+                        $where
+                    );
+                $valueArray = [];
+                $valueArray[] = '';
 
-				foreach ($feGroupArray as $uid => $row) {
-					$valueArray[] = [$row['title'], $row['uid']];
-				}
+                foreach ($feGroupArray as $uid => $row) {
+                    $valueArray[] = [$row['title'], $row['uid']];
+                }
 
-				$piVar = tx_ttproducts_model_control::getPiVar('fegroup');
-				$selectedKey = $piVars[$piVar] ?? 0;
-				$type = 'select';
-				$tagName = $prefix . '[' . $piVar . ']';
-				$text = tx_ttproducts_form_div::createSelect(
-					$languageObj,
-					$valueArray,
-					$tagName,
-					$selectedKey,
-					true,
-					false,
-					[],
-					$type
-				);
-				$markerArray['###' . $markerKey . '###'] = $text;
-				$fegroups_uid = $selectedKey;
-			}
-		}
+                $piVar = tx_ttproducts_model_control::getPiVar('fegroup');
+                $selectedKey = $piVars[$piVar] ?? 0;
+                $type = 'select';
+                $tagName = $prefix . '[' . $piVar . ']';
+                $text = tx_ttproducts_form_div::createSelect(
+                    $languageObj,
+                    $valueArray,
+                    $tagName,
+                    $selectedKey,
+                    true,
+                    false,
+                    [],
+                    $type
+                );
+                $markerArray['###' . $markerKey . '###'] = $text;
+                $fegroups_uid = $selectedKey;
+            }
+        }
 
-		$markerKey = 'VIEW_SELECT';
+        $markerKey = 'VIEW_SELECT';
 
-		if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
-			$valueArray = [];
-			$valueArray['0'] = $languageObj->getLabel('orders_view_orders');
-			$valueArray['1'] = $languageObj->getLabel('orders_view_products');
+        if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
+            $valueArray = [];
+            $valueArray['0'] = $languageObj->getLabel('orders_view_orders');
+            $valueArray['1'] = $languageObj->getLabel('orders_view_products');
 
-			$piVar = tx_ttproducts_model_control::getOrderViewVar();
-			$selectedKey = $piVars[$piVar] ?? 0;
-			$type = 'select';
-			$text = tx_ttproducts_form_div::createSelect(
-				$languageObj,
-				$valueArray,
-				$prefix . '[' . $piVar . ']',
-				$selectedKey,
-				true,
-				false,
-				[],
-				$type
-			);
-			$markerArray['###' . $markerKey . '###'] = $text;
-			$viewType = $selectedKey;
+            $piVar = tx_ttproducts_model_control::getOrderViewVar();
+            $selectedKey = $piVars[$piVar] ?? 0;
+            $type = 'select';
+            $text = tx_ttproducts_form_div::createSelect(
+                $languageObj,
+                $valueArray,
+                $prefix . '[' . $piVar . ']',
+                $selectedKey,
+                true,
+                false,
+                [],
+                $type
+            );
+            $markerArray['###' . $markerKey . '###'] = $text;
+            $viewType = $selectedKey;
 
-	// MESSAGE_VIEW
+    // MESSAGE_VIEW
 
-			$formConf = $cnf->getFormConf($theCode);
+            $formConf = $cnf->getFormConf($theCode);
 
-			if (
-				isset($formConf['panel.']) &&
-				is_array($formConf['panel.'])
-			) {
-				foreach ($formConf['panel.'] as $k1 => $panelConf) {
-					if (
-						isset($panelConf['layout']) &&
-						isset($panelConf['marker']) &&
-						isset($panelConf['elements.'])
-					) {
-						$layout = $panelConf['layout'];
-						$panelMarker = strtoupper($panelConf['marker']);
-						$elementMarkerArray = [];
+            if (
+                isset($formConf['panel.']) &&
+                is_array($formConf['panel.'])
+            ) {
+                foreach ($formConf['panel.'] as $k1 => $panelConf) {
+                    if (
+                        isset($panelConf['layout']) &&
+                        isset($panelConf['marker']) &&
+                        isset($panelConf['elements.'])
+                    ) {
+                        $layout = $panelConf['layout'];
+                        $panelMarker = strtoupper($panelConf['marker']);
+                        $elementMarkerArray = [];
 
-						foreach ($panelConf['elements.'] as $k2 => $elementConf) {
-							if (
-								isset($elementConf['marker']) &&
-								isset($elementConf['tag']) &&
-								isset($elementConf['name']) &&
-								isset($elementConf['label'])
-							) {
-								$marker = strtoupper($elementConf['marker']);
+                        foreach ($panelConf['elements.'] as $k2 => $elementConf) {
+                            if (
+                                isset($elementConf['marker']) &&
+                                isset($elementConf['tag']) &&
+                                isset($elementConf['name']) &&
+                                isset($elementConf['label'])
+                            ) {
+                                $marker = strtoupper($elementConf['marker']);
 
-								$htmlElement = tx_ttproducts_form_div::createTag($elementConf['tag'], $elementConf['name'], $elementConf['label'], '', $elementConf['params']);
-								$elementMarkerArray['###' . $marker . '###'] = $htmlElement;
-							}
-						}
+                                $htmlElement = tx_ttproducts_form_div::createTag($elementConf['tag'], $elementConf['name'], $elementConf['label'], '', $elementConf['params']);
+                                $elementMarkerArray['###' . $marker . '###'] = $htmlElement;
+                            }
+                        }
 
-						$panelContent =
-							$templateService->substituteMarkerArrayCached(
-								$layout,
-								$elementMarkerArray
-							);
-						$markerArray['###' . $panelMarker . '###'] = $panelContent;
-					}
-				}
-			}
+                        $panelContent =
+                            $templateService->substituteMarkerArrayCached(
+                                $layout,
+                                $elementMarkerArray
+                            );
+                        $markerArray['###' . $panelMarker . '###'] = $panelContent;
+                    }
+                }
+            }
 
-			$tagArray = $markerObj->getAllMarkers($templateCode);
+            $tagArray = $markerObj->getAllMarkers($templateCode);
 
-			foreach ($tagArray as $tag => $v) {
-				if (($pos = strpos($tag, 'MESSAGE_VIEW')) === 0) {
+            foreach ($tagArray as $tag => $v) {
+                if (($pos = strpos($tag, 'MESSAGE_VIEW')) === 0) {
 
-					$markerViewType = substr($tag, strlen('MESSAGE_VIEW_'));
+                    $markerViewType = substr($tag, strlen('MESSAGE_VIEW_'));
 
-					if ($viewType == $markerViewType || $markerViewType == 'NULL' && $viewType == '') {
-						$wrappedSubpartArray['###' . $tag . '###'] = '';
-					} else {
-						$subpartArray['###' . $tag . '###'] = '';
-					}
-				}
-			}
-		}
+                    if ($viewType == $markerViewType || $markerViewType == 'NULL' && $viewType == '') {
+                        $wrappedSubpartArray['###' . $tag . '###'] = '';
+                    } else {
+                        $subpartArray['###' . $tag . '###'] = '';
+                    }
+                }
+            }
+        }
 
-		$orderPiVar = tx_ttproducts_model_control::getPiVar('sys_products_orders');
-		$fieldPiVarArray = ['crdate' => ['ge', 'le']];
+        $orderPiVar = tx_ttproducts_model_control::getPiVar('sys_products_orders');
+        $fieldPiVarArray = ['crdate' => ['ge', 'le']];
 
-		foreach ($fieldPiVarArray as $fieldPiVar => $piVarTypeArray) {
-			foreach ($piVarTypeArray as $piVarType) {
-				$markerkey = $orderMarker . '_' . strtoupper($fieldPiVar) . '_' . strtoupper($piVarType);
+        foreach ($fieldPiVarArray as $fieldPiVar => $piVarTypeArray) {
+            foreach ($piVarTypeArray as $piVarType) {
+                $markerkey = $orderMarker . '_' . strtoupper($fieldPiVar) . '_' . strtoupper($piVarType);
 
-				if (
-					strpos($frameWork, '###' . $markerkey . '_SELECT###') !== false
-				) {
-					$selectedKey = $piVars[$orderPiVar][$fieldPiVar][$piVarType] ?? 0;
-					$type = 'input';
-					$tagName = $prefix . '[' . $orderPiVar . ']' . '[' . $fieldPiVar . ']' . '[' . $piVarType . ']';
+                if (
+                    strpos($frameWork, '###' . $markerkey . '_SELECT###') !== false
+                ) {
+                    $selectedKey = $piVars[$orderPiVar][$fieldPiVar][$piVarType] ?? 0;
+                    $type = 'input';
+                    $tagName = $prefix . '[' . $orderPiVar . ']' . '[' . $fieldPiVar . ']' . '[' . $piVarType . ']';
 
-					$htmlTag = tx_ttproducts_form_div::createTag(
-						$type,
-						$tagName,
-						$selectedKey,
-						'id="' . $idPrefix . '-' . str_replace('_', '-', strtolower($markerkey)) . '" class="dateSelector"'
-					);
-					$markerArray['###' . $markerkey . '_SELECT###'] = $htmlTag;
-				}
-			}
-		}
+                    $htmlTag = tx_ttproducts_form_div::createTag(
+                        $type,
+                        $tagName,
+                        $selectedKey,
+                        'id="' . $idPrefix . '-' . str_replace('_', '-', strtolower($markerkey)) . '" class="dateSelector"'
+                    );
+                    $markerArray['###' . $markerkey . '_SELECT###'] = $htmlTag;
+                }
+            }
+        }
 
-		if ($bUnlock || $feusers_uid) {
+        if ($bUnlock || $feusers_uid) {
 
-			$orderBy = $tableconf['orderBy'];
-			if ($orderBy == '') {
-				$orderBy = 'crdate';
-			}
+            $orderBy = $tableconf['orderBy'];
+            if ($orderBy == '') {
+                $orderBy = 'crdate';
+            }
 
-			if ($feusers_uid) {
-				$res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('name ', 'fe_users', 'uid=' . intval($feusers_uid));
-				$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1);
-				$GLOBALS['TYPO3_DB']->sql_free_result($res1);
-				$this->setFeuserMarker ($feuserMarker, $row, $markerArray);
+            if ($feusers_uid) {
+                $res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('name ', 'fe_users', 'uid=' . intval($feusers_uid));
+                $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1);
+                $GLOBALS['TYPO3_DB']->sql_free_result($res1);
+                $this->setFeuserMarker ($feuserMarker, $row, $markerArray);
 
-				$markerArray['###' . $fegroupMarker . '_TITLE###'] = '';
-			}
+                $markerArray['###' . $fegroupMarker . '_TITLE###'] = '';
+            }
 
-			if ($fegroups_uid) {
-				$res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('title ', 'fe_groups', 'uid="' . intval($fegroups_uid) . '"');
-				if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1)) {
-					$fegroupName = $row['title'];
-				}
-				$GLOBALS['TYPO3_DB']->sql_free_result($res1);
+            if ($fegroups_uid) {
+                $res1 = $GLOBALS['TYPO3_DB']->exec_SELECTquery('title ', 'fe_groups', 'uid="' . intval($fegroups_uid) . '"');
+                if ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1)) {
+                    $fegroupName = $row['title'];
+                }
+                $GLOBALS['TYPO3_DB']->sql_free_result($res1);
 
-				$markerArray['###' . $feuserMarker . '_NUMBER###'] = '';
-				$markerArray['###' . $feuserMarker . '_NAME###'] = '';
-				$markerArray['###' . $fegroupMarker . '_TITLE###'] = $fegroupName;
-			}
+                $markerArray['###' . $feuserMarker . '_NUMBER###'] = '';
+                $markerArray['###' . $feuserMarker . '_NAME###'] = '';
+                $markerArray['###' . $fegroupMarker . '_TITLE###'] = $fegroupName;
+            }
 
-			if ($feusers_uid || $fegroups_uid) {
+            if ($feusers_uid || $fegroups_uid) {
 
-				$where = '';
+                $where = '';
 
-				if ($feusers_uid) {
-					$where = 'feusers_uid = ' . intval($feusers_uid);
-					$from = '';
-				} else if ($fegroups_uid) {
-					$orderAlias = $orderObj->getAlias();
-					$from = $functablename . ' ' . $orderAlias . ' LEFT JOIN fe_users ON ' . $orderAlias . '.feusers_uid = fe_users.uid';
-					$where = 'fe_users.usergroup = ' . $fegroups_uid;
-				}
-				$whereArray = $piVars[tx_ttproducts_model_control::getPiVar($functablename)] ?? '';
+                if ($feusers_uid) {
+                    $where = 'feusers_uid = ' . intval($feusers_uid);
+                    $from = '';
+                } else if ($fegroups_uid) {
+                    $orderAlias = $orderObj->getAlias();
+                    $from = $functablename . ' ' . $orderAlias . ' LEFT JOIN fe_users ON ' . $orderAlias . '.feusers_uid = fe_users.uid';
+                    $where = 'fe_users.usergroup = ' . $fegroups_uid;
+                }
+                $whereArray = $piVars[tx_ttproducts_model_control::getPiVar($functablename)] ?? '';
 
-				if (is_array($whereArray)) {
-					foreach ($whereArray as $field => $value) {
-						if (is_array($value)) {
-							foreach ($value as $comparator => $comparand) {
-								$sqlOperator = '';
-								$comparator = tx_ttproducts_sql::transformComparator($comparator);
-								if ($comparand) {
-									$tablename = $itemTable->getTableObj()->getName();
-									$whereField =
-										tx_ttproducts_sql::getWhere4Field(
-											$tablename,
-											$field,
-											$comparator,
-											$comparand
-										);
-									if ($whereField !== false) {
+                if (is_array($whereArray)) {
+                    foreach ($whereArray as $field => $value) {
+                        if (is_array($value)) {
+                            foreach ($value as $comparator => $comparand) {
+                                $sqlOperator = '';
+                                $comparator = tx_ttproducts_sql::transformComparator($comparator);
+                                if ($comparand) {
+                                    $tablename = $itemTable->getTableObj()->getName();
+                                    $whereField =
+                                        tx_ttproducts_sql::getWhere4Field(
+                                            $tablename,
+                                            $field,
+                                            $comparator,
+                                            $comparand
+                                        );
+                                    if ($whereField !== false) {
 
-										$where .= $whereField;
-									}
-								}
-							}
-						} else {
-							$where .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $itemTable->getTableObj()->getName());
-						}
-					}
-				}
+                                        $where .= $whereField;
+                                    }
+                                }
+                            }
+                        } else {
+                            $where .= ' AND ' . $field . '=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($value, $itemTable->getTableObj()->getName());
+                        }
+                    }
+                }
 
-				$where .= $orderObj->getTableObj()->enableFields();
-				$whereProducts = '';
-				$where = $orderObj->getTableObj()->transformWhere($where);
-				$orderBy = $orderObj->getTableObj()->transformOrderby($orderBy);
+                $where .= $orderObj->getTableObj()->enableFields();
+                $whereProducts = '';
+                $where = $orderObj->getTableObj()->transformWhere($where);
+                $orderBy = $orderObj->getTableObj()->transformOrderby($orderBy);
 
-				switch ($viewType) {
-					case 0:
-						$this->getOrderMarkerSubpartArrays(
-							$pibaseClass,
-							$templateCode,
-							$frameWork,
-							$theCode,
-							$pageAsCategory,
-							$pid,
-							$pid_list,
-							$from,
-							$where,
-							$orderBy,
-							$markerArray,
-							$subpartArray,
-							$error_code
-						);
-						$subpartArray['###ORDER_PRODUCT_LIST###'] = '';
-						break;
-					case 1:
-						$this->getProductMarkerSubpartArrays(
-							$pibaseClass,
-							$templateCode,
-							$frameWork,
-							'ITEM_LIST_TEMPLATE',
-							$theCode,
-							$pageAsCategory,
-							$pid,
-							$pid_list,
-							$from,
-							$where,
-							$orderBy,
-							$whereProducts,
-							false,
-							$hiddenFields,
-							$markerArray,
-							$subpartArray,
-							$error_code
-						);
-						$wrappedSubpartArray['###ORDER_PRODUCT_LIST###'] = '';
-						$subpartArray['###ORDER_LIST###'] = '';
-						$subpartArray['###ORDER_NOROWS###'] = '';
-						break;
-					default:
-						break;
-				}
-			} else {
-				$markerArray['###' . $feuserMarker . '_NUMBER###'] = 0;
-				$markerArray['###' . $feuserMarker . '_NAME###'] = '';
-				$markerArray['###' . $fegroupMarker . '_TITLE###'] = '';
-				$subpartArray['###ORDER_LIST###'] = '';
-				$subpartArray['###ORDER_NOROWS###'] = '';
-				$subpartArray['###ORDER_PRODUCT_LIST###'] = '';
-			}
-		}
-		$markerArray['###HIDDENFIELDS###'] = $hiddenFields;
-		$content = $templateService->substituteMarkerArrayCached(
-			$frameWork,
-			$markerArray,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
+                switch ($viewType) {
+                    case 0:
+                        $this->getOrderMarkerSubpartArrays(
+                            $pibaseClass,
+                            $templateCode,
+                            $frameWork,
+                            $theCode,
+                            $pageAsCategory,
+                            $pid,
+                            $pid_list,
+                            $from,
+                            $where,
+                            $orderBy,
+                            $markerArray,
+                            $subpartArray,
+                            $error_code
+                        );
+                        $subpartArray['###ORDER_PRODUCT_LIST###'] = '';
+                        break;
+                    case 1:
+                        $this->getProductMarkerSubpartArrays(
+                            $pibaseClass,
+                            $templateCode,
+                            $frameWork,
+                            'ITEM_LIST_TEMPLATE',
+                            $theCode,
+                            $pageAsCategory,
+                            $pid,
+                            $pid_list,
+                            $from,
+                            $where,
+                            $orderBy,
+                            $whereProducts,
+                            false,
+                            $hiddenFields,
+                            $markerArray,
+                            $subpartArray,
+                            $error_code
+                        );
+                        $wrappedSubpartArray['###ORDER_PRODUCT_LIST###'] = '';
+                        $subpartArray['###ORDER_LIST###'] = '';
+                        $subpartArray['###ORDER_NOROWS###'] = '';
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                $markerArray['###' . $feuserMarker . '_NUMBER###'] = 0;
+                $markerArray['###' . $feuserMarker . '_NAME###'] = '';
+                $markerArray['###' . $fegroupMarker . '_TITLE###'] = '';
+                $subpartArray['###ORDER_LIST###'] = '';
+                $subpartArray['###ORDER_NOROWS###'] = '';
+                $subpartArray['###ORDER_PRODUCT_LIST###'] = '';
+            }
+        }
+        $markerArray['###HIDDENFIELDS###'] = $hiddenFields;
+        $content = $templateService->substituteMarkerArrayCached(
+            $frameWork,
+            $markerArray,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
 
-		return $content;
-	}
+        return $content;
+    }
 
 
 // download
-	public function printDownloadView (
-		$pibaseClass,
-		$templateCode,
-		$theCode,
-		$pid_list,
-		$recursive,
-		$pageAsCategory,
-		$updateCode,
-		$bIsAllowed,
-		$bValidUpdateCode,
-		$trackingCode,
+    public function printDownloadView (
+        $pibaseClass,
+        $templateCode,
+        $theCode,
+        $pid_list,
+        $recursive,
+        $pageAsCategory,
+        $updateCode,
+        $bIsAllowed,
+        $bValidUpdateCode,
+        $trackingCode,
         $onlyProductsWithFalOrders,
-		&$error_code
-	) {
+        &$error_code
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$orderObj = $this->getModelObj();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $orderObj = $this->getModelObj();
 
-		self::init2(
-			$bValidUpdateCode,
-			$theCode,
-			$pid_list,
-			$recursive,
-			$orderObj,
-			$cnf,
-			$itemTable,
-			$functablename,
-			$tableconf,
-			$feusers_uid,
-			$validFeUser,
-			$pid,
-			$markerArray,
-			$orderMarker,
-			$feuserMarker,
-			$piVars,
-			$prefix
-		);
-		$subpartArray = [];
-		$wrappedSubpartArray = [];
+        self::init2(
+            $bValidUpdateCode,
+            $theCode,
+            $pid_list,
+            $recursive,
+            $orderObj,
+            $cnf,
+            $itemTable,
+            $functablename,
+            $tableconf,
+            $feusers_uid,
+            $validFeUser,
+            $pid,
+            $markerArray,
+            $orderMarker,
+            $feuserMarker,
+            $piVars,
+            $prefix
+        );
+        $subpartArray = [];
+        $wrappedSubpartArray = [];
 
-		tx_ttproducts_admin_control_view::getSubpartArrays(
-			$bIsAllowed,
-			$bValidUpdateCode,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
-		$hiddenFields = tx_ttproducts_admin_control_view::getHiddenField($updateCode);
-		$markerArray['###ADMIN_HIDDENFIELDS###'] = $hiddenFields;
-		$markerArray['###TRACKING_NUMBER###'] =  $trackingCode;
-		$subPartMarker = 'DOWNLOAD_LIST_TEMPLATE';
+        tx_ttproducts_admin_control_view::getSubpartArrays(
+            $bIsAllowed,
+            $bValidUpdateCode,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
+        $hiddenFields = tx_ttproducts_admin_control_view::getHiddenField($updateCode);
+        $markerArray['###ADMIN_HIDDENFIELDS###'] = $hiddenFields;
+        $markerArray['###TRACKING_NUMBER###'] =  $trackingCode;
+        $subPartMarker = 'DOWNLOAD_LIST_TEMPLATE';
 
-		$frameWork = $this->getFrameWork(
-			$templateCode,
-			$subPartMarker,
-			$bValidUpdateCode,
-			$trackingCode,
-			true,
-			$feusers_uid,
-			$validFeUser,
-			$error_code
-		);
+        $frameWork = $this->getFrameWork(
+            $templateCode,
+            $subPartMarker,
+            $bValidUpdateCode,
+            $trackingCode,
+            true,
+            $feusers_uid,
+            $validFeUser,
+            $error_code
+        );
 
-		if (!$frameWork) {
-			return '';
-		}
+        if (!$frameWork) {
+            return '';
+        }
 
-		$bUnlock = false;
+        $bUnlock = false;
 
-		if ($bIsAllowed) {
-			$bUnlock = true;
-		}
+        if ($bIsAllowed) {
+            $bUnlock = true;
+        }
 
-		if ($bUnlock && $bValidUpdateCode) {
+        if ($bUnlock && $bValidUpdateCode) {
 
-			$markerKey = $feuserMarker . '_SELECT';
+            $markerKey = $feuserMarker . '_SELECT';
 
-			if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
+            if (strpos($frameWork, '###' . $markerKey . '###') !== false) {
 
-				$markerArray['###' . $markerKey . '###'] =
-					$this->processFeuserSelect(
-						$piVars,
-						$prefix,
-						$tableconf,
-						$pid_list,
-						$feusers_uid,
-						$hiddenFields
-					);
-			}
-		}
+                $markerArray['###' . $markerKey . '###'] =
+                    $this->processFeuserSelect(
+                        $piVars,
+                        $prefix,
+                        $tableconf,
+                        $pid_list,
+                        $feusers_uid,
+                        $hiddenFields
+                    );
+            }
+        }
 
-		if ($feusers_uid || $trackingCode != '') {
+        if ($feusers_uid || $trackingCode != '') {
 
-			$where = '';
-			if ($feusers_uid) {
-				$res1 =
-					$GLOBALS['TYPO3_DB']->exec_SELECTquery(
-						'name ',
-						'fe_users',
-						'uid=' . intval($feusers_uid)
-					);
-				$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1);
-				$GLOBALS['TYPO3_DB']->sql_free_result($res1);
+            $where = '';
+            if ($feusers_uid) {
+                $res1 =
+                    $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                        'name ',
+                        'fe_users',
+                        'uid=' . intval($feusers_uid)
+                    );
+                $row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res1);
+                $GLOBALS['TYPO3_DB']->sql_free_result($res1);
 
-				$this->setFeuserMarker(
-					$feuserMarker,
-					$row,
-					$markerArray
-				);
-			}
+                $this->setFeuserMarker(
+                    $feuserMarker,
+                    $row,
+                    $markerArray
+                );
+            }
 
-			$from = '';
-			$orderBy = 'sys_products_orders.uid DESC';
+            $from = '';
+            $orderBy = 'sys_products_orders.uid DESC';
 
-			$orderObj->getDownloadWhereClauses(
-				$feusers_uid,
-				$trackingCode,
-				$where,
-				$whereProducts
-			);
+            $orderObj->getDownloadWhereClauses(
+                $feusers_uid,
+                $trackingCode,
+                $where,
+                $whereProducts
+            );
 
-			$this->getProductMarkerSubpartArrays(
-				$pibaseClass,
-				$templateCode,
-				$frameWork,
-				'ITEM_LIST_DOWNLOADS_TEMPLATE',
-				$theCode,
-				$pageAsCategory,
-				$pid,
-				$pid_list,
-				$from,
-				$where,
-				$orderBy,
-				$whereProducts,
-				$onlyProductsWithFalOrders,
-				$hiddenFields,
-				$markerArray,
-				$subpartArray,
-				$error_code
-			);
+            $this->getProductMarkerSubpartArrays(
+                $pibaseClass,
+                $templateCode,
+                $frameWork,
+                'ITEM_LIST_DOWNLOADS_TEMPLATE',
+                $theCode,
+                $pageAsCategory,
+                $pid,
+                $pid_list,
+                $from,
+                $where,
+                $orderBy,
+                $whereProducts,
+                $onlyProductsWithFalOrders,
+                $hiddenFields,
+                $markerArray,
+                $subpartArray,
+                $error_code
+            );
 
-			$wrappedSubpartArray['###ORDER_PRODUCT_LIST###'] = '';
-		} else {
-			$markerArray['###' . $feuserMarker . '_NUMBER###'] = 0;
-			$markerArray['###' . $feuserMarker . '_NAME###'] = '';
-			$subpartArray['###ORDER_PRODUCT_LIST###'] = '';
-		}
+            $wrappedSubpartArray['###ORDER_PRODUCT_LIST###'] = '';
+        } else {
+            $markerArray['###' . $feuserMarker . '_NUMBER###'] = 0;
+            $markerArray['###' . $feuserMarker . '_NAME###'] = '';
+            $subpartArray['###ORDER_PRODUCT_LIST###'] = '';
+        }
 
-		$content = $templateService->substituteMarkerArrayCached(
-			$frameWork,
-			$markerArray,
-			$subpartArray,
-			$wrappedSubpartArray
-		);
+        $content = $templateService->substituteMarkerArrayCached(
+            $frameWork,
+            $markerArray,
+            $subpartArray,
+            $wrappedSubpartArray
+        );
 
-		return $content;
-	}
+        return $content;
+    }
 
 
 #######################
-	public function getSingleOrder ($row) {
+    public function getSingleOrder ($row) {
         $result = '';
-		$from = '';
-		$where = '';
-		$whereProducts = '';
-		$uids = $row['uid'];
-		$orderBy = '';
-		$pid_list = '';
-		$productRowArray = [];
-		$multiOrderArray = [];
+        $from = '';
+        $where = '';
+        $whereProducts = '';
+        $uids = $row['uid'];
+        $orderBy = '';
+        $pid_list = '';
+        $productRowArray = [];
+        $multiOrderArray = [];
 
-		$this->getModelObj()->getOrderedProducts(
-			$from,
-			$where,
-			$uids,
-			$orderBy,
-			$whereProducts,
-			false,
-			$pid_list,
-			$productRowArray,
-			$multiOrderArray
-		);
+        $this->getModelObj()->getOrderedProducts(
+            $from,
+            $where,
+            $uids,
+            $orderBy,
+            $whereProducts,
+            false,
+            $pid_list,
+            $productRowArray,
+            $multiOrderArray
+        );
 
         foreach ($productRowArray as $key => $productRow) {
             $result .= '<br>' . $productRow['uid'] . ': ' . $productRow['title'] . ' - ' . $productRow['subtitle'] . ' n. ' . $productRow['itemnumber'] . ' -> ' . $multiOrderArray[$key]['quantity'];

--- a/view/class.tx_ttproducts_orderaddress_view.php
+++ b/view/class.tx_ttproducts_orderaddress_view.php
@@ -42,166 +42,166 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 
 class tx_ttproducts_orderaddress_view extends tx_ttproducts_table_base_view {
-	public $dataArray; // array of read in frontend users
-	public $table;		 // object of the type tx_table_db
-	public $fields = [];
-	public $tableconf;
-	public $piVar = 'fe';
-	public $marker = 'FEUSER';
-	public $image;
+    public $dataArray; // array of read in frontend users
+    public $table;		 // object of the type tx_table_db
+    public $fields = [];
+    public $tableconf;
+    public $piVar = 'fe';
+    public $marker = 'FEUSER';
+    public $image;
 
 
 
-	public function getWrappedSubpartArray (
-		$viewTagArray,
-		$useBackPid,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	) {
-		$marker = 'FE_GROUP';
-		$markerLogin = 'LOGIN';
-		$markerNologin = 'NOLOGIN';
-		foreach ($viewTagArray as $tag => $value) {
-			if (strpos($tag, $marker . '_') === 0) {
-				$tagPart1 = substr($tag, strlen($marker . '_'));
-				$offset = strpos($tagPart1, '_TEMPLATE');
-				if ($offset > 0) {
-					$groupNumber = substr($tagPart1, 0, $offset);
+    public function getWrappedSubpartArray (
+        $viewTagArray,
+        $useBackPid,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    ) {
+        $marker = 'FE_GROUP';
+        $markerLogin = 'LOGIN';
+        $markerNologin = 'NOLOGIN';
+        foreach ($viewTagArray as $tag => $value) {
+            if (strpos($tag, $marker . '_') === 0) {
+                $tagPart1 = substr($tag, strlen($marker . '_'));
+                $offset = strpos($tagPart1, '_TEMPLATE');
+                if ($offset > 0) {
+                    $groupNumber = substr($tagPart1, 0, $offset);
 
-					if (MathUtility::canBeInterpretedAsInteger($groupNumber)) {
+                    if (MathUtility::canBeInterpretedAsInteger($groupNumber)) {
                         $comparatorNumber = $groupNumber;
                         if (!$comparatorNumber) {
                             $comparatorNumber = -1; // Also a logged in Front End User has group 0! 
                         }
 
-						if (GeneralUtility::inList($GLOBALS['TSFE']->gr_list, $comparatorNumber)) {
-							$wrappedSubpartArray['###FE_GROUP_' . $groupNumber . '_TEMPLATE###'] = ['', ''];
-						} else {
-							$subpartArray['###FE_GROUP_' . $groupNumber . '_TEMPLATE###'] = '';
-						}
-					}
-				}
-			} else if (strpos($tag, $markerLogin . '_') === 0) {
+                        if (GeneralUtility::inList($GLOBALS['TSFE']->gr_list, $comparatorNumber)) {
+                            $wrappedSubpartArray['###FE_GROUP_' . $groupNumber . '_TEMPLATE###'] = ['', ''];
+                        } else {
+                            $subpartArray['###FE_GROUP_' . $groupNumber . '_TEMPLATE###'] = '';
+                        }
+                    }
+                }
+            } else if (strpos($tag, $markerLogin . '_') === 0) {
                 if (
                     \JambageCom\Div2007\Utility\CompatibilityUtility::isLoggedIn() &&
                     isset($GLOBALS['TSFE']->fe_user->user) &&
                     is_array($GLOBALS['TSFE']->fe_user->user) &&
                     isset($GLOBALS['TSFE']->fe_user->user['uid'])
                 ) {
-					$wrappedSubpartArray['###LOGIN_TEMPLATE###'] = ['', ''];
-				} else {
-					$subpartArray['###LOGIN_TEMPLATE###'] = '';
-				}
-			} else if (strpos($tag, $markerNologin . '_') === 0) {
+                    $wrappedSubpartArray['###LOGIN_TEMPLATE###'] = ['', ''];
+                } else {
+                    $subpartArray['###LOGIN_TEMPLATE###'] = '';
+                }
+            } else if (strpos($tag, $markerNologin . '_') === 0) {
                 if (
                     isset($GLOBALS['TSFE']->fe_user->user) &&
                     is_array($GLOBALS['TSFE']->fe_user->user) &&
                     isset($GLOBALS['TSFE']->fe_user->user['uid'])
                 ) {
-					$subpartArray['###NOLOGIN_TEMPLATE###'] = '';
-				} else {
-					$wrappedSubpartArray['###NOLOGIN_TEMPLATE###'] = ['', ''];
-				}
+                    $subpartArray['###NOLOGIN_TEMPLATE###'] = '';
+                } else {
+                    $wrappedSubpartArray['###NOLOGIN_TEMPLATE###'] = ['', ''];
+                }
             }
-		}
+        }
 
-		if (
-			isset($viewTagArray['FE_CONDITION1_TRUE_TEMPLATE']) ||
-			isset($viewTagArray['FE_CONDITION1_FALSE_TEMPLATE'])
-		) {
-			if (
-				$this->getModelObj()->getCondition() ||
-				!$this->getModelObj()->getConditionRecord()
-			) {
-				$wrappedSubpartArray['###FE_CONDITION1_TRUE_TEMPLATE###'] = ['', ''];
-				$subpartArray['###FE_CONDITION1_FALSE_TEMPLATE###'] = '';
-			} else {
-				$wrappedSubpartArray['###FE_CONDITION1_FALSE_TEMPLATE###'] = ['', ''];
-				$subpartArray['###FE_CONDITION1_TRUE_TEMPLATE###'] = '';
-			}
-		}
-	}
+        if (
+            isset($viewTagArray['FE_CONDITION1_TRUE_TEMPLATE']) ||
+            isset($viewTagArray['FE_CONDITION1_FALSE_TEMPLATE'])
+        ) {
+            if (
+                $this->getModelObj()->getCondition() ||
+                !$this->getModelObj()->getConditionRecord()
+            ) {
+                $wrappedSubpartArray['###FE_CONDITION1_TRUE_TEMPLATE###'] = ['', ''];
+                $subpartArray['###FE_CONDITION1_FALSE_TEMPLATE###'] = '';
+            } else {
+                $wrappedSubpartArray['###FE_CONDITION1_FALSE_TEMPLATE###'] = ['', ''];
+                $subpartArray['###FE_CONDITION1_TRUE_TEMPLATE###'] = '';
+            }
+        }
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getAddressMarkerArray (
-		$functablename,
-		$row,
-		&$markerArray,
-		$bSelect,
-		$type
-	) {
-		$fieldOutputArray = [];
-		$modelObj = $this->getModelObj();
-		$selectInfoFields = $modelObj->getSelectInfoFields();
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getAddressMarkerArray (
+        $functablename,
+        $row,
+        &$markerArray,
+        $bSelect,
+        $type
+    ) {
+        $fieldOutputArray = [];
+        $modelObj = $this->getModelObj();
+        $selectInfoFields = $modelObj->getSelectInfoFields();
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
 
-		if ($bSelect) {
-			foreach ($selectInfoFields as $field) {
-				$tablename = $modelObj->getTCATableFromField($field);
-				$fieldOutputArray[$field] =
-					tx_ttproducts_form_div::createSelect(
-						$languageObj,
-						$GLOBALS['TCA'][$tablename]['columns'][$field]['config']['items'],
-						'recs[' . $type . '][' . $field . ']',
-						(is_array($row) && isset($row[$field]) ? $row[$field] : ''),
-						true,
-						true,
-						[],
-						'select',
-						['id' => 'field_' . $type . '_' . $field] /* Add ID for field to be able to use labels. */
-					);
-			}
-		} else {
-			foreach ($selectInfoFields as $field) {
-				$tablename = $modelObj->getTCATableFromField($field);
-				$itemConfig = $GLOBALS['TCA'][$tablename]['columns'][$field]['config']['items'];
+        if ($bSelect) {
+            foreach ($selectInfoFields as $field) {
+                $tablename = $modelObj->getTCATableFromField($field);
+                $fieldOutputArray[$field] =
+                    tx_ttproducts_form_div::createSelect(
+                        $languageObj,
+                        $GLOBALS['TCA'][$tablename]['columns'][$field]['config']['items'],
+                        'recs[' . $type . '][' . $field . ']',
+                        (is_array($row) && isset($row[$field]) ? $row[$field] : ''),
+                        true,
+                        true,
+                        [],
+                        'select',
+                        ['id' => 'field_' . $type . '_' . $field] /* Add ID for field to be able to use labels. */
+                    );
+            }
+        } else {
+            foreach ($selectInfoFields as $field) {
+                $tablename = $modelObj->getTCATableFromField($field);
+                $itemConfig = $GLOBALS['TCA'][$tablename]['columns'][$field]['config']['items'];
 
-				if (
+                if (
                     isset($row[$field]) &&
-					$row[$field] != '' &&
-					isset($itemConfig) &&
-					is_array($itemConfig)
-				) {
-					$tcaValue = '';
-					foreach ($itemConfig as $subItemConfig) {
-						if (
-							isset($subItemConfig) &&
-							is_array($subItemConfig) &&
-							$subItemConfig['1'] == $row[$field]
-						) {
-							$tcaValue = $subItemConfig['0'];
-							break;
-						}
-					}
+                    $row[$field] != '' &&
+                    isset($itemConfig) &&
+                    is_array($itemConfig)
+                ) {
+                    $tcaValue = '';
+                    foreach ($itemConfig as $subItemConfig) {
+                        if (
+                            isset($subItemConfig) &&
+                            is_array($subItemConfig) &&
+                            $subItemConfig['1'] == $row[$field]
+                        ) {
+                            $tcaValue = $subItemConfig['0'];
+                            break;
+                        }
+                    }
 
-					$tmp = $languageObj->splitLabel($tcaValue);
-					$fieldOutputArray[$field] = htmlspecialchars(
+                    $tmp = $languageObj->splitLabel($tcaValue);
+                    $fieldOutputArray[$field] = htmlspecialchars(
                         $languageObj->getLabel(
-							$tmp
-						)
-					);
-				} else {
-					$fieldOutputArray[$field] = '';
-				}
-			}
-		}
+                            $tmp
+                        )
+                    );
+                } else {
+                    $fieldOutputArray[$field] = '';
+                }
+            }
+        }
 
-		foreach ($fieldOutputArray as $field => $fieldOutput) {
-			$markerkey = '###' . ($type == 'personinfo' ? 'PERSON' : 'DELIVERY') . '_'. strtoupper($field) . '###';
-			$markerArray[$markerkey] = $fieldOutput;
-		}
-	} // getAddressMarkerArray
+        foreach ($fieldOutputArray as $field => $fieldOutput) {
+            $markerkey = '###' . ($type == 'personinfo' ? 'PERSON' : 'DELIVERY') . '_'. strtoupper($field) . '###';
+            $markerArray[$markerkey] = $fieldOutput;
+        }
+    } // getAddressMarkerArray
 }
 

--- a/view/class.tx_ttproducts_page_view.php
+++ b/view/class.tx_ttproducts_page_view.php
@@ -41,41 +41,41 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_page_view extends tx_ttproducts_category_base_view {
-	var $noteArray = []; 	// array of pages with notes
-	var $piVar = 'pid';
-	var $pageAsCategory;		// > 0 if pages are used as categories
+    var $noteArray = []; 	// array of pages with notes
+    var $piVar = 'pid';
+    var $pageAsCategory;		// > 0 if pages are used as categories
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 		 			for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$category,
-		$pid,
-		$imageNum=0,
-		$imageRenderObj = 'image',
-		&$viewCatTagArray,
-		$forminfoArray = [],
-		$pageAsCategory = 0,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$id,
-		$prefix,
-		$linkWrap = ''
-	) {
-		$functablename = $this->modelObj->getFuncTablename();
-		$row = $this->modelObj->get($pid);
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 		 			for the tt_producst record, $row
+     * @access private
+     */
+    public function getMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $category,
+        $pid,
+        $imageNum=0,
+        $imageRenderObj = 'image',
+        &$viewCatTagArray,
+        $forminfoArray = [],
+        $pageAsCategory = 0,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $id,
+        $prefix,
+        $linkWrap = ''
+    ) {
+        $functablename = $this->modelObj->getFuncTablename();
+        $row = $this->modelObj->get($pid);
 // 		$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
 //
 // 			// Get image
@@ -95,33 +95,33 @@ class tx_ttproducts_page_view extends tx_ttproducts_category_base_view {
 // 			$linkWrap
 // 		);
 
-		$pageCatTitle = htmlentities($row['title'], ENT_QUOTES, 'UTF-8');
-		$this->setMarkerArrayCatTitle($markerArray, $pageCatTitle, $prefix);
-		$markerArray['###' . $prefix . $this->marker . '_SUBTITLE###'] =
-			htmlentities(
-				$row['subtitle'],
-				ENT_QUOTES,
-				'UTF-8'
-			);
+        $pageCatTitle = htmlentities($row['title'], ENT_QUOTES, 'UTF-8');
+        $this->setMarkerArrayCatTitle($markerArray, $pageCatTitle, $prefix);
+        $markerArray['###' . $prefix . $this->marker . '_SUBTITLE###'] =
+            htmlentities(
+                $row['subtitle'],
+                ENT_QUOTES,
+                'UTF-8'
+            );
 
-		parent::getRowMarkerArray(
-			$functablename,
-			$row,
-			$markerKey,
-			$markerArray,
-			$variantFieldArray,
-			$variantMarkerArray,
-			$viewCatTagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			true,
-			'',
-			$imageNum,
-			$imageRenderObj,
-			$id,
-			$prefix
-		);
-	}
+        parent::getRowMarkerArray(
+            $functablename,
+            $row,
+            $markerKey,
+            $markerArray,
+            $variantFieldArray,
+            $variantMarkerArray,
+            $viewCatTagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            true,
+            '',
+            $imageNum,
+            $imageRenderObj,
+            $id,
+            $prefix
+        );
+    }
 }
 

--- a/view/class.tx_ttproducts_pdf_view.php
+++ b/view/class.tx_ttproducts_pdf_view.php
@@ -44,219 +44,219 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_pdf_view {
 
-	/**
-	 * generates the bill as a PDF file
-	 *
-	 * @param	string		reference to an item array with all the data of the item
-	 * @return	string / boolean	returns the absolute filename of the PDF bill or false
-	 * 		 			for the tt_producst record, $row
-	 * @access private
-	 */
-	public function generate (
-		$cObj,
-		$basketView,
-		$infoViewObj,
-		$templateCode,
-		$mainMarkerArray,
-		$itemArray,
-		$calculatedArray,
-		$orderArray,
-		$productRowArray,
-		$basketExtra,
-		$basketRecs,
-		$typeCode,
-		$generationConf,
-		$absFileName
-	) {
-		$result = false;
+    /**
+     * generates the bill as a PDF file
+     *
+     * @param	string		reference to an item array with all the data of the item
+     * @return	string / boolean	returns the absolute filename of the PDF bill or false
+     * 		 			for the tt_producst record, $row
+     * @access private
+     */
+    public function generate (
+        $cObj,
+        $basketView,
+        $infoViewObj,
+        $templateCode,
+        $mainMarkerArray,
+        $itemArray,
+        $calculatedArray,
+        $orderArray,
+        $productRowArray,
+        $basketExtra,
+        $basketRecs,
+        $typeCode,
+        $generationConf,
+        $absFileName
+    ) {
+        $result = false;
 
-		$infoArray = $infoViewObj->getInfoArray();
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $infoArray = $infoViewObj->getInfoArray();
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
 
-		if (
-			!empty($itemArray) &&
-			!empty($infoArray) &&
-			is_array($generationConf['handleLib.'])
-		) {
-			switch (strtoupper($generationConf['handleLib'])) {
-				case 'PHPWORD':
+        if (
+            !empty($itemArray) &&
+            !empty($infoArray) &&
+            is_array($generationConf['handleLib.'])
+        ) {
+            switch (strtoupper($generationConf['handleLib'])) {
+                case 'PHPWORD':
                     $pathsite = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/';
-					$itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
-					$path = $pathsite . $generationConf['handleLib.']['path'];
+                    $itemObj = GeneralUtility::makeInstance('tx_ttproducts_basketitem');
+                    $path = $pathsite . $generationConf['handleLib.']['path'];
 
- 					GeneralUtility::requireOnce ($path . '/src/PhpWord/Autoloader.php');
-					\PhpOffice\PhpWord\Autoloader::register();
+                    GeneralUtility::requireOnce ($path . '/src/PhpWord/Autoloader.php');
+                    \PhpOffice\PhpWord\Autoloader::register();
 
-					$phpWord = new \PhpOffice\PhpWord\PhpWord();
-					$templateFile = $pathsite . $generationConf['handleLib.']['template'];
+                    $phpWord = new \PhpOffice\PhpWord\PhpWord();
+                    $templateFile = $pathsite . $generationConf['handleLib.']['template'];
 
-					if (!file_exists($templateFile)) {
-						return false;
-					}
-					$nameInfo = pathinfo($templateFile);
-					$document = $phpWord->loadTemplate($templateFile);
-					$document->setValue('date', date('d.m.Y')); // On section/content
-					foreach ($infoArray['billing'] as $field => $value) {
-						$document->setValue('billing_' . $field, $value);
-					}
+                    if (!file_exists($templateFile)) {
+                        return false;
+                    }
+                    $nameInfo = pathinfo($templateFile);
+                    $document = $phpWord->loadTemplate($templateFile);
+                    $document->setValue('date', date('d.m.Y')); // On section/content
+                    foreach ($infoArray['billing'] as $field => $value) {
+                        $document->setValue('billing_' . $field, $value);
+                    }
 
                     $document->setValue('trackingcode', $orderArray['tracking_code']);
                     $trackingParts = explode('-', $orderArray['tracking_code']);
                     $document->setValue('trackingno', $trackingParts['0']);
-					$document->setValue('billno', $orderArray['bill_no']); // On section/content
-					$document->setValue('cnum', $infoArray['billing']['cnum']); // On section/content
+                    $document->setValue('billno', $orderArray['bill_no']); // On section/content
+                    $document->setValue('cnum', $infoArray['billing']['cnum']); // On section/content
 
-					$lineCount = 0;
-					// loop over all items in the basket indexed by sorting text
-					foreach ($itemArray as $sort => $actItemArray) {
-						$lineCount += count($actItemArray);
-					}
-					$document->cloneRow('article_title', $lineCount);
+                    $lineCount = 0;
+                    // loop over all items in the basket indexed by sorting text
+                    foreach ($itemArray as $sort => $actItemArray) {
+                        $lineCount += count($actItemArray);
+                    }
+                    $document->cloneRow('article_title', $lineCount);
 
-					$lineCount = 0;
-					// loop over all items in the basket indexed by sorting text
-					foreach ($itemArray as $sort => $actItemArray) {
-						foreach ($actItemArray as $k1 => $actItem) {
-							$extArray = [];
-							$lineCount++;
-							$row = $actItem['rec'];
+                    $lineCount = 0;
+                    // loop over all items in the basket indexed by sorting text
+                    foreach ($itemArray as $sort => $actItemArray) {
+                        foreach ($actItemArray as $k1 => $actItem) {
+                            $extArray = [];
+                            $lineCount++;
+                            $row = $actItem['rec'];
 
-							if (
-								isset($row['ext']) &&
-								is_array($row['ext'])
-							) {
-								$extArray = $row['ext'];
-							} else {
-								continue;
-							}
-							$outputRow = $row;
+                            if (
+                                isset($row['ext']) &&
+                                is_array($row['ext'])
+                            ) {
+                                $extArray = $row['ext'];
+                            } else {
+                                continue;
+                            }
+                            $outputRow = $row;
 
-							if (
-								isset($extArray['mergeArticles']) &&
-								is_array($extArray['mergeArticles'])
-							) {
-								$outputRow = $extArray['mergeArticles'];
-							}
-							if (
-								isset($extArray['records']) &&
-								is_array($extArray['records'])
-							) {
-								$newTitleArray = [];
-								$externalRowArray = $extArray['records'];
+                            if (
+                                isset($extArray['mergeArticles']) &&
+                                is_array($extArray['mergeArticles'])
+                            ) {
+                                $outputRow = $extArray['mergeArticles'];
+                            }
+                            if (
+                                isset($extArray['records']) &&
+                                is_array($extArray['records'])
+                            ) {
+                                $newTitleArray = [];
+                                $externalRowArray = $extArray['records'];
 
-								foreach ($externalRowArray as $tablename => $externalRow) {
-									$newTitleArray[] = $externalRow['title'];
-								}
-								$outputRow['title'] = implode(' | ', $newTitleArray);
-							}
+                                foreach ($externalRowArray as $tablename => $externalRow) {
+                                    $newTitleArray[] = $externalRow['title'];
+                                }
+                                $outputRow['title'] = implode(' | ', $newTitleArray);
+                            }
 
-							foreach ($outputRow as $field => $value) {
-								if (
-									$field != 'ext' &&
-									!strpos($field, '_uid') &&
-									!strpos($field, '_id') &&
-									is_string($value)
-								) {
-									if (strpos($field, 'price') !== false) {
-										$value = $priceViewObj->priceFormat($value);
-									}
-									$document->setValue('article_' . $field . '#' . $lineCount, $value);
-								}
-							}
-							$quantity = $itemObj->getQuantity($actItem);
-							$document->setValue('count#' . $lineCount, $quantity);
+                            foreach ($outputRow as $field => $value) {
+                                if (
+                                    $field != 'ext' &&
+                                    !strpos($field, '_uid') &&
+                                    !strpos($field, '_id') &&
+                                    is_string($value)
+                                ) {
+                                    if (strpos($field, 'price') !== false) {
+                                        $value = $priceViewObj->priceFormat($value);
+                                    }
+                                    $document->setValue('article_' . $field . '#' . $lineCount, $value);
+                                }
+                            }
+                            $quantity = $itemObj->getQuantity($actItem);
+                            $document->setValue('count#' . $lineCount, $quantity);
 
-							$document->setValue('price1#' . $lineCount, $priceViewObj->priceFormat($actItem['priceTax']));
-							$document->setValue('price1total#' . $lineCount, $priceViewObj->priceFormat($actItem['priceTax'] * $quantity));
-						}
-					}
+                            $document->setValue('price1#' . $lineCount, $priceViewObj->priceFormat($actItem['priceTax']));
+                            $document->setValue('price1total#' . $lineCount, $priceViewObj->priceFormat($actItem['priceTax'] * $quantity));
+                        }
+                    }
 
- 					$document->setValue('pricenotaxtotal', $priceViewObj->priceFormat($calculatedArray['priceNoTax']['total']['ALL']));
+                    $document->setValue('pricenotaxtotal', $priceViewObj->priceFormat($calculatedArray['priceNoTax']['total']['ALL']));
 
-					if (
-						isset($calculatedArray['priceNoTax']) &&
-						is_array($calculatedArray['priceNoTax']) &&
-						isset($calculatedArray['priceNoTax']['sametaxtotal']) &&
-						is_array($calculatedArray['priceNoTax']['sametaxtotal']) &&
-						!empty($calculatedArray['priceNoTax']['sametaxtotal'])
-					) {
-						$lineCount = 0;
-						foreach ($calculatedArray['priceNoTax']['sametaxtotal'] as $countryCode => $taxRow) {
-							if ($countryCode == 'ALL' || !is_array($taxRow)) {
-								continue;
-							}
-							$lineCount += count($taxRow);
-						}
-						$document->cloneRow('onlytax_line', $lineCount);
+                    if (
+                        isset($calculatedArray['priceNoTax']) &&
+                        is_array($calculatedArray['priceNoTax']) &&
+                        isset($calculatedArray['priceNoTax']['sametaxtotal']) &&
+                        is_array($calculatedArray['priceNoTax']['sametaxtotal']) &&
+                        !empty($calculatedArray['priceNoTax']['sametaxtotal'])
+                    ) {
+                        $lineCount = 0;
+                        foreach ($calculatedArray['priceNoTax']['sametaxtotal'] as $countryCode => $taxRow) {
+                            if ($countryCode == 'ALL' || !is_array($taxRow)) {
+                                continue;
+                            }
+                            $lineCount += count($taxRow);
+                        }
+                        $document->cloneRow('onlytax_line', $lineCount);
 
-						$lineCount = 0;
-						foreach ($calculatedArray['priceNoTax']['sametaxtotal'] as $countryCode => $taxRow) {
-							if ($countryCode == 'ALL') {
-								continue;
-							}
-							foreach ($taxRow as $tax => $value) {
-								$lineCount++;
-								$document->setValue('onlytax_line#' . $lineCount, '');
-								$document->setValue('country#' . $lineCount, $countryCode);
-								$document->setValue('onlytax#' . $lineCount, $tax . ' %');
-								$taxValue = $value * ($tax / 100);
-								$document->setValue('priceonlytaxtotal#' . $lineCount, $priceViewObj->priceFormat($taxValue));
-							}
-						}
-					}
+                        $lineCount = 0;
+                        foreach ($calculatedArray['priceNoTax']['sametaxtotal'] as $countryCode => $taxRow) {
+                            if ($countryCode == 'ALL') {
+                                continue;
+                            }
+                            foreach ($taxRow as $tax => $value) {
+                                $lineCount++;
+                                $document->setValue('onlytax_line#' . $lineCount, '');
+                                $document->setValue('country#' . $lineCount, $countryCode);
+                                $document->setValue('onlytax#' . $lineCount, $tax . ' %');
+                                $taxValue = $value * ($tax / 100);
+                                $document->setValue('priceonlytaxtotal#' . $lineCount, $priceViewObj->priceFormat($taxValue));
+                            }
+                        }
+                    }
 
-					$document->setValue('pricetaxtotal', $priceViewObj->priceFormat($calculatedArray['priceTax']['total']['ALL']));
-					$typeArray = ['payment', 'shipping'];
-					$fieldArray = ['title', 'price'];
-					foreach ($typeArray as $type) {
-						foreach ($fieldArray as $field) {
-							$value = '';
-							if (
-								isset($basketExtra[$type . '.']) &&
-								isset($basketExtra[$type . '.'][$field])
-							) {
-								$value = $basketExtra[$type . '.'][$field];
-							}
+                    $document->setValue('pricetaxtotal', $priceViewObj->priceFormat($calculatedArray['priceTax']['total']['ALL']));
+                    $typeArray = ['payment', 'shipping'];
+                    $fieldArray = ['title', 'price'];
+                    foreach ($typeArray as $type) {
+                        foreach ($fieldArray as $field) {
+                            $value = '';
+                            if (
+                                isset($basketExtra[$type . '.']) &&
+                                isset($basketExtra[$type . '.'][$field])
+                            ) {
+                                $value = $basketExtra[$type . '.'][$field];
+                            }
 
-							if ($field == 'price') {
-								$value = $priceViewObj->priceFormat($value);
-							}
+                            if ($field == 'price') {
+                                $value = $priceViewObj->priceFormat($value);
+                            }
 
-							$document->setValue($type . '_' . $field, $value);
-						}
-					}
-					$header = $generationConf['handleLib.']['rendererLibrary.']['marks.']['header'];
-					$headerArray = explode(PHP_EOL, $header);
+                            $document->setValue($type . '_' . $field, $value);
+                        }
+                    }
+                    $header = $generationConf['handleLib.']['rendererLibrary.']['marks.']['header'];
+                    $headerArray = explode(PHP_EOL, $header);
 
-					foreach ($headerArray as $k => $header) {
-						$document->setValue('header_' . ($k + 1), $header);
-					}
+                    foreach ($headerArray as $k => $header) {
+                        $document->setValue('header_' . ($k + 1), $header);
+                    }
 
-					$name = $nameInfo['dirname'] . '/' . $nameInfo['filename'] . '-out'. '.docx';
-					$document->saveAs($name);
-					GeneralUtility::requireOnce ($path . '/samples/Sample_Footer.php');
- 					$phpWord = \PhpOffice\PhpWord\IOFactory::load($name);
+                    $name = $nameInfo['dirname'] . '/' . $nameInfo['filename'] . '-out'. '.docx';
+                    $document->saveAs($name);
+                    GeneralUtility::requireOnce ($path . '/samples/Sample_Footer.php');
+                    $phpWord = \PhpOffice\PhpWord\IOFactory::load($name);
 
-					if (is_array($generationConf['handleLib.']['rendererLibrary.'])) {
+                    if (is_array($generationConf['handleLib.']['rendererLibrary.'])) {
 
                         $pathsite = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/';
-						$rendererName = \PhpOffice\PhpWord\Settings::PDF_RENDERER_DOMPDF;	//   PDF_RENDERER_MPDF PDF_RENDERER_TCPDF
-						$rendererLibraryPath = $pathsite . $generationConf['handleLib.']['rendererLibrary.']['path'];
-						\PhpOffice\PhpWord\Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
-						$objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'PDF');
-						$name = $nameInfo['dirname'] . '/' . $nameInfo['filename'] . '-' . $orderArray['tracking_code'] . '.pdf';
-						$objWriter->save($name);
+                        $rendererName = \PhpOffice\PhpWord\Settings::PDF_RENDERER_DOMPDF;	//   PDF_RENDERER_MPDF PDF_RENDERER_TCPDF
+                        $rendererLibraryPath = $pathsite . $generationConf['handleLib.']['rendererLibrary.']['path'];
+                        \PhpOffice\PhpWord\Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+                        $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'PDF');
+                        $name = $nameInfo['dirname'] . '/' . $nameInfo['filename'] . '-' . $orderArray['tracking_code'] . '.pdf';
+                        $objWriter->save($name);
 
-						$result = $name;
-					}
+                        $result = $name;
+                    }
 
-					break;
-				default:
-					break;
-			}
-		}
+                    break;
+                default:
+                    break;
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/view/class.tx_ttproducts_pdf_view_sample07.php
+++ b/view/class.tx_ttproducts_pdf_view_sample07.php
@@ -43,154 +43,154 @@
 
 class tx_ttproducts_pdf_view_sample07 {
 
-	/**
-	 * generates the bill as a PDF file
-	 *
-	 * @param	string		reference to an item array with all the data of the item
-	 * @return	string / boolean	returns the absolute filename of the PDF bill or false
-	 * 		 			for the tt_producst record, $row
-	 * @access private
-	 */
-	public function generate (
-		$cObj,
-		$basketView,
-		$infoViewObj,
-		$templateCode,
-		$mainMarkerArray,
-		$itemArray,
-		$calculatedArray,
-		$orderArray,
-		$productRowArray,
-		$basketExtra,
-		$basketRecs,
-		$typeCode,
-		$generationConf,
-		$absFileName
-	) {
-		$result = false;
+    /**
+     * generates the bill as a PDF file
+     *
+     * @param	string		reference to an item array with all the data of the item
+     * @return	string / boolean	returns the absolute filename of the PDF bill or false
+     * 		 			for the tt_producst record, $row
+     * @access private
+     */
+    public function generate (
+        $cObj,
+        $basketView,
+        $infoViewObj,
+        $templateCode,
+        $mainMarkerArray,
+        $itemArray,
+        $calculatedArray,
+        $orderArray,
+        $productRowArray,
+        $basketExtra,
+        $basketRecs,
+        $typeCode,
+        $generationConf,
+        $absFileName
+    ) {
+        $result = false;
 
-		if (is_array($generationConf['handleLib.'])) {
-			switch (strtoupper($generationConf['handleLib'])) {
-				case 'PHPWORD':
+        if (is_array($generationConf['handleLib.'])) {
+            switch (strtoupper($generationConf['handleLib'])) {
+                case 'PHPWORD':
                     $pathsite = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/';
 
-					$path = $pathsite . $generationConf['handleLib.']['path'];
+                    $path = $pathsite . $generationConf['handleLib.']['path'];
 
- 					require_once($path . '/src/PhpWord/Autoloader.php');
-					\PhpOffice\PhpWord\Autoloader::register();
+                    require_once($path . '/src/PhpWord/Autoloader.php');
+                    \PhpOffice\PhpWord\Autoloader::register();
 
-					$phpWord = new \PhpOffice\PhpWord\PhpWord();
+                    $phpWord = new \PhpOffice\PhpWord\PhpWord();
 
-					$document = $phpWord->loadTemplate($path . '/samples/resources/Sample_07_TemplateCloneRow.docx');
+                    $document = $phpWord->loadTemplate($path . '/samples/resources/Sample_07_TemplateCloneRow.docx');
 
-					// Variables on different parts of document
-					$document->setValue('weekday', date('l')); // On section/content
-					$document->setValue('time', date('H:i')); // On footer
-					$document->setValue('serverName', realpath(__DIR__)); // On header
+                    // Variables on different parts of document
+                    $document->setValue('weekday', date('l')); // On section/content
+                    $document->setValue('time', date('H:i')); // On footer
+                    $document->setValue('serverName', realpath(__DIR__)); // On header
 
-					// Simple table
-					$document->cloneRow('rowValue', 20);
+                    // Simple table
+                    $document->cloneRow('rowValue', 20);
 
-					$document->setValue('rowValue#1', 'Sun');
-					$document->setValue('rowValue#2', 'Mercury');
-					$document->setValue('rowValue#3', 'Venus');
-					$document->setValue('rowValue#4', 'Earth');
-					$document->setValue('rowValue#5', 'Mars');
-					$document->setValue('rowValue#6', 'Jupiter');
-					$document->setValue('rowValue#7', 'Saturn');
-					$document->setValue('rowValue#8', 'Uranus');
-					$document->setValue('rowValue#9', 'Neptun');
-					$document->setValue('rowValue#10', 'Pluto');
-					$document->setValue('rowValue#11', 'Sun');
-					$document->setValue('rowValue#12', 'Mercury');
-					$document->setValue('rowValue#13', 'Venus');
-					$document->setValue('rowValue#14', 'Earth');
-					$document->setValue('rowValue#15', 'Mars');
-					$document->setValue('rowValue#16', 'Jupiter');
-					$document->setValue('rowValue#17', 'Saturn');
-					$document->setValue('rowValue#18', 'Uranus');
-					$document->setValue('rowValue#19', 'Neptun');
-					$document->setValue('rowValue#20', 'Pluto');
+                    $document->setValue('rowValue#1', 'Sun');
+                    $document->setValue('rowValue#2', 'Mercury');
+                    $document->setValue('rowValue#3', 'Venus');
+                    $document->setValue('rowValue#4', 'Earth');
+                    $document->setValue('rowValue#5', 'Mars');
+                    $document->setValue('rowValue#6', 'Jupiter');
+                    $document->setValue('rowValue#7', 'Saturn');
+                    $document->setValue('rowValue#8', 'Uranus');
+                    $document->setValue('rowValue#9', 'Neptun');
+                    $document->setValue('rowValue#10', 'Pluto');
+                    $document->setValue('rowValue#11', 'Sun');
+                    $document->setValue('rowValue#12', 'Mercury');
+                    $document->setValue('rowValue#13', 'Venus');
+                    $document->setValue('rowValue#14', 'Earth');
+                    $document->setValue('rowValue#15', 'Mars');
+                    $document->setValue('rowValue#16', 'Jupiter');
+                    $document->setValue('rowValue#17', 'Saturn');
+                    $document->setValue('rowValue#18', 'Uranus');
+                    $document->setValue('rowValue#19', 'Neptun');
+                    $document->setValue('rowValue#20', 'Pluto');
 
-					$document->setValue('rowNumber#1', '1');
-					$document->setValue('rowNumber#2', '2');
-					$document->setValue('rowNumber#3', '3');
-					$document->setValue('rowNumber#4', '4');
-					$document->setValue('rowNumber#5', '5');
-					$document->setValue('rowNumber#6', '6');
-					$document->setValue('rowNumber#7', '7');
-					$document->setValue('rowNumber#8', '8');
-					$document->setValue('rowNumber#9', '9');
-					$document->setValue('rowNumber#10', '10');
-					$document->setValue('rowNumber#11', '11');
-					$document->setValue('rowNumber#12', '12');
-					$document->setValue('rowNumber#13', '13');
-					$document->setValue('rowNumber#14', '14');
-					$document->setValue('rowNumber#15', '15');
-					$document->setValue('rowNumber#16', '16');
-					$document->setValue('rowNumber#17', '17');
-					$document->setValue('rowNumber#18', '18');
-					$document->setValue('rowNumber#19', '19');
-					$document->setValue('rowNumber#20', '20');
+                    $document->setValue('rowNumber#1', '1');
+                    $document->setValue('rowNumber#2', '2');
+                    $document->setValue('rowNumber#3', '3');
+                    $document->setValue('rowNumber#4', '4');
+                    $document->setValue('rowNumber#5', '5');
+                    $document->setValue('rowNumber#6', '6');
+                    $document->setValue('rowNumber#7', '7');
+                    $document->setValue('rowNumber#8', '8');
+                    $document->setValue('rowNumber#9', '9');
+                    $document->setValue('rowNumber#10', '10');
+                    $document->setValue('rowNumber#11', '11');
+                    $document->setValue('rowNumber#12', '12');
+                    $document->setValue('rowNumber#13', '13');
+                    $document->setValue('rowNumber#14', '14');
+                    $document->setValue('rowNumber#15', '15');
+                    $document->setValue('rowNumber#16', '16');
+                    $document->setValue('rowNumber#17', '17');
+                    $document->setValue('rowNumber#18', '18');
+                    $document->setValue('rowNumber#19', '19');
+                    $document->setValue('rowNumber#20', '20');
 
-					// Table with a spanned cell
-					$document->cloneRow('userId', 6);
+                    // Table with a spanned cell
+                    $document->cloneRow('userId', 6);
 
-					$document->setValue('userId#1', '1');
-					$document->setValue('userFirstName#1', 'James');
-					$document->setValue('userName#1', 'Taylor');
-					$document->setValue('userPhone#1', '+1 428 889 773');
+                    $document->setValue('userId#1', '1');
+                    $document->setValue('userFirstName#1', 'James');
+                    $document->setValue('userName#1', 'Taylor');
+                    $document->setValue('userPhone#1', '+1 428 889 773');
 
-					$document->setValue('userId#2', '2');
-					$document->setValue('userFirstName#2', 'Robert');
-					$document->setValue('userName#2', 'Bell');
-					$document->setValue('userPhone#2', '+1 428 889 774');
+                    $document->setValue('userId#2', '2');
+                    $document->setValue('userFirstName#2', 'Robert');
+                    $document->setValue('userName#2', 'Bell');
+                    $document->setValue('userPhone#2', '+1 428 889 774');
 
-					$document->setValue('userId#3', '3');
-					$document->setValue('userFirstName#3', 'Michael');
-					$document->setValue('userName#3', 'Ray');
-					$document->setValue('userPhone#3', '+1 428 889 775');
+                    $document->setValue('userId#3', '3');
+                    $document->setValue('userFirstName#3', 'Michael');
+                    $document->setValue('userName#3', 'Ray');
+                    $document->setValue('userPhone#3', '+1 428 889 775');
 
-					$document->setValue('userId#4', '4');
-					$document->setValue('userFirstName#4', 'Sepp');
-					$document->setValue('userName#4', 'Joy');
-					$document->setValue('userPhone#4', '+1 428 229 775');
+                    $document->setValue('userId#4', '4');
+                    $document->setValue('userFirstName#4', 'Sepp');
+                    $document->setValue('userName#4', 'Joy');
+                    $document->setValue('userPhone#4', '+1 428 229 775');
 
-					$document->setValue('userId#5', '5');
-					$document->setValue('userFirstName#5', 'Hans');
-					$document->setValue('userName#5', 'May');
-					$document->setValue('userPhone#5', '+1 425 229 322');
+                    $document->setValue('userId#5', '5');
+                    $document->setValue('userFirstName#5', 'Hans');
+                    $document->setValue('userName#5', 'May');
+                    $document->setValue('userPhone#5', '+1 425 229 322');
 
-					$document->setValue('userId#6', '6');
-					$document->setValue('userFirstName#6', 'Franz');
-					$document->setValue('userName#6', 'Clay');
-					$document->setValue('userPhone#6', '+1 428 229 775');
+                    $document->setValue('userId#6', '6');
+                    $document->setValue('userFirstName#6', 'Franz');
+                    $document->setValue('userName#6', 'Clay');
+                    $document->setValue('userPhone#6', '+1 428 229 775');
 
-					$name = 'fileadmin/Sample_07_TemplateCloneRow.docx';
-					$document->saveAs($name);
+                    $name = 'fileadmin/Sample_07_TemplateCloneRow.docx';
+                    $document->saveAs($name);
 
- 					require_once($path . '/samples/Sample_Footer.php');
+                    require_once($path . '/samples/Sample_Footer.php');
 
                     $pathsite = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/';
                     $phpWord = \PhpOffice\PhpWord\IOFactory::load($pathsite . $name);
 
-					if (is_array($generationConf['handleLib.']['rendererLibrary.'])) {
-						$rendererName = \PhpOffice\PhpWord\Settings::PDF_RENDERER_DOMPDF;	//   PDF_RENDERER_MPDF PDF_RENDERER_TCPDF
-						$rendererLibraryPath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/' . $generationConf['handleLib.']['rendererLibrary.']['path'];
-						\PhpOffice\PhpWord\Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
-						$objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'PDF');
-						$objWriter->save('fileadmin/Sample_07_TemplateCloneRow.pdf');
+                    if (is_array($generationConf['handleLib.']['rendererLibrary.'])) {
+                        $rendererName = \PhpOffice\PhpWord\Settings::PDF_RENDERER_DOMPDF;	//   PDF_RENDERER_MPDF PDF_RENDERER_TCPDF
+                        $rendererLibraryPath = \TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/' . $generationConf['handleLib.']['rendererLibrary.']['path'];
+                        \PhpOffice\PhpWord\Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+                        $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'PDF');
+                        $objWriter->save('fileadmin/Sample_07_TemplateCloneRow.pdf');
 
-						$result = true;
-					}
+                        $result = true;
+                    }
 
-					break;
-				default:
-					break;
-			}
-		}
+                    break;
+                default:
+                    break;
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/view/class.tx_ttproducts_product_view.php
+++ b/view/class.tx_ttproducts_product_view.php
@@ -43,339 +43,339 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_product_view extends tx_ttproducts_article_base_view {
-	public $relatedArray = []; // array of related products
-	public $marker = 'PRODUCT';
-	public $type = 'product';
-	public $piVar = 'product';
-	public $articleArray = [];
-	public $datafield;
+    public $relatedArray = []; // array of related products
+    public $marker = 'PRODUCT';
+    public $type = 'product';
+    public $piVar = 'product';
+    public $articleArray = [];
+    public $datafield;
 
 
-	public function init (
-		$modelObj
-	) {
-		$this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_view');
-		$this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_view');
+    public function init (
+        $modelObj
+    ) {
+        $this->variant = GeneralUtility::makeInstance('tx_ttproducts_variant_view');
+        $this->editVariant = GeneralUtility::makeInstance('tx_ttproducts_edit_variant_view');
 
-		$result = parent::init($modelObj);
+        $result = parent::init($modelObj);
 
-		return $result;
-	}
-
-
-	public function getItemMarkerSubpartArrays (
-		$templateCode,
-		$functablename,
-		$row,
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$tagArray,
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$iCount = '',
-		$checkPriceZero = false
-	) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-
-		parent::getItemMarkerSubpartArrays(
-			$templateCode,
-			$functablename,
-			$row,
-			$markerArray,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$tagArray,
-			$multiOrderArray,
-			$productRowArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$iCount,
-			$checkPriceZero
-		);
-		$extArray = [];
-		if (isset($row['ext'])) {
-			$extArray = $row['ext'];
-		}
-
-		if (is_array($extArray) && isset($extArray['tt_products']) && is_array($extArray['tt_products'])) {
-			$variant = $extArray['tt_products'][0]['vars'];
-		} else if (is_array($extArray) && isset($extArray['tx_dam'])) {
-			$variant = $extArray['tx_dam'][0]['vars'];
-		}
-		$bGiftService = true;
-		if ($this->getModelObj()->hasAdditional($row, 'noGiftService')) {
-			$bGiftService = false;
-		}
-
-		$datafieldViewObj = $this->getFieldObj('datasheet');
-		if (isset($datafieldViewObj) && is_object($datafieldViewObj)) {
-			$datafieldViewObj->getItemSubpartArrays(
-				$templateCode,
-				$this->getMarker(),
-				$functablename,
-				$row,
-				'datasheet_uid',
-				$this->getModelObj()->getTableConf($theCode),
-				$subpartArray,
-				$wrappedSubpartArray,
-				$tagArray,
-				$theCode,
-				$basketExtra,
-				$basketRecs
-			);
-		}
+        return $result;
+    }
 
 
-		// download subparts
+    public function getItemMarkerSubpartArrays (
+        $templateCode,
+        $functablename,
+        $row,
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $tagArray,
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $iCount = '',
+        $checkPriceZero = false
+    ) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
 
-		$downloadTableView = $tablesObj->get('tt_products_downloads', true);
-		$downloadTable = $downloadTableView->getModelObj();
-		$downloadTagArray =
-			$downloadTableView->getTagMarkerArray(
-				$tagArray,
-				$this->getMarker()
-			);
+        parent::getItemMarkerSubpartArrays(
+            $templateCode,
+            $functablename,
+            $row,
+            $markerArray,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $tagArray,
+            $multiOrderArray,
+            $productRowArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $iCount,
+            $checkPriceZero
+        );
+        $extArray = [];
+        if (isset($row['ext'])) {
+            $extArray = $row['ext'];
+        }
 
-		$itemArray =
-			$downloadTable->getRelatedUidArray(
-				$row['uid'],
-				$downloadTagArray,
-				'tt_products'
-			);
+        if (is_array($extArray) && isset($extArray['tt_products']) && is_array($extArray['tt_products'])) {
+            $variant = $extArray['tt_products'][0]['vars'];
+        } else if (is_array($extArray) && isset($extArray['tx_dam'])) {
+            $variant = $extArray['tx_dam'][0]['vars'];
+        }
+        $bGiftService = true;
+        if ($this->getModelObj()->hasAdditional($row, 'noGiftService')) {
+            $bGiftService = false;
+        }
+
+        $datafieldViewObj = $this->getFieldObj('datasheet');
+        if (isset($datafieldViewObj) && is_object($datafieldViewObj)) {
+            $datafieldViewObj->getItemSubpartArrays(
+                $templateCode,
+                $this->getMarker(),
+                $functablename,
+                $row,
+                'datasheet_uid',
+                $this->getModelObj()->getTableConf($theCode),
+                $subpartArray,
+                $wrappedSubpartArray,
+                $tagArray,
+                $theCode,
+                $basketExtra,
+                $basketRecs
+            );
+        }
+
+
+        // download subparts
+
+        $downloadTableView = $tablesObj->get('tt_products_downloads', true);
+        $downloadTable = $downloadTableView->getModelObj();
+        $downloadTagArray =
+            $downloadTableView->getTagMarkerArray(
+                $tagArray,
+                $this->getMarker()
+            );
+
+        $itemArray =
+            $downloadTable->getRelatedUidArray(
+                $row['uid'],
+                $downloadTagArray,
+                'tt_products'
+            );
 
         $localRowArray = [];
 
-		foreach ($productRowArray as $productRow) {
-			if ($productRow['uid'] == $row['uid']) {
-				$localRowArray[] = $productRow;
-			}
-		}
+        foreach ($productRowArray as $productRow) {
+            if ($productRow['uid'] == $row['uid']) {
+                $localRowArray[] = $productRow;
+            }
+        }
 
-		$downloadTableView->getDownloadMarkerSubpartArrays(
-			$templateCode,
-			$conf,
-			$itemArray,
-			$markerArray,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$this->getMarker(),
-			$tagArray,
-			$hiddenFields = '',
-			$multiOrderArray,
-			$localRowArray,
-			$checkPriceZero
-		);
-	}
+        $downloadTableView->getDownloadMarkerSubpartArrays(
+            $templateCode,
+            $conf,
+            $itemArray,
+            $markerArray,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $this->getMarker(),
+            $tagArray,
+            $hiddenFields = '',
+            $multiOrderArray,
+            $localRowArray,
+            $checkPriceZero
+        );
+    }
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	string		title of the category
-	 * @param	integer		number of images to be shown
-	 * @param	object		the image cObj to be used
-	 * @param	array		information about the parent HTML form
-	 * @return	array
-	 * @access private
-	 */
-	public function getModelMarkerArray (
-		$row,
-		$markerParam,
-		&$markerArray,
-		$catTitle,
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		$tagArray = [],
-		$forminfoArray = [],
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '',
-		$prefix = '',
-		$suffix = '',
-		$linkWrap = '',
-		$bHtml = true,
-		$charset = '',
-		$hiddenFields = '',
-		$multiOrderArray = [],
-		$productRowArray = [],
-		$bEnableTaxZero = false,
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	string		title of the category
+     * @param	integer		number of images to be shown
+     * @param	object		the image cObj to be used
+     * @param	array		information about the parent HTML form
+     * @return	array
+     * @access private
+     */
+    public function getModelMarkerArray (
+        $row,
+        $markerParam,
+        &$markerArray,
+        $catTitle,
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        $tagArray = [],
+        $forminfoArray = [],
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '',
+        $prefix = '',
+        $suffix = '',
+        $linkWrap = '',
+        $bHtml = true,
+        $charset = '',
+        $hiddenFields = '',
+        $multiOrderArray = [],
+        $productRowArray = [],
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
-	) {
-			// Returns a markerArray ready for substitution with information for the tt_producst record, $row
+    ) {
+            // Returns a markerArray ready for substitution with information for the tt_producst record, $row
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$modelObj = $this->getModelObj();
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
-		$cObj = FrontendUtility::getContentObjectRenderer();
-		parent::getModelMarkerArray(
-			$row,
-			$markerParam,
-			$markerArray,
-			$catTitle,
-			$imageNum,
-			$imageRenderObj,
-			$tagArray,
-			$forminfoArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$id,
-			$prefix,
-			$suffix,
-			$linkWrap,
-			$bHtml,
-			$charset,
-			$hiddenFields,
-			$multiOrderArray,
-			$productRowArray,
-			$bEnableTaxZero,
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $modelObj = $this->getModelObj();
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
+        $cObj = FrontendUtility::getContentObjectRenderer();
+        parent::getModelMarkerArray(
+            $row,
+            $markerParam,
+            $markerArray,
+            $catTitle,
+            $imageNum,
+            $imageRenderObj,
+            $tagArray,
+            $forminfoArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $id,
+            $prefix,
+            $suffix,
+            $linkWrap,
+            $bHtml,
+            $charset,
+            $hiddenFields,
+            $multiOrderArray,
+            $productRowArray,
+            $bEnableTaxZero,
             $notOverwritePriceIfSet
-		);
+        );
 
-			// Subst. fields
-		$markerArray['###' . $this->getMarker() . '_UNIT###'] = $row['unit'] ?? '';
-		$markerArray['###' . $this->getMarker() . '_UNIT_FACTOR###'] = $row['unit_factor'] ?? '0';
-		$markerArray['###' . $this->getMarker() . '_WWW###'] = $row['www'] ?? '';
-		$markerArray['###BULKILY_WARNING###'] = !empty($row['bulkily']) ? $conf['bulkilyWarning'] : '';
+            // Subst. fields
+        $markerArray['###' . $this->getMarker() . '_UNIT###'] = $row['unit'] ?? '';
+        $markerArray['###' . $this->getMarker() . '_UNIT_FACTOR###'] = $row['unit_factor'] ?? '0';
+        $markerArray['###' . $this->getMarker() . '_WWW###'] = $row['www'] ?? '';
+        $markerArray['###BULKILY_WARNING###'] = !empty($row['bulkily']) ? $conf['bulkilyWarning'] : '';
 
-		if (!empty($conf['itemMarkerArrayFunc'])) {
-			$markerArray =
-				\JambageCom\Div2007\Utility\ObsoleteUtility::userProcess(
-					$this,
-					$conf,
-					'itemMarkerArrayFunc',
-					$markerArray
-				);
-		}
+        if (!empty($conf['itemMarkerArrayFunc'])) {
+            $markerArray =
+                \JambageCom\Div2007\Utility\ObsoleteUtility::userProcess(
+                    $this,
+                    $conf,
+                    'itemMarkerArrayFunc',
+                    $markerArray
+                );
+        }
 
-		if ($theCode == 'SINGLE') {
-			$addressUid = intval($row['address']);
-			$addressRow = [];
-			$addressViewObj = $tablesObj->get('address', true);
+        if ($theCode == 'SINGLE') {
+            $addressUid = intval($row['address']);
+            $addressRow = [];
+            $addressViewObj = $tablesObj->get('address', true);
 
-			if (is_object($addressViewObj)) {
+            if (is_object($addressViewObj)) {
 
-				if (
-					($conf['table.']['address'] != 'tt_address' || \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TT_ADDRESS_EXT)) &&
-					$addressUid &&
-					$modelObj->fieldArray['address']
-				) {
-					$addressObj = $addressViewObj->getModelObj();
-					$addressRow = $addressObj->get($addressUid);
-				}
-				$adressMarkerArray = [];
-				$tmp = '';
-				$addressViewObj->getRowMarkerArray(
-					'address',
-					$addressRow,
-					'',
-					$adressMarkerArray,
-					$tmp,
-					$tmp,
-					$tagArray,
-					$theCode,
-					$basketExtra,
-					$basketRecs,
-					$bHtml,
-					$charset,
-					$imageNum,
-					$imageRenderObj,
-					$id,
-					$prefix,
-					$suffix,
-					$linkWrap,
-					$bEnableTaxZero
-				);
-				if (is_array($adressMarkerArray)) {
-					$markerArray = array_merge($markerArray, $adressMarkerArray);
-				}
-			}
+                if (
+                    ($conf['table.']['address'] != 'tt_address' || \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded(TT_ADDRESS_EXT)) &&
+                    $addressUid &&
+                    $modelObj->fieldArray['address']
+                ) {
+                    $addressObj = $addressViewObj->getModelObj();
+                    $addressRow = $addressObj->get($addressUid);
+                }
+                $adressMarkerArray = [];
+                $tmp = '';
+                $addressViewObj->getRowMarkerArray(
+                    'address',
+                    $addressRow,
+                    '',
+                    $adressMarkerArray,
+                    $tmp,
+                    $tmp,
+                    $tagArray,
+                    $theCode,
+                    $basketExtra,
+                    $basketRecs,
+                    $bHtml,
+                    $charset,
+                    $imageNum,
+                    $imageRenderObj,
+                    $id,
+                    $prefix,
+                    $suffix,
+                    $linkWrap,
+                    $bEnableTaxZero
+                );
+                if (is_array($adressMarkerArray)) {
+                    $markerArray = array_merge($markerArray, $adressMarkerArray);
+                }
+            }
 
-			if ($row['note_uid']) {
-				$pageObj = $tablesObj->get('pages');
+            if ($row['note_uid']) {
+                $pageObj = $tablesObj->get('pages');
 
-				$notePageArray = $pageObj->getNotes ($row['uid']);
-				$contentConf = $cnfObj->getTableConf('tt_content', $code);
+                $notePageArray = $pageObj->getNotes ($row['uid']);
+                $contentConf = $cnfObj->getTableConf('tt_content', $code);
 
-				foreach($notePageArray as $k => $pid) {
-					$pageRow = $pageObj->get($pid);
-					$pageMarkerKey = 'PRODUCT_NOTE_UID_' . ($k + 1);
-					$contentArray = $tablesObj->get('tt_content')->getFromPid($pid);
-					$countArray = [];
-					foreach($contentArray as $k2 => $contentEl) {
-						$cType = $contentEl['CType'];
-						$countArray[$cType] = intval($countArray[$cType]) + 1;
-						$markerKey = $pageMarkerKey . '_' . $countArray[$cType] . '_' . strtoupper($cType);
+                foreach($notePageArray as $k => $pid) {
+                    $pageRow = $pageObj->get($pid);
+                    $pageMarkerKey = 'PRODUCT_NOTE_UID_' . ($k + 1);
+                    $contentArray = $tablesObj->get('tt_content')->getFromPid($pid);
+                    $countArray = [];
+                    foreach($contentArray as $k2 => $contentEl) {
+                        $cType = $contentEl['CType'];
+                        $countArray[$cType] = intval($countArray[$cType]) + 1;
+                        $markerKey = $pageMarkerKey . '_' . $countArray[$cType] . '_' . strtoupper($cType);
 
-						foreach($tagArray as $index => $v) {
-							$pageFoundPos = strpos($index, $pageMarkerKey);
-							if ($pageFoundPos == 0 && $pageFoundPos !== false) {
-								$fieldName = str_replace($pageMarkerKey . '_', '', $index);
-								if (isset($pageRow[$fieldName])) {
-									$markerArray['###' . $index . '###'] = $pageRow[$fieldName];
-								}
-							}
-							if (strpos($index, $markerKey) === false) {
-								continue;
-							}
-							$fieldPos = strrpos($index, '_');
-							$fieldName = substr($index, $fieldPos+1);
-							$markerArray['###' . $index . '###'] = $contentEl[$fieldName];
-							if (
-								isset ($contentConf['displayFields.']) &&
-								is_array ($contentConf['displayFields.']) &&
-								$contentConf['displayFields.'][$fieldName] == 'RTEcssText'
-							) {
-									// Extension CSS styled content
-								if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('css_styled_content')) {
-									$markerArray['###' . $index . '###'] =
-										FrontendUtility::RTEcssText(
+                        foreach($tagArray as $index => $v) {
+                            $pageFoundPos = strpos($index, $pageMarkerKey);
+                            if ($pageFoundPos == 0 && $pageFoundPos !== false) {
+                                $fieldName = str_replace($pageMarkerKey . '_', '', $index);
+                                if (isset($pageRow[$fieldName])) {
+                                    $markerArray['###' . $index . '###'] = $pageRow[$fieldName];
+                                }
+                            }
+                            if (strpos($index, $markerKey) === false) {
+                                continue;
+                            }
+                            $fieldPos = strrpos($index, '_');
+                            $fieldName = substr($index, $fieldPos+1);
+                            $markerArray['###' . $index . '###'] = $contentEl[$fieldName];
+                            if (
+                                isset ($contentConf['displayFields.']) &&
+                                is_array ($contentConf['displayFields.']) &&
+                                $contentConf['displayFields.'][$fieldName] == 'RTEcssText'
+                            ) {
+                                    // Extension CSS styled content
+                                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('css_styled_content')) {
+                                    $markerArray['###' . $index . '###'] =
+                                        FrontendUtility::RTEcssText(
                                             $local_cObj,
                                             $contentEl[$fieldName]
                                         );
-								} else if (is_array($conf['parseFunc.'])) {
-									$markerArray['###' . $index . '###'] =
-										$cObj->parseFunc($contentEl[$fieldName],$conf['parseFunc.']);
-								}
-							}
-						}
-					}
-				}
-			}
+                                } else if (is_array($conf['parseFunc.'])) {
+                                    $markerArray['###' . $index . '###'] =
+                                        $cObj->parseFunc($contentEl[$fieldName],$conf['parseFunc.']);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			foreach ($tagArray as $key => $val) {
-				if (strpos($key,'PRODUCT_NOTE_UID') !== false) {
-					if (!isset($markerArray['###' . $key . '###'])) {
-						$markerArray['###' . $key . '###'] = '';
-					}
-				}
-			}
+            foreach ($tagArray as $key => $val) {
+                if (strpos($key,'PRODUCT_NOTE_UID') !== false) {
+                    if (!isset($markerArray['###' . $key . '###'])) {
+                        $markerArray['###' . $key . '###'] = '';
+                    }
+                }
+            }
 
-			$extKey = '';
+            $extKey = '';
 
-				// check need for rating
-			if (
-				(
-					isset($tagArray['RATING']) ||
-					isset($tagArray['RATING_STATIC'])
-				) &&
-				isset($conf['RATING']) && isset($conf['RATING.'])
-			) {
-				$cObjectType = $conf['RATING'];
-				$conf1 = $conf['RATING.'];
-				$extKey = $conf['RATING.']['extkey'];
-				$api = $conf['RATING.']['api'];
-			}
+                // check need for rating
+            if (
+                (
+                    isset($tagArray['RATING']) ||
+                    isset($tagArray['RATING_STATIC'])
+                ) &&
+                isset($conf['RATING']) && isset($conf['RATING.'])
+            ) {
+                $cObjectType = $conf['RATING'];
+                $conf1 = $conf['RATING.'];
+                $extKey = $conf['RATING.']['extkey'];
+                $api = $conf['RATING.']['api'];
+            }
 
             if (
                 $extKey != '' &&
@@ -385,94 +385,94 @@ class tx_ttproducts_product_view extends tx_ttproducts_article_base_view {
             )
             {
                 $apiObj = GeneralUtility::makeInstance($api);
-				if (method_exists($apiObj, 'getDefaultConfig')) {
-					$ratingConf = $apiObj->getDefaultConfig();
-					if (isset($ratingConf) && is_array($ratingConf)) {
+                if (method_exists($apiObj, 'getDefaultConfig')) {
+                    $ratingConf = $apiObj->getDefaultConfig();
+                    if (isset($ratingConf) && is_array($ratingConf)) {
                         $tmpConf = $conf1;
-						\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($tmpConf, $ratingConf);
-						$ratingConf = $tmpConf;
-					} else {
-						$ratingConf = $conf1;
-					}
-				} else {
-					$ratingConf = $conf1;
-				}
-				$ratingConf['ref'] = TT_PRODUCTS_EXT . '_' . $row['uid'];
+                        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($tmpConf, $ratingConf);
+                        $ratingConf = $tmpConf;
+                    } else {
+                        $ratingConf = $conf1;
+                    }
+                } else {
+                    $ratingConf = $conf1;
+                }
+                $ratingConf['ref'] = TT_PRODUCTS_EXT . '_' . $row['uid'];
 
-				$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-				/* @var $cObj TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */
-				$cObj->start([]);
-				$markerArray['###RATING###'] = $cObj->cObjGetSingle($cObjectType, $ratingConf);
-				$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-				/* @var $cObj TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */
-				$cObj->start([]);
-				$ratingConf['mode'] = 'static';
-				$markerArray['###RATING_STATIC###'] = $cObj->cObjGetSingle($cObjectType, $ratingConf);
-			} else {
-				$markerArray['###RATING###'] = '';
-				$markerArray['###RATING_STATIC###'] = '';
-			}
+                $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+                /* @var $cObj TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */
+                $cObj->start([]);
+                $markerArray['###RATING###'] = $cObj->cObjGetSingle($cObjectType, $ratingConf);
+                $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+                /* @var $cObj TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */
+                $cObj->start([]);
+                $ratingConf['mode'] = 'static';
+                $markerArray['###RATING_STATIC###'] = $cObj->cObjGetSingle($cObjectType, $ratingConf);
+            } else {
+                $markerArray['###RATING###'] = '';
+                $markerArray['###RATING_STATIC###'] = '';
+            }
 
-			$extKey = '';
-				// check need for comments
-			if (
-				isset($tagArray['COMMENT']) &&
-				isset($conf['COMMENT']) &&
-				isset($conf['COMMENT.'])
-			) {
-				$cObjectType = $conf['COMMENT'];
-				$conf1 = $conf['COMMENT.'];
-				$extKey = $conf['COMMENT.']['extkey'];
-				$api = $conf['COMMENT.']['api'];
-				$param = $conf['COMMENT.']['param'];
-				if ($param == '') {
-					$param = 'list';
-				}
-			}
+            $extKey = '';
+                // check need for comments
+            if (
+                isset($tagArray['COMMENT']) &&
+                isset($conf['COMMENT']) &&
+                isset($conf['COMMENT.'])
+            ) {
+                $cObjectType = $conf['COMMENT'];
+                $conf1 = $conf['COMMENT.'];
+                $extKey = $conf['COMMENT.']['extkey'];
+                $api = $conf['COMMENT.']['api'];
+                $param = $conf['COMMENT.']['param'];
+                if ($param == '') {
+                    $param = 'list';
+                }
+            }
 
-			if ($extKey != '' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey) && $api != '' && class_exists($api)) {
-				$apiObj = GeneralUtility::makeInstance($api);
+            if ($extKey != '' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey) && $api != '' && class_exists($api)) {
+                $apiObj = GeneralUtility::makeInstance($api);
 
-				if (method_exists($apiObj, 'getDefaultConfig')) {
-					$commentConf = $apiObj->getDefaultConfig($param);
-					if (isset($commentConf) && is_array($commentConf)) {
+                if (method_exists($apiObj, 'getDefaultConfig')) {
+                    $commentConf = $apiObj->getDefaultConfig($param);
+                    if (isset($commentConf) && is_array($commentConf)) {
                         $tmpConf = $conf1;
-						\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($tmpConf, $commentConf);
-						$commentConf = $tmpConf;
-					} else {
-						$commentConf = $conf1;
-					}
-				} else {
-					$commentConf = $conf1;
-				}
-				$commentConf['ref'] = TT_PRODUCTS_EXT . '_' . $row['uid'];
-				$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
-				$linkParams = $urlObj->getLinkParams(
-					'',
-					[
-						'product' => $row['uid']
-					],
-					true,
-					false,
-					0,
-					''
-				);
-				$commentConf['linkParams'] = $linkParams;
+                        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($tmpConf, $commentConf);
+                        $commentConf = $tmpConf;
+                    } else {
+                        $commentConf = $conf1;
+                    }
+                } else {
+                    $commentConf = $conf1;
+                }
+                $commentConf['ref'] = TT_PRODUCTS_EXT . '_' . $row['uid'];
+                $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+                $linkParams = $urlObj->getLinkParams(
+                    '',
+                    [
+                        'product' => $row['uid']
+                    ],
+                    true,
+                    false,
+                    0,
+                    ''
+                );
+                $commentConf['linkParams'] = $linkParams;
 
-				$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-				$cObj->start([]);
-				$markerArray['###COMMENT###'] = $cObj->cObjGetSingle($cObjectType, $commentConf);
-			} else {
-				$markerArray['###COMMENT###'] = '';
-			}
-		}
+                $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+                $cObj->start([]);
+                $markerArray['###COMMENT###'] = $cObj->cObjGetSingle($cObjectType, $commentConf);
+            } else {
+                $markerArray['###COMMENT###'] = '';
+            }
+        }
 
-		if (!empty($row['special_preparation'])) {
-			$markerArray['###' . $this->getMarker() . '_SPECIAL_PREP###'] = $templateService->substituteMarkerArray($conf['specialPreparation'], $markerArray);
-		} else {
-			$markerArray['###' . $this->getMarker() . '_SPECIAL_PREP###'] = '';
-		}
-	} // getModelMarkerArray
+        if (!empty($row['special_preparation'])) {
+            $markerArray['###' . $this->getMarker() . '_SPECIAL_PREP###'] = $templateService->substituteMarkerArray($conf['specialPreparation'], $markerArray);
+        } else {
+            $markerArray['###' . $this->getMarker() . '_SPECIAL_PREP###'] = '';
+        }
+    } // getModelMarkerArray
 }
 
 

--- a/view/class.tx_ttproducts_relatedlist_view.php
+++ b/view/class.tx_ttproducts_relatedlist_view.php
@@ -44,121 +44,121 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_relatedlist_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $pidListObj;
+    public $pidListObj;
 
 
-	public function init ($pid_list, $recursive) {
+    public function init ($pid_list, $recursive) {
 
-		$this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$this->pidListObj->applyRecursive($recursive, $pid_list, true);
-		$this->pidListObj->setPageArray();
-	}
+        $this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $this->pidListObj->applyRecursive($recursive, $pid_list, true);
+        $this->pidListObj->setPageArray();
+    }
 
-	public function getListUncachedMarkerArray (
-		$uid,
-		$conf,
-		$funcTablename,
-		$viewTagArray
-	) {
-		$result = [];
+    public function getListUncachedMarkerArray (
+        $uid,
+        $conf,
+        $funcTablename,
+        $viewTagArray
+    ) {
+        $result = [];
 
-		if (
-			$funcTablename == 'tt_products' &&
-			isset($conf['LISTRELATEDBYSYSTEMCATEGORY']) &&
-			isset($conf['LISTRELATEDBYSYSTEMCATEGORY.']) &&
-			isset($conf['LISTRELATEDBYSYSTEMCATEGORY.']['userFunc'])
-		) {
-			if (isset($viewTagArray['PRODUCT_RELATED_SYSCAT'])) {
-				$cObjectType = $conf['LISTRELATEDBYSYSTEMCATEGORY'];
-				$relatedConf = $conf['LISTRELATEDBYSYSTEMCATEGORY.'];
-				$relatedConf['ref'] = $uid;
-				$relatedConf['code'] = 'LISTRELATEDBYSYSTEMCATEGORY';
-				$relatedConf['userFunc'] = $conf['LISTRELATEDBYSYSTEMCATEGORY.']['userFunc'];
-				$cObjectType = $conf['LISTRELATEDBYSYSTEMCATEGORY'];
+        if (
+            $funcTablename == 'tt_products' &&
+            isset($conf['LISTRELATEDBYSYSTEMCATEGORY']) &&
+            isset($conf['LISTRELATEDBYSYSTEMCATEGORY.']) &&
+            isset($conf['LISTRELATEDBYSYSTEMCATEGORY.']['userFunc'])
+        ) {
+            if (isset($viewTagArray['PRODUCT_RELATED_SYSCAT'])) {
+                $cObjectType = $conf['LISTRELATEDBYSYSTEMCATEGORY'];
+                $relatedConf = $conf['LISTRELATEDBYSYSTEMCATEGORY.'];
+                $relatedConf['ref'] = $uid;
+                $relatedConf['code'] = 'LISTRELATEDBYSYSTEMCATEGORY';
+                $relatedConf['userFunc'] = $conf['LISTRELATEDBYSYSTEMCATEGORY.']['userFunc'];
+                $cObjectType = $conf['LISTRELATEDBYSYSTEMCATEGORY'];
 
-				$cObj = FrontendUtility::getContentObjectRenderer([]);
-				$output = $cObj->cObjGetSingle($cObjectType, $relatedConf);
-				$result['###PRODUCT_RELATED_SYSCAT###'] = $output;
-			}
-		} else {
-			if (isset($viewTagArray['PRODUCT_RELATED_SYSCAT'])) {
-				$result['###PRODUCT_RELATED_SYSCAT###'] = '';
-			}
-		}
-		return $result;
-	}
+                $cObj = FrontendUtility::getContentObjectRenderer([]);
+                $output = $cObj->cObjGetSingle($cObjectType, $relatedConf);
+                $result['###PRODUCT_RELATED_SYSCAT###'] = $output;
+            }
+        } else {
+            if (isset($viewTagArray['PRODUCT_RELATED_SYSCAT'])) {
+                $result['###PRODUCT_RELATED_SYSCAT###'] = '';
+            }
+        }
+        return $result;
+    }
 
 
-	public function getAddListArray (
-		$theCode,
-		$funcTablename,
-		$marker,
-		$uid,
-		$useArticles
-	) {
-		$result = false;
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnfObj->getConf();
+    public function getAddListArray (
+        $theCode,
+        $funcTablename,
+        $marker,
+        $uid,
+        $useArticles
+    ) {
+        $result = false;
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnfObj->getConf();
 
-		switch ($funcTablename) {
-			case 'tt_products':
-				$result =
-					[
-						'articles' => [
-							'marker' => 'PRODUCT_RELATED_ARTICLES',
-							'template' => 'ITEM_LIST_RELATED_ARTICLES_TEMPLATE',
-							'require' => $useArticles,
-							'code' => 'LISTRELATEDARTICLES',
-							'additionalPages' => $conf['pidsRelatedArticles'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'tt_products_articles',
-							'callFunctableArray' => [],
-							'cached' => true
-						],
-						'accessories' => [
-							'marker' => 'PRODUCT_ACCESSORY_UID',
-							'template' => 'ITEM_LIST_ACCESSORY_TEMPLATE',
-							'require' => true,
-							'code' => 'LISTRELATEDACCESSORY',
-							'additionalPages' => $conf['pidsRelatedAccessories'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'tt_products',
-							'callFunctableArray' => [],
-							'cached' => true
-						],
-						'products' => [
-							'marker' => 'PRODUCT_RELATED_UID',
-							'template' => 'ITEM_LIST_RELATED_TEMPLATE',
-							'require' => true,
-							'code' => 'LISTRELATED',
-							'additionalPages' => $conf['pidsRelatedProducts'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'tt_products',
-							'callFunctableArray' => [],
-							'cached' => true
-						],
-						'productsbysystemcategory' => [
-							'marker' => 'PRODUCT_RELATED_SYSCAT',
-							'template' => 'ITEM_LIST_RELATED_BY_SYSTEMCATEGORY_TEMPLATE',
-							'require' => true,
-							'code' => 'LISTRELATEDBYSYSTEMCATEGORY',
-							'additionalPages' => $conf['pidsRelatedProducts'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'tt_products',
-							'callFunctableArray' => [],
-							'cached' => false
-						],
-						'complete_downloads' => [
-							'marker' => 'PRODUCT_COMPLETE_DOWNLOAD_UID',
-							'template' => 'ITEM_LIST_COMPLETE_DOWNLOAD_TEMPLATE',
-							'require' => true,
-							'code' => 'LISTRELATEDCOMPLETEDOWNLOAD',
-							'additionalPages' => $conf['pidsRelatedDownloads'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'sys_file_reference',
-							'callFunctableArray' => [],
-							'cached' => true
-						],
+        switch ($funcTablename) {
+            case 'tt_products':
+                $result =
+                    [
+                        'articles' => [
+                            'marker' => 'PRODUCT_RELATED_ARTICLES',
+                            'template' => 'ITEM_LIST_RELATED_ARTICLES_TEMPLATE',
+                            'require' => $useArticles,
+                            'code' => 'LISTRELATEDARTICLES',
+                            'additionalPages' => $conf['pidsRelatedArticles'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'tt_products_articles',
+                            'callFunctableArray' => [],
+                            'cached' => true
+                        ],
+                        'accessories' => [
+                            'marker' => 'PRODUCT_ACCESSORY_UID',
+                            'template' => 'ITEM_LIST_ACCESSORY_TEMPLATE',
+                            'require' => true,
+                            'code' => 'LISTRELATEDACCESSORY',
+                            'additionalPages' => $conf['pidsRelatedAccessories'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'tt_products',
+                            'callFunctableArray' => [],
+                            'cached' => true
+                        ],
+                        'products' => [
+                            'marker' => 'PRODUCT_RELATED_UID',
+                            'template' => 'ITEM_LIST_RELATED_TEMPLATE',
+                            'require' => true,
+                            'code' => 'LISTRELATED',
+                            'additionalPages' => $conf['pidsRelatedProducts'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'tt_products',
+                            'callFunctableArray' => [],
+                            'cached' => true
+                        ],
+                        'productsbysystemcategory' => [
+                            'marker' => 'PRODUCT_RELATED_SYSCAT',
+                            'template' => 'ITEM_LIST_RELATED_BY_SYSTEMCATEGORY_TEMPLATE',
+                            'require' => true,
+                            'code' => 'LISTRELATEDBYSYSTEMCATEGORY',
+                            'additionalPages' => $conf['pidsRelatedProducts'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'tt_products',
+                            'callFunctableArray' => [],
+                            'cached' => false
+                        ],
+                        'complete_downloads' => [
+                            'marker' => 'PRODUCT_COMPLETE_DOWNLOAD_UID',
+                            'template' => 'ITEM_LIST_COMPLETE_DOWNLOAD_TEMPLATE',
+                            'require' => true,
+                            'code' => 'LISTRELATEDCOMPLETEDOWNLOAD',
+                            'additionalPages' => $conf['pidsRelatedDownloads'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'sys_file_reference',
+                            'callFunctableArray' => [],
+                            'cached' => true
+                        ],
                         'all_downloads' => [
                             'marker' => 'PRODUCT_ALL_DOWNLOAD_UID',
                             'template' => 'ITEM_LIST_ALL_DOWNLOAD_TEMPLATE',
@@ -170,190 +170,190 @@ class tx_ttproducts_relatedlist_view implements \TYPO3\CMS\Core\SingletonInterfa
                             'callFunctableArray' => [],
                             'cached' => true
                         ],
-						'partial_downloads' => [
-							'marker' => 'PRODUCT_PARTIAL_DOWNLOAD_UID',
-							'template' => 'ITEM_LIST_PARTIAL_DOWNLOAD_TEMPLATE',
-							'require' => true,
-							'code' => 'LISTRELATEDPARTIALDOWNLOAD',
-							'additionalPages' => $conf['pidsRelatedDownloads'] ?? '',
-							'mergeRow' => [],
-							'functablename' => 'sys_file_reference',
-							'callFunctableArray' => [],
-							'cached' => true
-						],
-					];
-				break;
+                        'partial_downloads' => [
+                            'marker' => 'PRODUCT_PARTIAL_DOWNLOAD_UID',
+                            'template' => 'ITEM_LIST_PARTIAL_DOWNLOAD_TEMPLATE',
+                            'require' => true,
+                            'code' => 'LISTRELATEDPARTIALDOWNLOAD',
+                            'additionalPages' => $conf['pidsRelatedDownloads'] ?? '',
+                            'mergeRow' => [],
+                            'functablename' => 'sys_file_reference',
+                            'callFunctableArray' => [],
+                            'cached' => true
+                        ],
+                    ];
+                break;
 
-			case 'tx_dam':
-				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
-					if ($uid > 0) {
-						$damext = ['tx_dam' =>
-							[
-								['uid' => $uid]
-							]
-						];
-						$extArray = ['ext' => $damext];
-					} else {
-						$extArray = [];
-					}
-					$result =
-						[
-							'products' => [
-								'marker' => 'DAM_PRODUCTS',
-								'template' => 'DAM_ITEM_LIST_TEMPLATE',
-								'require' => true,
-								'code' => $theCode,
-								'additionalPages' => false,
-								'mergeRow' => $extArray,
-								'functablename' => 'tt_products',
-								'callFunctableArray' => [$marker => 'tx_dam'],
-								'cached' => true
-							]
-						];
-				}
-				break;
-		}
+            case 'tx_dam':
+                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
+                    if ($uid > 0) {
+                        $damext = ['tx_dam' =>
+                            [
+                                ['uid' => $uid]
+                            ]
+                        ];
+                        $extArray = ['ext' => $damext];
+                    } else {
+                        $extArray = [];
+                    }
+                    $result =
+                        [
+                            'products' => [
+                                'marker' => 'DAM_PRODUCTS',
+                                'template' => 'DAM_ITEM_LIST_TEMPLATE',
+                                'require' => true,
+                                'code' => $theCode,
+                                'additionalPages' => false,
+                                'mergeRow' => $extArray,
+                                'functablename' => 'tt_products',
+                                'callFunctableArray' => [$marker => 'tx_dam'],
+                                'cached' => true
+                            ]
+                        ];
+                }
+                break;
+        }
 
-		if (is_array($result)) {
-			foreach ($result as $subtype => $funcArray) {
-				if (!isset($GLOBALS['TCA'][$funcArray['functablename']]['columns'])) {
-					unset($result[$subtype]); // if the current TYPO3 version does not support the needed foreign table
-				}
-			}
-		}
-		return $result;
-	}
+        if (is_array($result)) {
+            foreach ($result as $subtype => $funcArray) {
+                if (!isset($GLOBALS['TCA'][$funcArray['functablename']]['columns'])) {
+                    unset($result[$subtype]); // if the current TYPO3 version does not support the needed foreign table
+                }
+            }
+        }
+        return $result;
+    }
 
 
-	public function getListMarkerArray (
-		$theCode,
-		$templateCode,
-		$viewTagArray,
-		$funcTablename,
-		$uid,
-		$paramUidArray,
-		$parentProductRow,
-		$notOverwritePriceIfSet,
+    public function getListMarkerArray (
+        $theCode,
+        $templateCode,
+        $viewTagArray,
+        $funcTablename,
+        $uid,
+        $paramUidArray,
+        $parentProductRow,
+        $notOverwritePriceIfSet,
         $multiOrderArray,
-		$useArticles,
-		$pageAsCategory,
-		$pid,
-		&$error_code
-	) {
-		$cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$config = $cnfObj->getConfig();
+        $useArticles,
+        $pageAsCategory,
+        $pid,
+        &$error_code
+    ) {
+        $cnfObj = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $config = $cnfObj->getConfig();
 
-		$result = false;
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemViewObj = $tablesObj->get($funcTablename, true);
-		$addListArray =
-			$this->getAddListArray(
-				$theCode,
-				$funcTablename,
-				$itemViewObj->getMarker(),
-				$uid,
-				$useArticles
-			);
+        $result = false;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemViewObj = $tablesObj->get($funcTablename, true);
+        $addListArray =
+            $this->getAddListArray(
+                $theCode,
+                $funcTablename,
+                $itemViewObj->getMarker(),
+                $uid,
+                $useArticles
+            );
 
-		if (is_array($addListArray)) {
-			$listView = '';
-			$itemObj = $itemViewObj->getModelObj();
+        if (is_array($addListArray)) {
+            $listView = '';
+            $itemObj = $itemViewObj->getModelObj();
 
-			foreach ($addListArray as $subtype => $funcArray) {
-				if (!$funcArray['cached']) {
-					continue;
-				}
+            foreach ($addListArray as $subtype => $funcArray) {
+                if (!$funcArray['cached']) {
+                    continue;
+                }
 
-				if (isset($viewTagArray[$funcArray['marker']]) && $funcArray['require']) {
-					$relatedItemObj = $itemObj;
-					$parentFuncTablename = '';
-					if ($funcTablename != $funcArray['functablename']) {
-						$relatedItemObj = $tablesObj->get($funcArray['functablename'], false);
-						$parentFuncTablename = $funcArray['functablename'];
-					}
-					$tableConf = $relatedItemObj->getTableConf($funcArray['code']);
-					$orderBy = '';
-					if (isset($tableConf['orderBy'])) {
-						$orderBy = $tableConf['orderBy'];
-					}
-					$mergeRow = [];
-					$parentRows = [];
-					$relatedIds =
-						$itemObj->getRelated(
-							$parentFuncTablename,
-							$parentRows,
+                if (isset($viewTagArray[$funcArray['marker']]) && $funcArray['require']) {
+                    $relatedItemObj = $itemObj;
+                    $parentFuncTablename = '';
+                    if ($funcTablename != $funcArray['functablename']) {
+                        $relatedItemObj = $tablesObj->get($funcArray['functablename'], false);
+                        $parentFuncTablename = $funcArray['functablename'];
+                    }
+                    $tableConf = $relatedItemObj->getTableConf($funcArray['code']);
+                    $orderBy = '';
+                    if (isset($tableConf['orderBy'])) {
+                        $orderBy = $tableConf['orderBy'];
+                    }
+                    $mergeRow = [];
+                    $parentRows = [];
+                    $relatedIds =
+                        $itemObj->getRelated(
+                            $parentFuncTablename,
+                            $parentRows,
                             $multiOrderArray,
-							$uid,
-							$subtype,
-							$orderBy
-						);
-	
-					if (count($relatedIds)) {
-						// List all products:
+                            $uid,
+                            $subtype,
+                            $orderBy
+                        );
+    
+                    if (count($relatedIds)) {
+                        // List all products:
 
-						if (!is_object($listView)) {
+                        if (!is_object($listView)) {
 
-							$listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
-							$listView->init(
-								$pid,
-								$paramUidArray,
-								$tmp = $this->pidListObj->getPidlist(),
-								0
-							);
-						}
-						$callFunctableArray = $funcArray['callFunctableArray'];
-						$listPids = $funcArray['additionalPages'];
-						if ($listPids != '') {
-							$this->pidListObj->applyRecursive($config['recursive'], $listPids);
-						} else {
-							$listPids = $this->pidListObj->getPidlist();
-						}
+                            $listView = GeneralUtility::makeInstance('tx_ttproducts_list_view');
+                            $listView->init(
+                                $pid,
+                                $paramUidArray,
+                                $tmp = $this->pidListObj->getPidlist(),
+                                0
+                            );
+                        }
+                        $callFunctableArray = $funcArray['callFunctableArray'];
+                        $listPids = $funcArray['additionalPages'];
+                        if ($listPids != '') {
+                            $this->pidListObj->applyRecursive($config['recursive'], $listPids);
+                        } else {
+                            $listPids = $this->pidListObj->getPidlist();
+                        }
 
-						$parentDataArray = [
-							'functablename' => $funcTablename,
-							'uid' => $uid
-						];
+                        $parentDataArray = [
+                            'functablename' => $funcTablename,
+                            'uid' => $uid
+                        ];
 
-						$productRowArray = [];
-						$bEditableVariants = true;
+                        $productRowArray = [];
+                        $bEditableVariants = true;
 
-						$tmpContent = $listView->printView(
-							$templateCode,
-							$funcArray['code'],
-							$funcArray['functablename'],
-							implode(',', $relatedIds),
-							$listPids,
-							'',
-							$error_code,
-							$funcArray['template'] . $config['templateSuffix'],
-							$pageAsCategory,
-							tx_ttproducts_control_basket::getBasketExtra(),
-							tx_ttproducts_control_basket::getRecs(),
-							$mergeRow,
-							1,
-							$callFunctableArray,
-							$parentDataArray,
-							$parentProductRow,
-							$parentFuncTablename,
-							$parentRows,
-							$notOverwritePriceIfSet,
-							$multiOrderArray,
-							$productRowArray,
-							$bEditableVariants
-						);
-						$result['###' . $funcArray['marker'] . '###'] = $tmpContent;
-					} else {
-						$result['###' . $funcArray['marker'] . '###'] = '';
-					}
-				} else {
-					if (isset($viewTagArray[$funcArray['marker']])) {
-						$result['###' . $funcArray['marker'] . '###'] = '';
-					}
-				}
-			}
-		}
+                        $tmpContent = $listView->printView(
+                            $templateCode,
+                            $funcArray['code'],
+                            $funcArray['functablename'],
+                            implode(',', $relatedIds),
+                            $listPids,
+                            '',
+                            $error_code,
+                            $funcArray['template'] . $config['templateSuffix'],
+                            $pageAsCategory,
+                            tx_ttproducts_control_basket::getBasketExtra(),
+                            tx_ttproducts_control_basket::getRecs(),
+                            $mergeRow,
+                            1,
+                            $callFunctableArray,
+                            $parentDataArray,
+                            $parentProductRow,
+                            $parentFuncTablename,
+                            $parentRows,
+                            $notOverwritePriceIfSet,
+                            $multiOrderArray,
+                            $productRowArray,
+                            $bEditableVariants
+                        );
+                        $result['###' . $funcArray['marker'] . '###'] = $tmpContent;
+                    } else {
+                        $result['###' . $funcArray['marker'] . '###'] = '';
+                    }
+                } else {
+                    if (isset($viewTagArray[$funcArray['marker']])) {
+                        $result['###' . $funcArray['marker'] . '###'] = '';
+                    }
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/view/class.tx_ttproducts_search_view.php
+++ b/view/class.tx_ttproducts_search_view.php
@@ -42,94 +42,94 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_search_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $config;
+    public $conf;
+    public $config;
 
 
-	public function init () {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    public function init () {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
 
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
-	}
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
+    }
 
-	/**
-	 * Displays the search for the first letter
-	 */
-	public function &printFirstletter ($pibaseObj, &$templateCode, $columns, &$error_code) {
-		// local_table
+    /**
+     * Displays the search for the first letter
+     */
+    public function &printFirstletter ($pibaseObj, &$templateCode, $columns, &$error_code) {
+        // local_table
 
 /*		$ctrlArray = GeneralUtility::makeInstance('tx_ttproducts_model_control');
-		$ctrlArray = tx_ttproducts_model_control::$tableParamsArray;*/
+        $ctrlArray = tx_ttproducts_model_control::$tableParamsArray;*/
 
-		$searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
+        $searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
 
-		$paramArray = [
-			'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
-			'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']],
-		];
-		$rc = $searboxViewObj->printFirstletter($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['fields'], $this->config['group_by_fields'], $this->config['all'], $this->config['delimiter'], $error_code);
-		return $rc;
-	}
+        $paramArray = [
+            'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
+            'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']],
+        ];
+        $rc = $searboxViewObj->printFirstletter($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['fields'], $this->config['group_by_fields'], $this->config['all'], $this->config['delimiter'], $error_code);
+        return $rc;
+    }
 
-	/**
-	 * Displays the search for the year
-	 */
-	public function printYear ($pibaseObj, &$templateCode, $columns, &$error_code) {
+    /**
+     * Displays the search for the year
+     */
+    public function printYear ($pibaseObj, &$templateCode, $columns, &$error_code) {
 
-		$searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
-		$paramArray = array(
-			'local' => array('table' => $this->config['local_table'], 'param' => $this->config['local_param']),
-			'foreign' => array('table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']),
-		);
-		$rc = $searboxViewObj->printYear($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $this->config['all'], $error_code);
+        $searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
+        $paramArray = array(
+            'local' => array('table' => $this->config['local_table'], 'param' => $this->config['local_param']),
+            'foreign' => array('table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']),
+        );
+        $rc = $searboxViewObj->printYear($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $this->config['all'], $error_code);
 
-		return $rc;
-	}
+        return $rc;
+    }
 
-	/**
-	 * Displays the search for the key field
-	 */
-	public function printKeyField ($pibaseObj, &$templateCode, $columns, $type, $formid, $keyfieldConf, &$error_code) {
+    /**
+     * Displays the search for the key field
+     */
+    public function printKeyField ($pibaseObj, &$templateCode, $columns, $type, $formid, $keyfieldConf, &$error_code) {
 
-		$searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
-		$paramArray = [
-			'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
-			'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']
-		];
+        $searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
+        $paramArray = [
+            'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
+            'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']
+        ];
 
-		$rc = $searboxViewObj->printKeyField($pibaseObj,$pibaseObj->prefixId,$this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $type, $this->config['url'], $this->config['all'], $keyfieldConf, $formid, $error_code);
+        $rc = $searboxViewObj->printKeyField($pibaseObj,$pibaseObj->prefixId,$this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $type, $this->config['url'], $this->config['all'], $keyfieldConf, $formid, $error_code);
 
-		return $rc;
-	}
+        return $rc;
+    }
 
-	/**
-	 * Displays the search for the last entries
-	 */
-	public function &printLastEntries ($pibaseObj, &$templateCode, $columns, &$error_code) {
+    /**
+     * Displays the search for the last entries
+     */
+    public function &printLastEntries ($pibaseObj, &$templateCode, $columns, &$error_code) {
 
-		$searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
-		$paramArray = [
-			'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
-			'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']]
-		];
-		$rc = $searboxViewObj->printLastEntries($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $error_code);
+        $searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
+        $paramArray = [
+            'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
+            'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']]
+        ];
+        $rc = $searboxViewObj->printLastEntries($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $error_code);
 
-		return $rc;
-	}
+        return $rc;
+    }
 
-	/**
-	 * Displays the search for the last entries
-	 */
-	public function &printTextField ($pibaseObj, &$templateCode, $columns, $formid, $contentRow, &$error_code) {
+    /**
+     * Displays the search for the last entries
+     */
+    public function &printTextField ($pibaseObj, &$templateCode, $columns, $formid, $contentRow, &$error_code) {
 
-		$searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
-		$paramArray = [
-			'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
-			'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']]
-		];
-		$rc = $searboxViewObj->printTextField($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $this->config['url'], $formid, $contentRow['uid'], $error_code);
-		return $rc;
-	}
+        $searboxViewObj = GeneralUtility::makeInstance('tx_searchbox_view');
+        $paramArray = [
+            'local' => ['table' => $this->config['local_table'], 'param' => $this->config['local_param']],
+            'foreign' => ['table' => $this->config['foreign_table'], 'param' => $this->config['foreign_param']]
+        ];
+        $rc = $searboxViewObj->printTextField($pibaseObj,$pibaseObj->prefixId, $this->conf['PIDlistDisplay'], $templateCode, $columns, $paramArray, $this->config['parameters'], $this->config['fields'], $this->config['url'], $formid, $contentRow['uid'], $error_code);
+        return $rc;
+    }
 }
 

--- a/view/class.tx_ttproducts_selectcat_view.php
+++ b/view/class.tx_ttproducts_selectcat_view.php
@@ -43,266 +43,266 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_selectcat_view extends tx_ttproducts_catlist_view_base {
 
-	protected $htmlTagMain = 'select';	// main HTML tag
-	protected $htmlTagElement = 'option';
+    protected $htmlTagMain = 'select';	// main HTML tag
+    protected $htmlTagElement = 'option';
 
-	// returns the products list view
-	public function printView (
-		$functablename,
-		&$templateCode,
-		$theCode,
-		&$error_code,
-		$templateArea = 'ITEM_CATEGORY_SELECT_TEMPLATE',
-		$pageAsCategory,
-		$templateSuffix = '',
-		$basketExtra,
-		$basketRecs
-	) {
+    // returns the products list view
+    public function printView (
+        $functablename,
+        &$templateCode,
+        $theCode,
+        &$error_code,
+        $templateArea = 'ITEM_CATEGORY_SELECT_TEMPLATE',
+        $pageAsCategory,
+        $templateSuffix = '',
+        $basketExtra,
+        $basketRecs
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$content = '';
-		$out = '';
-		$where = '';
+        $content = '';
+        $out = '';
+        $where = '';
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$categoryTableView = $tablesObj->get($functablename,1);
-		$categoryTable = $categoryTableView->getModelObj();
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $categoryTableView = $tablesObj->get($functablename,1);
+        $categoryTable = $categoryTableView->getModelObj();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
 
-		$bSeparated = false;
-		$method = 'clickShow';
-		$t = [];
-		$ctrlArray = [];
+        $bSeparated = false;
+        $method = 'clickShow';
+        $t = [];
+        $ctrlArray = [];
 
-		parent::getPrintViewArrays(
-			$functablename,
-			$templateCode,
-			$t,
-			$htmlParts,
-			$theCode,
-			$error_code,
-			$templateArea,
-			$pageAsCategory,
-			$templateSuffix,
-			$basketExtra,
-			$basketRecs,
-			$currentCat,
-			$categoryArray,
-			$catArray,
-			$activeRootline,
-			$rootpathArray,
-			$subCategoryMarkers,
-			$ctrlArray
-		);
+        parent::getPrintViewArrays(
+            $functablename,
+            $templateCode,
+            $t,
+            $htmlParts,
+            $theCode,
+            $error_code,
+            $templateArea,
+            $pageAsCategory,
+            $templateSuffix,
+            $basketExtra,
+            $basketRecs,
+            $currentCat,
+            $categoryArray,
+            $catArray,
+            $activeRootline,
+            $rootpathArray,
+            $subCategoryMarkers,
+            $ctrlArray
+        );
 
-		if (empty($error_code)) {
-			$count = 0;
-			$depth = 1;
-			if($pos = strpos($t['listFrameWork'], '###CATEGORY_SINGLE_')) {
-				$bSeparated = true;
-			}
+        if (empty($error_code)) {
+            $count = 0;
+            $depth = 1;
+            if($pos = strpos($t['listFrameWork'], '###CATEGORY_SINGLE_')) {
+                $bSeparated = true;
+            }
 
-			$contentId = '';
+            $contentId = '';
 
-			$contentPos = strpos($this->cObj->currentRecord, 'tt_content');
-			if ($contentPos !== false) {
-				$contentIdPos = strpos($this->cObj->currentRecord, ':');
-				$contentId = substr($this->cObj->currentRecord, $contentIdPos + 1);
-			}
+            $contentPos = strpos($this->cObj->currentRecord, 'tt_content');
+            if ($contentPos !== false) {
+                $contentIdPos = strpos($this->cObj->currentRecord, ':');
+                $contentId = substr($this->cObj->currentRecord, $contentIdPos + 1);
+            }
 
-			$menu = $conf['CSS.'][$functablename . '.']['menu'];
-			$menu = ($menu ? $menu : $categoryTableView->getPivar() . '-' . $contentId . '-' . $depth);
-			$fillOnchange = '';
-			if ($method == 'clickShow') {
-				if ($bSeparated) {
-					$fillOnchange = 'fillSelect(this, 2, ' . $contentId . ', 1);';
-				} else {
-					$fillOnchange = 'fillSelect(this, 0, ' . $contentId . ', 0);';
-				}
-			}
+            $menu = $conf['CSS.'][$functablename . '.']['menu'];
+            $menu = ($menu ? $menu : $categoryTableView->getPivar() . '-' . $contentId . '-' . $depth);
+            $fillOnchange = '';
+            if ($method == 'clickShow') {
+                if ($bSeparated) {
+                    $fillOnchange = 'fillSelect(this, 2, ' . $contentId . ', 1);';
+                } else {
+                    $fillOnchange = 'fillSelect(this, 0, ' . $contentId . ', 0);';
+                }
+            }
 
-			$selectArray = [];
-			if (
-				isset($conf['form.'][$theCode . '.']) &&
-				is_array($conf['form.'][$theCode . '.']) &&
-				is_array($conf['form.'][$theCode . '.']['dataArray.'])
-			) {
-				foreach ($conf['form.'][$theCode . '.']['dataArray.'] as $k => $setting) {
-					if (is_array($setting)) {
-						$selectArray[$k] = [];
-						$type = $setting['type'];
-						if ($type) {
-							$parts = GeneralUtility::trimExplode('=', $type);
-							if ($parts[1] == 'select') {
-								$selectArray[$k]['name'] = $parts[0];
-							}
-						}
-						$label = $setting['label'];
-						if ($label) {
-							$selectArray[$k]['label'] = $label;
-						}
-						$params = $setting['params'];
-						if ($params) {
-							$selectArray[$k]['params'] = $params;
-						}
-					}
-				}
-			}
+            $selectArray = [];
+            if (
+                isset($conf['form.'][$theCode . '.']) &&
+                is_array($conf['form.'][$theCode . '.']) &&
+                is_array($conf['form.'][$theCode . '.']['dataArray.'])
+            ) {
+                foreach ($conf['form.'][$theCode . '.']['dataArray.'] as $k => $setting) {
+                    if (is_array($setting)) {
+                        $selectArray[$k] = [];
+                        $type = $setting['type'];
+                        if ($type) {
+                            $parts = GeneralUtility::trimExplode('=', $type);
+                            if ($parts[1] == 'select') {
+                                $selectArray[$k]['name'] = $parts[0];
+                            }
+                        }
+                        $label = $setting['label'];
+                        if ($label) {
+                            $selectArray[$k]['label'] = $label;
+                        }
+                        $params = $setting['params'];
+                        if ($params) {
+                            $selectArray[$k]['params'] = $params;
+                        }
+                    }
+                }
+            }
 
-			$label = '';
-			$name = 'tt_products[' . strtolower($theCode) . ']';
+            $label = '';
+            $name = 'tt_products[' . strtolower($theCode) . ']';
 
-			reset($selectArray);
-			$select = current($selectArray);
+            reset($selectArray);
+            $select = current($selectArray);
 
-			if (is_array($select)) {
-				if ($select['name']) {
-					$name = $select['name'];
-				}
-				if ($select['label']) {
-					$label = $select['label'] . ' ';
-				}
-				if ($select['params']) {
-					$params = $select['params'];
-				}
-			}
+            if (is_array($select)) {
+                if ($select['name']) {
+                    $name = $select['name'];
+                }
+                if ($select['label']) {
+                    $label = $select['label'] . ' ';
+                }
+                if ($select['params']) {
+                    $params = $select['params'];
+                }
+            }
 
-			$selectedKey = '0';
-			$valueArray = [];
-			$valueArray['0'] = '';
-			$selectedCat = $currentCat;
+            $selectedKey = '0';
+            $valueArray = [];
+            $valueArray['0'] = '';
+            $selectedCat = $currentCat;
 
-			if (is_array($catArray[$depth])) {
-				foreach ($catArray[$depth] as $k => $actCategory) {
-					if (!$categoryArray[$actCategory]['reference_category']) {
-						$valueArray[$actCategory] = $categoryArray[$actCategory]['title'];
-					} else
-						{
-					}
-				}
-			}
+            if (is_array($catArray[$depth])) {
+                foreach ($catArray[$depth] as $k => $actCategory) {
+                    if (!$categoryArray[$actCategory]['reference_category']) {
+                        $valueArray[$actCategory] = $categoryArray[$actCategory]['title'];
+                    } else
+                        {
+                    }
+                }
+            }
 
-			$mainAttributeArray = [];
-			$mainAttributeArray['id'] = $menu;
-			if ($fillOnchange != '') {
-				$mainAttributeArray['onchange'] = $fillOnchange;
-			}
+            $mainAttributeArray = [];
+            $mainAttributeArray['id'] = $menu;
+            if ($fillOnchange != '') {
+                $mainAttributeArray['onchange'] = $fillOnchange;
+            }
 
-			$foreignRootLine = $categoryTable->getRootline(['0'], $currentCat, 0);
+            $foreignRootLine = $categoryTable->getRootline(['0'], $currentCat, 0);
 
-			if (is_array($foreignRootLine)) {
-				foreach ($foreignRootLine as $cat => $foreignRow) {
-					if (
-						isset($valueArray[$cat]) ||
-						(
-							isset($categoryArray[$cat]) &&
-							$categoryArray[$cat]['reference_category'] > 0 &&
-							isset($valueArray[$categoryArray[$cat]['reference_category']])
-						)
-					) {
-						$mainAttributeArray['disabled'] = 'disabled';
-						$selectedCat = $cat;
-						if (!isset($valueArray[$cat])) {
-							$selectedCat = $categoryArray[$cat]['reference_category'];
-						}
-						$mainAttributeArray['class'] .= (isset($mainAttributeArray['class']) ? ' ' : '') . 'sel-inactive';
-						break;
-					}
-				}
-			}
+            if (is_array($foreignRootLine)) {
+                foreach ($foreignRootLine as $cat => $foreignRow) {
+                    if (
+                        isset($valueArray[$cat]) ||
+                        (
+                            isset($categoryArray[$cat]) &&
+                            $categoryArray[$cat]['reference_category'] > 0 &&
+                            isset($valueArray[$categoryArray[$cat]['reference_category']])
+                        )
+                    ) {
+                        $mainAttributeArray['disabled'] = 'disabled';
+                        $selectedCat = $cat;
+                        if (!isset($valueArray[$cat])) {
+                            $selectedCat = $categoryArray[$cat]['reference_category'];
+                        }
+                        $mainAttributeArray['class'] .= (isset($mainAttributeArray['class']) ? ' ' : '') . 'sel-inactive';
+                        break;
+                    }
+                }
+            }
 
-			$paramArray = GeneralUtility::get_tag_attributes($params);
-			if (isset($paramArray) && is_array($paramArray)) {
-				$mainAttributeArray = array_merge($mainAttributeArray, $paramArray);
-			}
+            $paramArray = GeneralUtility::get_tag_attributes($params);
+            if (isset($paramArray) && is_array($paramArray)) {
+                $mainAttributeArray = array_merge($mainAttributeArray, $paramArray);
+            }
 
-			if (!$valueArray[$selectedCat]) {
-				$selectedCat = '0';
-			}
+            if (!$valueArray[$selectedCat]) {
+                $selectedCat = '0';
+            }
 
-			$selectOut = tx_ttproducts_form_div::createSelect(
-				$languageObj,
-				$valueArray,
-				$name,
-				$selectedCat,
-				$bSelectTags = true,
-				$bTranslateText = false,
-				[],
-				$this->htmlTagMain,
-				$mainAttributeArray,
-				$layout = '',
-				$imageFileArray = '',
-				$keyMarkerArray = ''
-			);
-			$out = $label . $selectOut;
+            $selectOut = tx_ttproducts_form_div::createSelect(
+                $languageObj,
+                $valueArray,
+                $name,
+                $selectedCat,
+                $bSelectTags = true,
+                $bTranslateText = false,
+                [],
+                $this->htmlTagMain,
+                $mainAttributeArray,
+                $layout = '',
+                $imageFileArray = '',
+                $keyMarkerArray = ''
+            );
+            $out = $label . $selectOut;
 
-			$markerArray = [];
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
-			$markerArray =
-				$this->urlObj->addURLMarkers(
-					$conf['PIDlistDisplay'] ?? 0,
-					$markerArray
-				);
-			$this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
-			$subpartArray['###CATEGORY_SINGLE###'] = $out;
+            $markerArray = [];
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
+            $markerArray =
+                $this->urlObj->addURLMarkers(
+                    $conf['PIDlistDisplay'] ?? 0,
+                    $markerArray
+                );
+            $this->urlObj->getWrappedSubpartArray($wrappedSubpartArray);
+            $subpartArray['###CATEGORY_SINGLE###'] = $out;
 
-			$count = intval(substr_count($t['listFrameWork'], '###CATEGORY_SINGLE_') / 2);
-			if ($pageAsCategory == 2) {
-				// $catid = 'pid';
-				$parentFieldArray = ['pid'];
-			} else {
-				// $catid = 'cat';
-				$parentFieldArray = ['parent_category'];
-			}
-			$piVar = $categoryTableView->piVar;
+            $count = intval(substr_count($t['listFrameWork'], '###CATEGORY_SINGLE_') / 2);
+            if ($pageAsCategory == 2) {
+                // $catid = 'pid';
+                $parentFieldArray = ['pid'];
+            } else {
+                // $catid = 'cat';
+                $parentFieldArray = ['parent_category'];
+            }
+            $piVar = $categoryTableView->piVar;
 
-			if ($method == 'clickShow') {
-				$javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
-				$javaScriptObj->set(
-					$languageObj,
-					'selectcat',
-					[$categoryArray],
-					$this->cObj->currentRecord,
-					1 + $count,
-					'cat',
-					$parentFieldArray,
-					[$piVar],
-					[],
-					'clickShow'
-				);
-			}
+            if ($method == 'clickShow') {
+                $javaScriptObj = GeneralUtility::makeInstance('tx_ttproducts_javascript');
+                $javaScriptObj->set(
+                    $languageObj,
+                    'selectcat',
+                    [$categoryArray],
+                    $this->cObj->currentRecord,
+                    1 + $count,
+                    'cat',
+                    $parentFieldArray,
+                    [$piVar],
+                    [],
+                    'clickShow'
+                );
+            }
 
-			if ($bSeparated) {
-				for ($i = 2; $i <= 1 + $count; ++$i) {
-					$menu = $piVar . '-' . $contentId . '-' . $i;
-					$bShowSubcategories = ($i < 1 + $count ? 1 : 0);
-					$boxNumber = ($i < 1 + $count ? ($i + 1) : 0);
-					$fill = ' onchange="fillSelect(this, ' . $boxNumber . ', ' . $contentId . ', ' . $bShowSubcategories . ');"';
-					$tmp = '<' . $this->htmlTagMain .
-						' name="' . $name . '"' .
-						' id="' . $menu . '"' . $fill . '>';
-					$tmp .= '<' . $this->htmlTagElement . ' value="0"></' . $this->htmlTagElement . '>';
-					$tmp .= '</' . $this->htmlTagMain . '>';
-					$subpartArray['###CATEGORY_SINGLE_' . $i . '###'] = $tmp;
-				}
+            if ($bSeparated) {
+                for ($i = 2; $i <= 1 + $count; ++$i) {
+                    $menu = $piVar . '-' . $contentId . '-' . $i;
+                    $bShowSubcategories = ($i < 1 + $count ? 1 : 0);
+                    $boxNumber = ($i < 1 + $count ? ($i + 1) : 0);
+                    $fill = ' onchange="fillSelect(this, ' . $boxNumber . ', ' . $contentId . ', ' . $bShowSubcategories . ');"';
+                    $tmp = '<' . $this->htmlTagMain .
+                        ' name="' . $name . '"' .
+                        ' id="' . $menu . '"' . $fill . '>';
+                    $tmp .= '<' . $this->htmlTagElement . ' value="0"></' . $this->htmlTagElement . '>';
+                    $tmp .= '</' . $this->htmlTagMain . '>';
+                    $subpartArray['###CATEGORY_SINGLE_' . $i . '###'] = $tmp;
+                }
 
-				// $subpartArray['###CATEGORY_SINGLE_BUTTON'] = '<input type="button" value="Laden" onclick="fillSelect(0, '.$boxNumber.','.$bShowSubcategories.');">';
-			}
+                // $subpartArray['###CATEGORY_SINGLE_BUTTON'] = '<input type="button" value="Laden" onclick="fillSelect(0, '.$boxNumber.','.$bShowSubcategories.');">';
+            }
 
-			$out =
-				$templateService->substituteMarkerArrayCached(
-					$t['listFrameWork'],
-					$markerArray,
-					$subpartArray,
-					$wrappedSubpartArray
-				);
-			$content = $out;
-		}
+            $out =
+                $templateService->substituteMarkerArrayCached(
+                    $t['listFrameWork'],
+                    $markerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
+            $content = $out;
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 }
 

--- a/view/class.tx_ttproducts_single_view.php
+++ b/view/class.tx_ttproducts_single_view.php
@@ -44,576 +44,576 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $config;
-	public $uid; 	// product id
-	public $type = 'product'; 	// 'product', 'article' or 'dam'
-	public $variants; 	// different attributes
-	public $pid; // PID where to go
-	public $useArticles;
-	public $uidArray = [];
-	public $pidListObj;
+    public $conf;
+    public $config;
+    public $uid; 	// product id
+    public $type = 'product'; 	// 'product', 'article' or 'dam'
+    public $variants; 	// different attributes
+    public $pid; // PID where to go
+    public $useArticles;
+    public $uidArray = [];
+    public $pidListObj;
 
 
-	public function init (
-		$uidArray,
-		$extVars,
-		$pid,
-		$useArticles,
-		$pid_list,
-		$recursive
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
+    public function init (
+        $uidArray,
+        $extVars,
+        $pid,
+        $useArticles,
+        $pid_list,
+        $recursive
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
 
-		if (count($uidArray)) {
-			$this->uidArray = $uidArray;
-			reset($uidArray);
-			if (isset($uidArray['product'])) {
-				$this->type = 'product';
-				$this->uid = $uidArray['product'];
-			} else if (isset($uidArray['article'])) {
-				$this->uid = $uidArray['article'];
-				$this->type = 'article';
-			} else if (isset($uidArray['dam']) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
-				$this->type = 'dam';
-				$this->uid = $uidArray['dam'];
-			}
-		}
+        if (count($uidArray)) {
+            $this->uidArray = $uidArray;
+            reset($uidArray);
+            if (isset($uidArray['product'])) {
+                $this->type = 'product';
+                $this->uid = $uidArray['product'];
+            } else if (isset($uidArray['article'])) {
+                $this->uid = $uidArray['article'];
+                $this->type = 'article';
+            } else if (isset($uidArray['dam']) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
+                $this->type = 'dam';
+                $this->uid = $uidArray['dam'];
+            }
+        }
 
-		$this->variants = $extVars;
-		$this->pid = $pid;
-		if ($this->type != 'product') {	// articles are only possible for products
-			$useArticles = 0;
-		}
-		$this->useArticles = $useArticles;
-		$this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
-		$this->pidListObj->applyRecursive($recursive, $pid_list, true);
-		$this->pidListObj->setPageArray();
-	}
+        $this->variants = $extVars;
+        $this->pid = $pid;
+        if ($this->type != 'product') {	// articles are only possible for products
+            $useArticles = 0;
+        }
+        $this->useArticles = $useArticles;
+        $this->pidListObj = GeneralUtility::makeInstance('tx_ttproducts_pid_list');
+        $this->pidListObj->applyRecursive($recursive, $pid_list, true);
+        $this->pidListObj->setPageArray();
+    }
 
 
-	// returns the single view
-	public function printView (
-		$templateCode,
-		&$errorCode,
-		$pageAsCategory,
-		$templateSuffix = ''
-	) {
+    // returns the single view
+    public function printView (
+        $templateCode,
+        &$errorCode,
+        $pageAsCategory,
+        $templateSuffix = ''
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
-		$javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
+        $basketObj = GeneralUtility::makeInstance('tx_ttproducts_basket');
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $subpartmarkerObj = GeneralUtility::makeInstance('tx_ttproducts_subpartmarker');
+        $javaScriptMarker = GeneralUtility::makeInstance('tx_ttproducts_javascript_marker');
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $urlObj = GeneralUtility::makeInstance('tx_ttproducts_url_view');
         $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
 
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$conf = $cnf->getConf();
-		$externalRowArray = [];
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $conf = $cnf->getConf();
+        $externalRowArray = [];
 
-		$theCode = 'SINGLE';
+        $theCode = 'SINGLE';
 
-		$basketExt = tx_ttproducts_control_basket::getBasketExt();
-		$basketExtra = tx_ttproducts_control_basket::getBasketExtra();
-		$basketRecs =  tx_ttproducts_control_basket::getRecs();
-		$prodRow = [];
+        $basketExt = tx_ttproducts_control_basket::getBasketExt();
+        $basketExtra = tx_ttproducts_control_basket::getBasketExtra();
+        $basketRecs =  tx_ttproducts_control_basket::getRecs();
+        $prodRow = [];
 
-		$useBackPid = true;
-		$viewControlConf = $cnf->getViewControlConf('SINGLE');
+        $useBackPid = true;
+        $viewControlConf = $cnf->getViewControlConf('SINGLE');
 
-		if (count($viewControlConf)) {
-			if (isset($viewControlConf['param.']) && is_array($viewControlConf['param.'])) {
-				$viewParamConf = $viewControlConf['param.'];
-			}
+        if (count($viewControlConf)) {
+            if (isset($viewControlConf['param.']) && is_array($viewControlConf['param.'])) {
+                $viewParamConf = $viewControlConf['param.'];
+            }
 
-			if (
-				isset($viewControlConf['links.']) &&
-				is_array($viewControlConf['links.'])
-			) {
-				$linkConfArray = $viewControlConf['links.'];
-			}
-		}
+            if (
+                isset($viewControlConf['links.']) &&
+                is_array($viewControlConf['links.'])
+            ) {
+                $linkConfArray = $viewControlConf['links.'];
+            }
+        }
 
-		$useBackPid = (isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ? true : false);
+        $useBackPid = (isset($viewParamConf) && $viewParamConf['use'] == 'backPID' ? true : false);
 
-		$itemTableArray = [];
-		$itemTableArray['product'] = $tablesObj->get('tt_products');
-		$tableConf = $itemTableArray['product']->getTableConf('SINGLE');
-		$itemTableArray['product']->initCodeConf('SINGLE', $tableConf);
-		$itemTableArray['article'] = $tablesObj->get('tt_products_articles');
-		$tableConf = $itemTableArray['article']->getTableConf('SINGLE');
-		$itemTableArray['article']->initCodeConf('SINGLE', $tableConf);
-		$itemTableViewArray = [];
-		$itemTableViewArray['product'] = $tablesObj->get('tt_products', true);
-		$itemTableViewArray['article'] = $tablesObj->get('tt_products_articles', true);
-		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
-			$itemTableArray['dam'] = $tablesObj->get('tx_dam');
-			$itemTableViewArray['dam'] = $tablesObj->get('tx_dam', true);
-		}
-		$funcTablename = $itemTableArray[$this->type]->getFuncTablename();
+        $itemTableArray = [];
+        $itemTableArray['product'] = $tablesObj->get('tt_products');
+        $tableConf = $itemTableArray['product']->getTableConf('SINGLE');
+        $itemTableArray['product']->initCodeConf('SINGLE', $tableConf);
+        $itemTableArray['article'] = $tablesObj->get('tt_products_articles');
+        $tableConf = $itemTableArray['article']->getTableConf('SINGLE');
+        $itemTableArray['article']->initCodeConf('SINGLE', $tableConf);
+        $itemTableViewArray = [];
+        $itemTableViewArray['product'] = $tablesObj->get('tt_products', true);
+        $itemTableViewArray['article'] = $tablesObj->get('tt_products_articles', true);
+        if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam')) {
+            $itemTableArray['dam'] = $tablesObj->get('tx_dam');
+            $itemTableViewArray['dam'] = $tablesObj->get('tx_dam', true);
+        }
+        $funcTablename = $itemTableArray[$this->type]->getFuncTablename();
 
-		$rowArray = ['product' => [], 'article' => [], 'dam' => []];
-		$itemTableConf = $rowArray;
-		$itemTableLangFields = $rowArray;
-		$content = '';
-		$wherePid = '';
+        $rowArray = ['product' => [], 'article' => [], 'dam' => []];
+        $itemTableConf = $rowArray;
+        $itemTableLangFields = $rowArray;
+        $content = '';
+        $wherePid = '';
 
-		if (
-			$this->config['displayCurrentRecord'] &&
-			$this->type == 'product' &&
-			!$this->useArticles
-		) {
-			$rowArray[$this->type] = $cObj->data;
-		} else if ($this->uid) {
-			$pid_list = $this->pidListObj->getPidlist();
-			if ($pid_list != '-1') {
-				$wherePid = 'pid IN (' . $pid_list . ')';
-			}
-			$rowArray[$this->type] =
-				$itemTableArray[$this->type]->get(
-					$this->uid,
-					0,
-					true,
-					$wherePid
-				);
-			$itemTableConf[$this->type] =
-				$cnf->getTableConf(
-					$itemTableArray[$this->type]->getFuncTablename(),
-					'SINGLE'
-				);
-			$itemTableLangFields[$this->type] =
-				$cnf->getTranslationFields($itemTableConf[$this->type]);
-			// TODO: $itemImageFields[$this->type] = $cnf->getImageFields($itemTableConf[$this->type]);
+        if (
+            $this->config['displayCurrentRecord'] &&
+            $this->type == 'product' &&
+            !$this->useArticles
+        ) {
+            $rowArray[$this->type] = $cObj->data;
+        } else if ($this->uid) {
+            $pid_list = $this->pidListObj->getPidlist();
+            if ($pid_list != '-1') {
+                $wherePid = 'pid IN (' . $pid_list . ')';
+            }
+            $rowArray[$this->type] =
+                $itemTableArray[$this->type]->get(
+                    $this->uid,
+                    0,
+                    true,
+                    $wherePid
+                );
+            $itemTableConf[$this->type] =
+                $cnf->getTableConf(
+                    $itemTableArray[$this->type]->getFuncTablename(),
+                    'SINGLE'
+                );
+            $itemTableLangFields[$this->type] =
+                $cnf->getTranslationFields($itemTableConf[$this->type]);
+            // TODO: $itemImageFields[$this->type] = $cnf->getImageFields($itemTableConf[$this->type]);
 
-			if ($this->type == 'product' || $this->type == 'dam') {
-				if ($this->variants) {
-					$itemTableArray[$this->type]->getVariant()->modifyRowFromVariant(
-						$rowArray[$this->type],
-						$this->variants
-					);
-				}
-			} else if ($this->type == 'article') {
-				$where = 'pid IN (' . $this->pidListObj->getPidlist() . ')';
-				$rowArray['product'] =
-					$itemTableArray['product']->get(
-						intval($rowArray[$this->type]['uid_product']),
-						0,
-						true,
-						$wherePid
-					);
+            if ($this->type == 'product' || $this->type == 'dam') {
+                if ($this->variants) {
+                    $itemTableArray[$this->type]->getVariant()->modifyRowFromVariant(
+                        $rowArray[$this->type],
+                        $this->variants
+                    );
+                }
+            } else if ($this->type == 'article') {
+                $where = 'pid IN (' . $this->pidListObj->getPidlist() . ')';
+                $rowArray['product'] =
+                    $itemTableArray['product']->get(
+                        intval($rowArray[$this->type]['uid_product']),
+                        0,
+                        true,
+                        $wherePid
+                    );
 
-				$itemTableConf['product'] = $cnf->getTableConf($itemTableArray['product']->getFuncTablename(), 'SINGLE');
-				$itemTableLangFields['product'] = $cnf->getTranslationFields($itemTableConf['product']);
-				$itemImageFields['product'] = $cnf->getImageFields($itemTableConf['product']);
-				$itemTableArray['article']->mergeAttributeFields(
-					$rowArray['product'],
-					$rowArray['article'],
-					false,
-					false,
-					false,
-					'',
-					false
-				);
-			}
-		}
+                $itemTableConf['product'] = $cnf->getTableConf($itemTableArray['product']->getFuncTablename(), 'SINGLE');
+                $itemTableLangFields['product'] = $cnf->getTranslationFields($itemTableConf['product']);
+                $itemImageFields['product'] = $cnf->getImageFields($itemTableConf['product']);
+                $itemTableArray['article']->mergeAttributeFields(
+                    $rowArray['product'],
+                    $rowArray['article'],
+                    false,
+                    false,
+                    false,
+                    '',
+                    false
+                );
+            }
+        }
 
-		$origRow = $rowArray[$this->type];
+        $origRow = $rowArray[$this->type];
 
-		foreach ($itemTableLangFields as $type => $fieldArray) {
-			if (is_array($fieldArray)) {
-				foreach ($fieldArray as $field => $langfield) {
-					$rowArray[$type][$field] = $rowArray[$type][$langfield];
-				}
-			}
-		}
-		$row = $rowArray[$this->type];
-		$tablename = $itemTableArray[$this->type]->getTableObj()->getName();
+        foreach ($itemTableLangFields as $type => $fieldArray) {
+            if (is_array($fieldArray)) {
+                foreach ($fieldArray as $field => $langfield) {
+                    $rowArray[$type][$field] = $rowArray[$type][$langfield];
+                }
+            }
+        }
+        $row = $rowArray[$this->type];
+        $tablename = $itemTableArray[$this->type]->getTableObj()->getName();
 
-		if (!empty($row['uid'])) {
-			// $this->uid = intval ($row['uid']); // store the uid for later usage here
+        if (!empty($row['uid'])) {
+            // $this->uid = intval ($row['uid']); // store the uid for later usage here
 
-			$itemTableArray['product']->getTableObj()->transformRow($row, TT_PRODUCTS_EXT);
-			$useArticles = $itemTableArray['product']->getVariant()->getUseArticles();
+            $itemTableArray['product']->getTableObj()->transformRow($row, TT_PRODUCTS_EXT);
+            $useArticles = $itemTableArray['product']->getVariant()->getUseArticles();
 
-			if ($useArticles == 3) {
-				$itemTableArray['product']->fillVariantsFromArticles($row);
-			}
-				// add Global Marker Array
-			$markerArray = $markerObj->getGlobalMarkerArray();
-			$subpartArray = [];
-			$wrappedSubpartArray = [];
-			$pageObj = $tablesObj->get('pages');
+            if ($useArticles == 3) {
+                $itemTableArray['product']->fillVariantsFromArticles($row);
+            }
+                // add Global Marker Array
+            $markerArray = $markerObj->getGlobalMarkerArray();
+            $subpartArray = [];
+            $wrappedSubpartArray = [];
+            $pageObj = $tablesObj->get('pages');
 
-			$bIsGift = false; // no GIFT feature any more!
+            $bIsGift = false; // no GIFT feature any more!
 
-				// Get the subpart code
-			$subPartMarker ='';
+                // Get the subpart code
+            $subPartMarker ='';
 
-			if ($this->config['displayCurrentRecord']) {
-				$subPartMarker = 'ITEM_SINGLE_DISPLAY_RECORDINSERT';
-			} else if (
-				!$this->conf['alwaysInStock'] &&
-				$row['inStock'] <= 0 &&
-				$this->conf['showNotinStock'] &&
-				isset($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock']) &&
-				is_array($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock'])
-			) {
-				$subPartMarker = 'ITEM_SINGLE_DISPLAY_NOT_IN_STOCK';
-			} else {
-				if ($this->type == 'product') {
-					$subPartMarker = 'ITEM_SINGLE_DISPLAY';
-				} else if ($this->type == 'article') {
-					$subPartMarker = 'ARTICLE_SINGLE_DISPLAY';
-				} else if ($this->type == 'dam') {
-					$subPartMarker = 'DAM_SINGLE_DISPLAY';
-				}
-			}
+            if ($this->config['displayCurrentRecord']) {
+                $subPartMarker = 'ITEM_SINGLE_DISPLAY_RECORDINSERT';
+            } else if (
+                !$this->conf['alwaysInStock'] &&
+                $row['inStock'] <= 0 &&
+                $this->conf['showNotinStock'] &&
+                isset($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock']) &&
+                is_array($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock'])
+            ) {
+                $subPartMarker = 'ITEM_SINGLE_DISPLAY_NOT_IN_STOCK';
+            } else {
+                if ($this->type == 'product') {
+                    $subPartMarker = 'ITEM_SINGLE_DISPLAY';
+                } else if ($this->type == 'article') {
+                    $subPartMarker = 'ARTICLE_SINGLE_DISPLAY';
+                } else if ($this->type == 'dam') {
+                    $subPartMarker = 'DAM_SINGLE_DISPLAY';
+                }
+            }
 
-			// get categories
-			if (!$pageAsCategory || $pageAsCategory == 1) {
-				if ($this->type == 'product' || $this->type == 'article') {
-					$catTablename = 'tt_products_cat';
-				} else if ($this->type == 'dam') {
-					$catTablename = 'tx_dam_cat';
-				}
-			} else {
-				$catTablename = 'pages';
-			}
-			$viewCatViewTable = $tablesObj->get($catTablename, true);
-			$viewCatTable = $viewCatViewTable->getModelObj();
-			$categoryPivar = $viewCatViewTable->getPivar();
+            // get categories
+            if (!$pageAsCategory || $pageAsCategory == 1) {
+                if ($this->type == 'product' || $this->type == 'article') {
+                    $catTablename = 'tt_products_cat';
+                } else if ($this->type == 'dam') {
+                    $catTablename = 'tx_dam_cat';
+                }
+            } else {
+                $catTablename = 'pages';
+            }
+            $viewCatViewTable = $tablesObj->get($catTablename, true);
+            $viewCatTable = $viewCatViewTable->getModelObj();
+            $categoryPivar = $viewCatViewTable->getPivar();
 
-			// Add the template suffix
-			$subPartMarker = $subPartMarker.$templateSuffix;
-			$itemFrameWork = $templateService->getSubpart($templateCode, $subpartmarkerObj->spMarker('###' . $subPartMarker . '###'));
-			$checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
-			if (!empty($checkExpression)) {
-				$wrongPounds = preg_match_all($checkExpression, $itemFrameWork, $matches);
+            // Add the template suffix
+            $subPartMarker = $subPartMarker.$templateSuffix;
+            $itemFrameWork = $templateService->getSubpart($templateCode, $subpartmarkerObj->spMarker('###' . $subPartMarker . '###'));
+            $checkExpression = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['templateCheck'];
+            if (!empty($checkExpression)) {
+                $wrongPounds = preg_match_all($checkExpression, $itemFrameWork, $matches);
 
-				if ($wrongPounds) {
-					$errorCode[0] = 'template_invalid_marker_border';
-					$errorCode[1] = '###' . $subPartMarker . '###';
-					$errorCode[2] = htmlspecialchars(implode('|', $matches['0']));
+                if ($wrongPounds) {
+                    $errorCode[0] = 'template_invalid_marker_border';
+                    $errorCode[1] = '###' . $subPartMarker . '###';
+                    $errorCode[2] = htmlspecialchars(implode('|', $matches['0']));
 
-					return '';
-				}
-			}
+                    return '';
+                }
+            }
 
-			$t = [];
-			$t['categoryFrameWork'] = $templateService->getSubpart(
-				$itemFrameWork,
-				'###ITEM_CATEGORY###'
-			);
+            $t = [];
+            $t['categoryFrameWork'] = $templateService->getSubpart(
+                $itemFrameWork,
+                '###ITEM_CATEGORY###'
+            );
 
-			$urlObj->getWrappedSubpartArray(
-				$wrappedSubpartArray,[],
-				'',
-				$useBackPid
-			);
+            $urlObj->getWrappedSubpartArray(
+                $wrappedSubpartArray,[],
+                '',
+                $useBackPid
+            );
 
-			$excludeList = '';
+            $excludeList = '';
 
-			if (isset($viewParamConf) && is_array($viewParamConf)) {
-				if (!empty($viewParamConf['ignore'])) {
-					$excludeList = $viewParamConf['ignore'];
-				}
-				if (isset($viewParamConf['item']) && GeneralUtility::inList($viewParamConf['item'], $categoryPivar)) {
-					// nothing
-				} else {
-					$prefixId = tx_ttproducts_model_control::getPrefixId();
-					$excludeList .= ($excludeList != '' ? ',' : '') . $prefixId . '[' . $categoryPivar . ']';
-				}
-			}
-			$pidMemo = ($this->conf['PIDmemo'] ? $this->conf['PIDmemo'] : $GLOBALS['TSFE']->id);
+            if (isset($viewParamConf) && is_array($viewParamConf)) {
+                if (!empty($viewParamConf['ignore'])) {
+                    $excludeList = $viewParamConf['ignore'];
+                }
+                if (isset($viewParamConf['item']) && GeneralUtility::inList($viewParamConf['item'], $categoryPivar)) {
+                    // nothing
+                } else {
+                    $prefixId = tx_ttproducts_model_control::getPrefixId();
+                    $excludeList .= ($excludeList != '' ? ',' : '') . $prefixId . '[' . $categoryPivar . ']';
+                }
+            }
+            $pidMemo = ($this->conf['PIDmemo'] ? $this->conf['PIDmemo'] : $GLOBALS['TSFE']->id);
 
-			tx_ttproducts_control_memo::getWrappedSubpartArray(
-				$wrappedSubpartArray,
-				$pidMemo,
-				$row['uid'],
-				$cObj,
-				$urlObj,
-				$excludeList,
-				[],
-				'',
-				$useBackPid
-			);
+            tx_ttproducts_control_memo::getWrappedSubpartArray(
+                $wrappedSubpartArray,
+                $pidMemo,
+                $row['uid'],
+                $cObj,
+                $urlObj,
+                $excludeList,
+                [],
+                '',
+                $useBackPid
+            );
 
-			if (!$itemFrameWork) {
-				$templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
-				$errorCode[0] = 'no_subtemplate';
-				$errorCode[1] = '###' . $subPartMarker . '###';
-				$errorCode[2] = $templateObj->getTemplateFile();
+            if (!$itemFrameWork) {
+                $templateObj = GeneralUtility::makeInstance('tx_ttproducts_template');
+                $errorCode[0] = 'no_subtemplate';
+                $errorCode[1] = '###' . $subPartMarker . '###';
+                $errorCode[2] = $templateObj->getTemplateFile();
 
-				return '';
-			}
-			$viewTagArray = $markerObj->getAllMarkers($itemFrameWork);
-			$tablesObj->get('fe_users', true)->getWrappedSubpartArray(
-				$viewTagArray,
-				$useBackPid,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
+                return '';
+            }
+            $viewTagArray = $markerObj->getAllMarkers($itemFrameWork);
+            $tablesObj->get('fe_users', true)->getWrappedSubpartArray(
+                $viewTagArray,
+                $useBackPid,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
 
-			$itemFrameWork = $templateService->substituteMarkerArrayCached(
-				$itemFrameWork,
-				$markerArray,
-				$subpartArray,
-				$wrappedSubpartArray
-			);
-			
-			$markerFieldArray = [
-				'BULKILY_WARNING' => 'bulkily',
-				'PRODUCT_SPECIAL_PREP' => 'special_preparation',
-				'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
-				'PRODUCT_LINK_DATASHEET' => 'datasheet'];
-			$viewTagArray = [];
-			$parentArray = [];
+            $itemFrameWork = $templateService->substituteMarkerArrayCached(
+                $itemFrameWork,
+                $markerArray,
+                $subpartArray,
+                $wrappedSubpartArray
+            );
+            
+            $markerFieldArray = [
+                'BULKILY_WARNING' => 'bulkily',
+                'PRODUCT_SPECIAL_PREP' => 'special_preparation',
+                'PRODUCT_ADDITIONAL_SINGLE' => 'additional',
+                'PRODUCT_LINK_DATASHEET' => 'datasheet'];
+            $viewTagArray = [];
+            $parentArray = [];
 
-			$fieldsArray = $markerObj->getMarkerFields(
-				$itemFrameWork,
-				$itemTableArray[$this->type]->getTableObj()->tableFieldArray,
-				$itemTableArray[$this->type]->getTableObj()->requiredFieldArray,
-				$markerFieldArray,
-				$itemTableArray[$this->type]->marker,
-				$viewTagArray,
-				$parentArray
-			);
+            $fieldsArray = $markerObj->getMarkerFields(
+                $itemFrameWork,
+                $itemTableArray[$this->type]->getTableObj()->tableFieldArray,
+                $itemTableArray[$this->type]->getTableObj()->requiredFieldArray,
+                $markerFieldArray,
+                $itemTableArray[$this->type]->marker,
+                $viewTagArray,
+                $parentArray
+            );
 
-			$articleViewTagArray = [];
-			if ($this->type == 'product' && in_array($useArticles, [1, 3])) {
-				$markerFieldArray = [];
-				$articleParentArray = [];
-				$articleFieldsArray = $markerObj->getMarkerFields(
-					$itemFrameWork,
-					$itemTableArray[$this->type]->getTableObj()->tableFieldArray,
-					$itemTableArray[$this->type]->getTableObj()->requiredFieldArray,
-					$markerFieldArray,
-					$itemTableViewArray['article']->marker,
-					$articleViewTagArray,
-					$articleParentArray
-				);
+            $articleViewTagArray = [];
+            if ($this->type == 'product' && in_array($useArticles, [1, 3])) {
+                $markerFieldArray = [];
+                $articleParentArray = [];
+                $articleFieldsArray = $markerObj->getMarkerFields(
+                    $itemFrameWork,
+                    $itemTableArray[$this->type]->getTableObj()->tableFieldArray,
+                    $itemTableArray[$this->type]->getTableObj()->requiredFieldArray,
+                    $markerFieldArray,
+                    $itemTableViewArray['article']->marker,
+                    $articleViewTagArray,
+                    $articleParentArray
+                );
 
-				$prodUidField = $cnf->getTableDesc($itemTableArray['article']->getTableObj()->name, 'uid_product');
-				$fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
-				$uidKey = array_search($prodUidField, $fieldsArray);
-				if ($uidKey != '') {
-					unset($fieldsArray[$uidKey]);
-				}
-			}
+                $prodUidField = $cnf->getTableDesc($itemTableArray['article']->getTableObj()->name, 'uid_product');
+                $fieldsArray = array_merge($fieldsArray, $articleFieldsArray);
+                $uidKey = array_search($prodUidField, $fieldsArray);
+                if ($uidKey != '') {
+                    unset($fieldsArray[$uidKey]);
+                }
+            }
 
-			$backPID = $piVars['backPID'] ?? '';
-			$backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
-			$basketPID = $this->conf['PIDbasket'];
-			$bNeedSingleParams = false;
+            $backPID = $piVars['backPID'] ?? '';
+            $backPID = ($backPID ? $backPID : GeneralUtility::_GP('backPID'));
+            $basketPID = $this->conf['PIDbasket'];
+            $bNeedSingleParams = false;
 
-			if ($this->conf['clickIntoList']) {
-				$pid =
-					$pageObj->getPID(
-						$this->conf['PIDlistDisplay'] ?? '',
-						$this->conf['PIDlistDisplay.'] ?? '',
-						$row
-					);
-			} else if (!empty($this->conf['clickIntoBasket']) && ($basketPID || $backPID)) {
-				$pid = ($basketPID ? $basketPID : $backPID);
-			} else {
-				$pid = $GLOBALS['TSFE']->id;
-				$bNeedSingleParams = true;
-			}
+            if ($this->conf['clickIntoList']) {
+                $pid =
+                    $pageObj->getPID(
+                        $this->conf['PIDlistDisplay'] ?? '',
+                        $this->conf['PIDlistDisplay.'] ?? '',
+                        $row
+                    );
+            } else if (!empty($this->conf['clickIntoBasket']) && ($basketPID || $backPID)) {
+                $pid = ($basketPID ? $basketPID : $backPID);
+            } else {
+                $pid = $GLOBALS['TSFE']->id;
+                $bNeedSingleParams = true;
+            }
 
-			if ($this->type == 'product') {
+            if ($this->type == 'product') {
 
-				$viewTextTable = $tablesObj->get('tt_products_texts');
-				$viewTextViewTable = $tablesObj->get('tt_products_texts', true);
-				$textTagArray =
-					$viewTextViewTable->getTagMarkerArray(
-						$viewTagArray,
-						$itemTableArray['product']->marker
-					);
+                $viewTextTable = $tablesObj->get('tt_products_texts');
+                $viewTextViewTable = $tablesObj->get('tt_products_texts', true);
+                $textTagArray =
+                    $viewTextViewTable->getTagMarkerArray(
+                        $viewTagArray,
+                        $itemTableArray['product']->marker
+                    );
 
-				$itemArray =
-					$viewTextTable->getChildUidArray(
-						$theCode,
-						$this->uid,
-						$textTagArray,
-						'tt_products'
-					);
-				$viewTextViewTable->getRowsMarkerArray(
-					$itemArray,
-					$markerArray,
-					$itemTableArray['product']->marker,
-					$textTagArray
-				);
-			}
+                $itemArray =
+                    $viewTextTable->getChildUidArray(
+                        $theCode,
+                        $this->uid,
+                        $textTagArray,
+                        'tt_products'
+                    );
+                $viewTextViewTable->getRowsMarkerArray(
+                    $itemArray,
+                    $markerArray,
+                    $itemTableArray['product']->marker,
+                    $textTagArray
+                );
+            }
 
-			// $variant = $itemTableArray[$this->type]->variant->getFirstVariantRow();
+            // $variant = $itemTableArray[$this->type]->variant->getFirstVariantRow();
 
-			$forminfoArray = ['###FORM_NAME###' => 'item_' . $this->uid];
+            $forminfoArray = ['###FORM_NAME###' => 'item_' . $this->uid];
 
-			if ($this->type == 'product' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+            if ($this->type == 'product' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
 
-				tx_ttproducts_control_product::addAjax(
-					$tablesObj,
-					$languageObj,
-					$theCode,
-					$itemTableArray[$this->type]->getFuncTablename()
-				);
-			}
+                tx_ttproducts_control_product::addAjax(
+                    $tablesObj,
+                    $languageObj,
+                    $theCode,
+                    $itemTableArray[$this->type]->getFuncTablename()
+                );
+            }
 
-			$viewCatTagArray = [];
-			$catParentArray = [];
-			$tmp = [];
-			$catfieldsArray = $markerObj->getMarkerFields(
-				$itemFrameWork,
-				$viewCatTable->getTableObj()->tableFieldArray,
-				$viewCatTable->getTableObj()->requiredFieldArray,
-				$tmp,
-				$viewCatViewTable->getMarker(),
-				$viewCatTagArray,
-				$catParentArray
-			);
+            $viewCatTagArray = [];
+            $catParentArray = [];
+            $tmp = [];
+            $catfieldsArray = $markerObj->getMarkerFields(
+                $itemFrameWork,
+                $viewCatTable->getTableObj()->tableFieldArray,
+                $viewCatTable->getTableObj()->requiredFieldArray,
+                $tmp,
+                $viewCatViewTable->getMarker(),
+                $viewCatTagArray,
+                $catParentArray
+            );
 
-			$mergeTagArray = array_merge($viewTagArray, $viewCatTagArray);
-			$cat = $row['category'];
-			$itemTableConf['category'] = $cnf->getTableConf($viewCatTable->getFuncTablename(), 'SINGLE');
-			$catArray = $viewCatTable->getCategoryArray($row, $itemTableConf['category']['orderBy']);
+            $mergeTagArray = array_merge($viewTagArray, $viewCatTagArray);
+            $cat = $row['category'];
+            $itemTableConf['category'] = $cnf->getTableConf($viewCatTable->getFuncTablename(), 'SINGLE');
+            $catArray = $viewCatTable->getCategoryArray($row, $itemTableConf['category']['orderBy']);
 
-			if (is_array($catArray) && count($catArray)) {
-				reset($catArray);
-				$cat = current($catArray);
-			}
-			$allowedCategoryArray = [];
+            if (is_array($catArray) && count($catArray)) {
+                reset($catArray);
+                $cat = current($catArray);
+            }
+            $allowedCategoryArray = [];
 
-			if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] != '2') {
-				$allowedCategories = $this->config['defaultCategoryID'];
-				if ($allowedCategories != '') {
-					$allowedCategoryArray = explode(',', $allowedCategories);
-				}
-			}
+            if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['pageAsCategory'] != '2') {
+                $allowedCategories = $this->config['defaultCategoryID'];
+                if ($allowedCategories != '') {
+                    $allowedCategoryArray = explode(',', $allowedCategories);
+                }
+            }
 
-			$show = true;
+            $show = true;
 
-			if (!empty($allowedCategoryArray)) {
-				if (empty($catArray)) {
-					$show = false;
-				} else {
-					$matches = array_intersect($allowedCategoryArray, $catArray);
-					if (empty($matches)) {
-						$show = false;
-					}
-				}
-			}
+            if (!empty($allowedCategoryArray)) {
+                if (empty($catArray)) {
+                    $show = false;
+                } else {
+                    $matches = array_intersect($allowedCategoryArray, $catArray);
+                    if (empty($matches)) {
+                        $show = false;
+                    }
+                }
+            }
 
-			if ($show) {
-				if (
-					!empty($t['categoryFrameWork'])
-				) {
-					if (is_array($catArray) && count($catArray)) {
+            if ($show) {
+                if (
+                    !empty($t['categoryFrameWork'])
+                ) {
+                    if (is_array($catArray) && count($catArray)) {
                         $subpartArray['###ITEM_CATEGORY###'] = '';
-						foreach ($catArray as $category) {
+                        foreach ($catArray as $category) {
 
-							$categoryMarkerArray = [];
-							$viewCatViewTable->getMarkerArray( // Todo: do not repeat this step for the first category
-								$categoryMarkerArray,
-								'',
-								$category,
-								$row['pid'],
-								$this->config['limitImage'],
-								'listcatImage',
-								$viewCatTagArray,
-								[],
-								$pageAsCategory,
-								'SINGLE',
-								$basketExtra,
-								$basketRecs,
-								'',
-								'',
-								''
-							);
-							$subpartArray['###ITEM_CATEGORY###'] .=
-								$templateService->substituteMarkerArrayCached(
-									$t['categoryFrameWork'],
-									$categoryMarkerArray,
-									[],
-									[]
-								);
-						}
-					} else {
-						$wrappedSubpartArray['###ITEM_CATEGORY###'] = '';
-					}
-				}
+                            $categoryMarkerArray = [];
+                            $viewCatViewTable->getMarkerArray( // Todo: do not repeat this step for the first category
+                                $categoryMarkerArray,
+                                '',
+                                $category,
+                                $row['pid'],
+                                $this->config['limitImage'],
+                                'listcatImage',
+                                $viewCatTagArray,
+                                [],
+                                $pageAsCategory,
+                                'SINGLE',
+                                $basketExtra,
+                                $basketRecs,
+                                '',
+                                '',
+                                ''
+                            );
+                            $subpartArray['###ITEM_CATEGORY###'] .=
+                                $templateService->substituteMarkerArrayCached(
+                                    $t['categoryFrameWork'],
+                                    $categoryMarkerArray,
+                                    [],
+                                    []
+                                );
+                        }
+                    } else {
+                        $wrappedSubpartArray['###ITEM_CATEGORY###'] = '';
+                    }
+                }
 
-				$categoryMarkerArray = [];
-				$viewCatViewTable->getMarkerArray(
-					$categoryMarkerArray,
-					'',
-					$cat,
-					$row['pid'],
-					$this->config['limitImage'],
-					'listcatImage',
-					$viewCatTagArray,
-					[],
-					$pageAsCategory,
-					'SINGLE',
-					$basketExtra,
-					$basketRecs,
-					'',
-					'',
-					''
-				);
+                $categoryMarkerArray = [];
+                $viewCatViewTable->getMarkerArray(
+                    $categoryMarkerArray,
+                    '',
+                    $cat,
+                    $row['pid'],
+                    $this->config['limitImage'],
+                    'listcatImage',
+                    $viewCatTagArray,
+                    [],
+                    $pageAsCategory,
+                    'SINGLE',
+                    $basketExtra,
+                    $basketRecs,
+                    '',
+                    '',
+                    ''
+                );
 
-				$categoryJoin = '';
-				$whereCat = '';
-				if ($cat) {
-					$currentCat = $piVars[$viewCatViewTable->getPivar()] ?? '';
-					$currentCatArray = [];
+                $categoryJoin = '';
+                $whereCat = '';
+                if ($cat) {
+                    $currentCat = $piVars[$viewCatViewTable->getPivar()] ?? '';
+                    $currentCatArray = [];
 
-					if ($currentCat != '') {
-						$currentCatArray = GeneralUtility::trimExplode(',', $currentCat);
-					}
-					if (!empty($allowedCategoryArray)) {
-						$currentCatArray = array_merge($currentCatArray, $allowedCategoryArray);
-					}
+                    if ($currentCat != '') {
+                        $currentCatArray = GeneralUtility::trimExplode(',', $currentCat);
+                    }
+                    if (!empty($allowedCategoryArray)) {
+                        $currentCatArray = array_merge($currentCatArray, $allowedCategoryArray);
+                    }
 
-					if (isset($currentCatArray) && is_array($currentCatArray)) {
-						$inArray = $GLOBALS['TYPO3_DB']->fullQuoteArray($currentCatArray, 'tt_products');
-						$inCat = implode(',', $inArray);
-						$catMMTable = $viewCatTable->getMMTablename();
+                    if (isset($currentCatArray) && is_array($currentCatArray)) {
+                        $inArray = $GLOBALS['TYPO3_DB']->fullQuoteArray($currentCatArray, 'tt_products');
+                        $inCat = implode(',', $inArray);
+                        $catMMTable = $viewCatTable->getMMTablename();
 
-						if (!empty($currentCatArray)) {
-							// $useBackPid = false;
-							$cat = $currentCat;
-							if ($catMMTable) {
-								$categoryJoin = $itemTableArray[$this->type]->getTablename() . ' ' . $itemTableArray[$this->type]->getAlias().' INNER JOIN ' . $viewCatTable->getMMTablename() . ' M ON ' . $itemTableArray[$this->type]->getAlias().'.uid=M.uid_local';
-								$whereCat = ' AND M.uid_foreign IN (' . $inCat . ') ';
-							} else {
-								$whereCat = ' AND category IN (' . $inCat . ') ';
-							}
-						}
-					}
-				}
+                        if (!empty($currentCatArray)) {
+                            // $useBackPid = false;
+                            $cat = $currentCat;
+                            if ($catMMTable) {
+                                $categoryJoin = $itemTableArray[$this->type]->getTablename() . ' ' . $itemTableArray[$this->type]->getAlias().' INNER JOIN ' . $viewCatTable->getMMTablename() . ' M ON ' . $itemTableArray[$this->type]->getAlias().'.uid=M.uid_local';
+                                $whereCat = ' AND M.uid_foreign IN (' . $inCat . ') ';
+                            } else {
+                                $whereCat = ' AND category IN (' . $inCat . ') ';
+                            }
+                        }
+                    }
+                }
 
-				if (
+                if (
                     isset($this->conf['PIDlistDisplay']) ||
                     isset($this->conf['PIDlistDisplay.'])
                 ) {
-					$linkPid =
-						$pageObj->getPID(
-							$this->conf['PIDlistDisplay'] ?? '',
-							$this->conf['PIDlistDisplay.'] ?? '',
-							$row
-						);
-				} else {
-					$linkPid = $pid;
-				}
+                    $linkPid =
+                        $pageObj->getPID(
+                            $this->conf['PIDlistDisplay'] ?? '',
+                            $this->conf['PIDlistDisplay.'] ?? '',
+                            $row
+                        );
+                } else {
+                    $linkPid = $pid;
+                }
 
-				if ($useBackPid && $backPID) {
-					$linkPid = $backPID;
-				}
+                if ($useBackPid && $backPID) {
+                    $linkPid = $backPID;
+                }
 
                 $addQueryString = [];
 
@@ -630,8 +630,8 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                     $addQueryString['sword'] = $sword;
                 }
 
-				if (isset($viewTagArray['LINK_ITEM'])) {
-					$excludeListLinkItem = '';
+                if (isset($viewTagArray['LINK_ITEM'])) {
+                    $excludeListLinkItem = '';
 
                     if (
                         (
@@ -647,21 +647,21 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                             $this->conf['PIDitemDisplay'] != '{$plugin.tt_products.PIDitemDisplay}'
                         )
                     ) {
-						// if the page remains the same then the product parameter will still be needed
-						$excludeListLinkItem = '';
-					} else {
-						$excludeListLinkItem = $itemTableViewArray[$this->type]->getPivar();
-					}
-					$queryString =
-						$urlObj->getLinkParams(
-							$excludeListLinkItem,
-							$addQueryString,
-							true,
-							$useBackPid,
-							0,
-							'',
-							$viewCatViewTable->getPivar()
-						);
+                        // if the page remains the same then the product parameter will still be needed
+                        $excludeListLinkItem = '';
+                    } else {
+                        $excludeListLinkItem = $itemTableViewArray[$this->type]->getPivar();
+                    }
+                    $queryString =
+                        $urlObj->getLinkParams(
+                            $excludeListLinkItem,
+                            $addQueryString,
+                            true,
+                            $useBackPid,
+                            0,
+                            '',
+                            $viewCatViewTable->getPivar()
+                        );
                     $linkUrl = FrontendUtility::getTypoLink_URL(
                         $cObj,
                         $linkPid,
@@ -669,378 +669,378 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                         '', // no product parameter if it returns to the list view
                         []
                     );
-					$linkUrl = htmlspecialchars($linkUrl);
-					$wrappedSubpartArray['###LINK_ITEM###'] = ['<a class="singlelink" href="' . $linkUrl . '">', '</a>'];
-				}
+                    $linkUrl = htmlspecialchars($linkUrl);
+                    $wrappedSubpartArray['###LINK_ITEM###'] = ['<a class="singlelink" href="' . $linkUrl . '">', '</a>'];
+                }
 
-				if (isset($viewCatTagArray['LINK_CATEGORY'])) {
-					$catRow = $viewCatTable->get($cat);
-					$catListPid =
-						$pageObj->getPID(
-							$this->conf['PIDlistDisplay'] ?? '',
-							$this->conf['PIDlistDisplay.'] ?? '',
-							$catRow
-						);
-					$viewCatViewTable->getSubpartArrays(
-						$urlObj,
-						$catRow,
-						$subpartArray,
-						$wrappedSubpartArray,
-						$viewCatTagArray,
-						$catListPid,
-						'LINK_CATEGORY'
-					);
-				}
+                if (isset($viewCatTagArray['LINK_CATEGORY'])) {
+                    $catRow = $viewCatTable->get($cat);
+                    $catListPid =
+                        $pageObj->getPID(
+                            $this->conf['PIDlistDisplay'] ?? '',
+                            $this->conf['PIDlistDisplay.'] ?? '',
+                            $catRow
+                        );
+                    $viewCatViewTable->getSubpartArrays(
+                        $urlObj,
+                        $catRow,
+                        $subpartArray,
+                        $wrappedSubpartArray,
+                        $viewCatTagArray,
+                        $catListPid,
+                        'LINK_CATEGORY'
+                    );
+                }
 
-				$catTitle = $viewCatViewTable->getMarkerArrayCatTitle($categoryMarkerArray);
-				$viewParentCatTagArray = [];
-				$viewCatViewTable->getParentMarkerArray(
-					$parentArray,
-					$row,
-					$catParentArray,
-					$row['category'],
-					$row['pid'],
-					$this->config['limitImage'],
-					'listcatImage',
-					$viewParentCatTagArray,
-					[],
-					$pageAsCategory,
-					'SINGLE',
-					$basketExtra,
-					$basketRecs,
-					'',
-					''
-				);
+                $catTitle = $viewCatViewTable->getMarkerArrayCatTitle($categoryMarkerArray);
+                $viewParentCatTagArray = [];
+                $viewCatViewTable->getParentMarkerArray(
+                    $parentArray,
+                    $row,
+                    $catParentArray,
+                    $row['category'],
+                    $row['pid'],
+                    $this->config['limitImage'],
+                    'listcatImage',
+                    $viewParentCatTagArray,
+                    [],
+                    $pageAsCategory,
+                    'SINGLE',
+                    $basketExtra,
+                    $basketRecs,
+                    '',
+                    ''
+                );
 
-				if (isset($viewCatTagArray['LINK_PARENT1_CATEGORY'])) {
-					$catRow = $viewCatTable->getParent($cat);
-					$catListPid =
-						$pageObj->getPID(
-							$this->conf['PIDlistDisplay'] ?? '',
-							$this->conf['PIDlistDisplay.'] ?? '',
-							$catRow
-						);
-					$viewCatTable->getSubpartArrays(
-						$urlObj,
-						$catRow,
-						$subpartArray,
-						$wrappedSubpartArray,
-						$viewCatTagArray,
-						$catListPid,
-						'LINK_PARENT1_CATEGORY'
-					);
-				}
+                if (isset($viewCatTagArray['LINK_PARENT1_CATEGORY'])) {
+                    $catRow = $viewCatTable->getParent($cat);
+                    $catListPid =
+                        $pageObj->getPID(
+                            $this->conf['PIDlistDisplay'] ?? '',
+                            $this->conf['PIDlistDisplay.'] ?? '',
+                            $catRow
+                        );
+                    $viewCatTable->getSubpartArrays(
+                        $urlObj,
+                        $catRow,
+                        $subpartArray,
+                        $wrappedSubpartArray,
+                        $viewCatTagArray,
+                        $catListPid,
+                        'LINK_PARENT1_CATEGORY'
+                    );
+                }
 
-				if ($this->type == 'product' && in_array($useArticles, [1, 3])) {
-					// get the article uid with these colors, sizes and gradings
+                if ($this->type == 'product' && in_array($useArticles, [1, 3])) {
+                    // get the article uid with these colors, sizes and gradings
 
-					$articleRow = $itemTableArray['product']->getArticleRow($row, 'SINGLE', true);
-					if (
-						is_array($articleRow) &&
-						isset($articleRow['inStock'])
-					) {
-						$row['inStock'] = $articleRow['inStock'];
-					}
-				}
+                    $articleRow = $itemTableArray['product']->getArticleRow($row, 'SINGLE', true);
+                    if (
+                        is_array($articleRow) &&
+                        isset($articleRow['inStock'])
+                    ) {
+                        $row['inStock'] = $articleRow['inStock'];
+                    }
+                }
 
-				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
-					$ajaxObj = GeneralUtility::makeInstance('tx_ttproducts_ajax');
-					$storedRecs = $ajaxObj->getStoredRecs();
+                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('taxajax')) {
+                    $ajaxObj = GeneralUtility::makeInstance('tx_ttproducts_ajax');
+                    $storedRecs = $ajaxObj->getStoredRecs();
 
-					if (
-						isset($storedRecs) &&
-						is_array($storedRecs) &&
-						isset($storedRecs['tt_products']) &&
-						is_array($storedRecs['tt_products']) &&
-						isset($storedRecs['tt_products'][$this->uid]) &&
-						is_array($storedRecs['tt_products'][$this->uid])
-					) {
-						$storedRow = $storedRecs['tt_products'][$this->uid];
-						foreach ($storedRow as $field => $value) {
-							if ($value != '') {
-								$row[$field] = $value;
-							}
-						}
-					}
-				}
+                    if (
+                        isset($storedRecs) &&
+                        is_array($storedRecs) &&
+                        isset($storedRecs['tt_products']) &&
+                        is_array($storedRecs['tt_products']) &&
+                        isset($storedRecs['tt_products'][$this->uid]) &&
+                        is_array($storedRecs['tt_products'][$this->uid])
+                    ) {
+                        $storedRow = $storedRecs['tt_products'][$this->uid];
+                        foreach ($storedRow as $field => $value) {
+                            if ($value != '') {
+                                $row[$field] = $value;
+                            }
+                        }
+                    }
+                }
 
-				$basketExt = tx_ttproducts_control_basket::getBasketExt();
-				$basketRecs = tx_ttproducts_control_basket::getRecs();
+                $basketExt = tx_ttproducts_control_basket::getBasketExt();
+                $basketRecs = tx_ttproducts_control_basket::getRecs();
 
-				$prodVariantRow = $row;
-				$itemTableViewArray[$this->type]->getModelMarkerArray(
-					$row,
-					$itemTableViewArray[$this->type]->getMarker(),
-					$markerArray,
-					$catTitle,
-					$this->config['limitImageSingle'],
-					'image',
-					$viewTagArray,
-					$forminfoArray,
-					'SINGLE',
-					$basketExtra,
-					$basketRecs,
-					'',
-					'',
-					'',
-					'',
-					true,
-					'UTF-8',
-					'', // $hiddenFields
-					'',
-					[],
-					[],
-					$bIsGift
-				);
+                $prodVariantRow = $row;
+                $itemTableViewArray[$this->type]->getModelMarkerArray(
+                    $row,
+                    $itemTableViewArray[$this->type]->getMarker(),
+                    $markerArray,
+                    $catTitle,
+                    $this->config['limitImageSingle'],
+                    'image',
+                    $viewTagArray,
+                    $forminfoArray,
+                    'SINGLE',
+                    $basketExtra,
+                    $basketRecs,
+                    '',
+                    '',
+                    '',
+                    '',
+                    true,
+                    'UTF-8',
+                    '', // $hiddenFields
+                    '',
+                    [],
+                    [],
+                    $bIsGift
+                );
 
-				if ($this->type == 'product') {
-					$prodRow = $row;
+                if ($this->type == 'product') {
+                    $prodRow = $row;
 
-					if (in_array($useArticles, [1, 3])) {
+                    if (in_array($useArticles, [1, 3])) {
 
-						// use the product if no article row has been found
-						if ($articleRow) {
-							$itemTableArray['product']->mergeAttributeFields(
-								$prodVariantRow,
-								$articleRow,
-								false,
-								false,
-								true,
-								'',
-								false
-							);
-						}
+                        // use the product if no article row has been found
+                        if ($articleRow) {
+                            $itemTableArray['product']->mergeAttributeFields(
+                                $prodVariantRow,
+                                $articleRow,
+                                false,
+                                false,
+                                true,
+                                '',
+                                false
+                            );
+                        }
 
-						$itemTableViewArray['article']->getItemSubpartArrays(
-							$itemFrameWork,
-							'tt_products_articles',
-							$prodVariantRow,
-							$subpartArray,
-							$wrappedSubpartArray,
-							$articleViewTagArray,
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							0
-						);
-					}
-					$allVariants =
-						$basketObj->getAllVariants(
-							$funcTablename,
-							$row,
-							$prodVariantRow
-						);
+                        $itemTableViewArray['article']->getItemSubpartArrays(
+                            $itemFrameWork,
+                            'tt_products_articles',
+                            $prodVariantRow,
+                            $subpartArray,
+                            $wrappedSubpartArray,
+                            $articleViewTagArray,
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            0
+                        );
+                    }
+                    $allVariants =
+                        $basketObj->getAllVariants(
+                            $funcTablename,
+                            $row,
+                            $prodVariantRow
+                        );
 
-					$currRow =
-						$basketObj->getItemRow(
-							$prodVariantRow,
-							$allVariants,
-							$useArticles,
-							$itemTableArray[$this->type]->getFuncTablename(),
-							false
-						);
+                    $currRow =
+                        $basketObj->getItemRow(
+                            $prodVariantRow,
+                            $allVariants,
+                            $useArticles,
+                            $itemTableArray[$this->type]->getFuncTablename(),
+                            false
+                        );
 
-					$basketExt1 = [];
-					if (isset($basketExt) && is_array($basketExt) && count($basketExt)) {
-						$basketExt1 = $basketExt;
-					} else {
-						$basketExt1 =
-							tx_ttproducts_control_basket::generatedBasketExtFromRow(
-								$currRow,
-								'1'
-							);
-					}
-					$itemArray =
-						$basketObj->getItemArrayFromRow(
-							$currRow,
-							$basketExt1,
-							$basketExtra,
-							$basketRecs,
-							$funcTablename,
-							$externalRowArray,
-							$bIsGift
-						);
+                    $basketExt1 = [];
+                    if (isset($basketExt) && is_array($basketExt) && count($basketExt)) {
+                        $basketExt1 = $basketExt;
+                    } else {
+                        $basketExt1 =
+                            tx_ttproducts_control_basket::generatedBasketExtFromRow(
+                                $currRow,
+                                '1'
+                            );
+                    }
+                    $itemArray =
+                        $basketObj->getItemArrayFromRow(
+                            $currRow,
+                            $basketExt1,
+                            $basketExtra,
+                            $basketRecs,
+                            $funcTablename,
+                            $externalRowArray,
+                            $bIsGift
+                        );
 
-					$basketObj->calculate($itemArray); // get the calculated arrays
-					$prodVariantRow =
-						$basketObj->getMergedRowFromItemArray(
-							$itemArray,
-							$basketExtra
-						);
+                    $basketObj->calculate($itemArray); // get the calculated arrays
+                    $prodVariantRow =
+                        $basketObj->getMergedRowFromItemArray(
+                            $itemArray,
+                            $basketExtra
+                        );
 
-					if (
-						!empty($articleRow) &&
-						isset($prodVariantRow['ext']) &&
-						!isset($prodVariantRow['ext']['tt_products_articles'])
-					) {
-						$prodVariantRow['ext']['tt_products_articles'][] = $articleRow;
-					}
+                    if (
+                        !empty($articleRow) &&
+                        isset($prodVariantRow['ext']) &&
+                        !isset($prodVariantRow['ext']['tt_products_articles'])
+                    ) {
+                        $prodVariantRow['ext']['tt_products_articles'][] = $articleRow;
+                    }
 
-						// use the fields of the article instead of the product
-					$itemTableViewArray['product']->getModelMarkerArray(
-						$prodVariantRow,
-						$itemTableViewArray['article']->getMarker(),
-						$markerArray,
-						$catTitle,
-						$this->config['limitImageSingle'],
-						'image',
-						$articleViewTagArray,
-						[],
-						'SINGLE',
-						$basketExtra,
-						$basketRecs,
-						'from-tt-products-articles',
-						'',
-						'',
-						'',
-						true,
-						'UTF-8',
-						'', // $hiddenFields
-						'',
-						[],
-						[],
-						$bIsGift
-					);
-				} else if ($this->type == 'article') {
-					$articleRow = $row;
-					$prodVariantRow = $prodRow = $itemTableArray['product']->get($row['uid_product']);
-					$itemTableViewArray['product']->getModelMarkerArray(
-						$prodRow,
-						$itemTableViewArray['product']->getMarker(),
-						$markerArray,
-						$catTitle,
-						$this->config['limitImageSingle'],
-						'listImage',
-						$viewTagArray,
-						[],
-						'SINGLE',
-						$basketExtra,
-						$basketRecs,
-						1,
-						'',
-						'',
-						'',
-						true,
-						'UTF-8',
-						'', // $hiddenFields
-						'',
-						[],
-						[],
-						$bIsGift
-					);
-				}
+                        // use the fields of the article instead of the product
+                    $itemTableViewArray['product']->getModelMarkerArray(
+                        $prodVariantRow,
+                        $itemTableViewArray['article']->getMarker(),
+                        $markerArray,
+                        $catTitle,
+                        $this->config['limitImageSingle'],
+                        'image',
+                        $articleViewTagArray,
+                        [],
+                        'SINGLE',
+                        $basketExtra,
+                        $basketRecs,
+                        'from-tt-products-articles',
+                        '',
+                        '',
+                        '',
+                        true,
+                        'UTF-8',
+                        '', // $hiddenFields
+                        '',
+                        [],
+                        [],
+                        $bIsGift
+                    );
+                } else if ($this->type == 'article') {
+                    $articleRow = $row;
+                    $prodVariantRow = $prodRow = $itemTableArray['product']->get($row['uid_product']);
+                    $itemTableViewArray['product']->getModelMarkerArray(
+                        $prodRow,
+                        $itemTableViewArray['product']->getMarker(),
+                        $markerArray,
+                        $catTitle,
+                        $this->config['limitImageSingle'],
+                        'listImage',
+                        $viewTagArray,
+                        [],
+                        'SINGLE',
+                        $basketExtra,
+                        $basketRecs,
+                        1,
+                        '',
+                        '',
+                        '',
+                        true,
+                        'UTF-8',
+                        '', // $hiddenFields
+                        '',
+                        [],
+                        [],
+                        $bIsGift
+                    );
+                }
 
-				if ($this->type == 'product' || $this->type == 'article') {
+                if ($this->type == 'product' || $this->type == 'article') {
 
-					$basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
-					$editConfig = $itemTableArray[$this->type]->editVariant->getValidConfig($prodVariantRow);
-					$validEditVariant = true;
+                    $basketItemView = GeneralUtility::makeInstance('tx_ttproducts_basketitem_view');
+                    $editConfig = $itemTableArray[$this->type]->editVariant->getValidConfig($prodVariantRow);
+                    $validEditVariant = true;
 
-					if (is_array($editConfig)) {
-						$validEditVariant =
-							$itemTableArray[$this->type]->editVariant->checkValid(
-								$editConfig,
-								$prodVariantRow
-							);
-					}
+                    if (is_array($editConfig)) {
+                        $validEditVariant =
+                            $itemTableArray[$this->type]->editVariant->checkValid(
+                                $editConfig,
+                                $prodVariantRow
+                            );
+                    }
 
-					$bInputDisabled =
-						(
-							$prodVariantRow['inStock'] <= 0 ||
-							is_array($validEditVariant)
-						);
+                    $bInputDisabled =
+                        (
+                            $prodVariantRow['inStock'] <= 0 ||
+                            is_array($validEditVariant)
+                        );
                     $variantValuesRow =
                         $itemTableArray['product']->getVariant()->getVariantValuesRow(
                             $prodRow,
                             []
                         );
                     $prodVariantValuesRow = array_merge($prodVariantRow, $variantValuesRow);
-					$item =
-						$basketObj->getItem(
-							$basketExt,
-							$basketExtra,
-							$basketRecs,
+                    $item =
+                        $basketObj->getItem(
+                            $basketExt,
+                            $basketExtra,
+                            $basketRecs,
                             $prodVariantValuesRow, // $prodVariantRow,  // $prodRow  wiederhergestellt wie früher
-							'firstVariant',
-							$funcTablename,
-							$externalRowArray,
-							$bIsGift
-						);
+                            'firstVariant',
+                            $funcTablename,
+                            $externalRowArray,
+                            $bIsGift
+                        );
 
-					$basketItemView->getItemMarkerArray(
-						$itemTableArray[$this->type]->getFuncTablename(),
-						true,
-						$item,
-						$markerArray,
-						$viewTagArray,
-						$tmpHidden,
-						'SINGLE',
-						$bInputDisabled,
-						1,
-						true,
-						'UTF-8',
-						[],
-						'',
-						[],
-						[],
-						[]
-					);
+                    $basketItemView->getItemMarkerArray(
+                        $itemTableArray[$this->type]->getFuncTablename(),
+                        true,
+                        $item,
+                        $markerArray,
+                        $viewTagArray,
+                        $tmpHidden,
+                        'SINGLE',
+                        $bInputDisabled,
+                        1,
+                        true,
+                        'UTF-8',
+                        [],
+                        '',
+                        [],
+                        [],
+                        []
+                    );
 
-					$basketItemView->getItemMarkerSubpartArrays(
-						$itemFrameWork,
-						$itemTableArray[$this->type]->getFuncTablename(),
-						$row,
-						'SINGLE',
-						$viewTagArray,
-						true,
-						[],
-						$markerArray,
-						$subpartArray,
-						$wrappedSubpartArray
-					);
+                    $basketItemView->getItemMarkerSubpartArrays(
+                        $itemFrameWork,
+                        $itemTableArray[$this->type]->getFuncTablename(),
+                        $row,
+                        'SINGLE',
+                        $viewTagArray,
+                        true,
+                        [],
+                        $markerArray,
+                        $subpartArray,
+                        $wrappedSubpartArray
+                    );
 
-					$itemTableViewArray[$this->type]->getItemMarkerSubpartArrays(
-						$itemFrameWork,
-						'tt_products',
-						$row,
-						$markerArray,
-						$subpartArray,
-						$wrappedSubpartArray,
-						$viewTagArray,
-						[],
-						[],
-						'SINGLE',
-						$basketExtra,
-						$basketRecs,
-						1
-					);
-					$currPriceMarkerArray = [];
-					$itemTableViewArray[$this->type]->getCurrentPriceMarkerArray(
-						$currPriceMarkerArray,
-						'',
-						$itemTableArray['product']->getTablename(),
-						$prodRow,
-						$itemTableArray['article']->getTablename(),
-						$prodVariantRow,
-						'',
-						'SINGLE',
-						$basketExtra,
-						$basketRecs,
-						$bIsGift,
-						false
-					);
-					$markerArray = array_merge($markerArray, $currPriceMarkerArray);
-				}
-				$linkMemoConf = [];
-				if (
-					isset($linkConfArray) &&
-					is_array($linkConfArray) &&
-					isset($linkConfArray['FORM_MEMO.'])
-				) {
-					$linkMemoConf = $linkConfArray['FORM_MEMO.'];
-				}
+                    $itemTableViewArray[$this->type]->getItemMarkerSubpartArrays(
+                        $itemFrameWork,
+                        'tt_products',
+                        $row,
+                        $markerArray,
+                        $subpartArray,
+                        $wrappedSubpartArray,
+                        $viewTagArray,
+                        [],
+                        [],
+                        'SINGLE',
+                        $basketExtra,
+                        $basketRecs,
+                        1
+                    );
+                    $currPriceMarkerArray = [];
+                    $itemTableViewArray[$this->type]->getCurrentPriceMarkerArray(
+                        $currPriceMarkerArray,
+                        '',
+                        $itemTableArray['product']->getTablename(),
+                        $prodRow,
+                        $itemTableArray['article']->getTablename(),
+                        $prodVariantRow,
+                        '',
+                        'SINGLE',
+                        $basketExtra,
+                        $basketRecs,
+                        $bIsGift,
+                        false
+                    );
+                    $markerArray = array_merge($markerArray, $currPriceMarkerArray);
+                }
+                $linkMemoConf = [];
+                if (
+                    isset($linkConfArray) &&
+                    is_array($linkConfArray) &&
+                    isset($linkConfArray['FORM_MEMO.'])
+                ) {
+                    $linkMemoConf = $linkConfArray['FORM_MEMO.'];
+                }
 
-				$markerArray['###FORM_NAME###'] = $forminfoArray['###FORM_NAME###'];
+                $markerArray['###FORM_NAME###'] = $forminfoArray['###FORM_NAME###'];
                 $markerArray['###FORM_MEMO###'] = htmlspecialchars(
                     FrontendUtility::getTypoLink_URL(
                         $cObj,
@@ -1058,153 +1058,153 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                     )
                 );
 
-				$markerArray = $urlObj->addURLMarkers(
-					$pid,
-					$markerArray,
-					$addQueryString,
-					$excludeList,
-					$useBackPid,
-					0
-				); // Applied it here also...
+                $markerArray = $urlObj->addURLMarkers(
+                    $pid,
+                    $markerArray,
+                    $addQueryString,
+                    $excludeList,
+                    $useBackPid,
+                    0
+                ); // Applied it here also...
 
-				$queryPrevPrefix = '';
-				$queryNextPrefix = '';
-				$prevOrderby = '';
-				$nextOrderby = '';
-				$bDefaultOrder = true;
+                $queryPrevPrefix = '';
+                $queryNextPrefix = '';
+                $prevOrderby = '';
+                $nextOrderby = '';
+                $bDefaultOrder = true;
 
-				if ($this->conf['orderByItemNumberSg']) {
-					$itemnumberField = $itemTableArray[$this->type]->fieldArray['itemnumber'];
-					$queryPrevPrefix = $itemnumberField . ' < ' .
-						$GLOBALS['TYPO3_DB']->fullQuoteStr(
-							$origRow[$itemnumberField],
-							$tablename
-						);
-					$queryNextPrefix = $itemnumberField . ' > ' .
-						$GLOBALS['TYPO3_DB']->fullQuoteStr(
-							$origRow[$itemnumberField],
-							$tablename
-						);
-					$prevOrderby = $itemnumberField . ' DESC';
-					$nextOrderby = $itemnumberField . ' ASC';
-					$bDefaultOrder = false;
-				} else {
-					if(
-						isset($itemTableConf[$this->type]) &&
-						is_array($itemTableConf[$this->type]) &&
-						isset($itemTableConf[$this->type]['orderBy'])
-					) {
-						$orderByFieldArray =
-							GeneralUtility::trimExplode(
-								',',
-								$itemTableConf[$this->type]['orderBy']
-							);
-						$count = count($orderByFieldArray);
+                if ($this->conf['orderByItemNumberSg']) {
+                    $itemnumberField = $itemTableArray[$this->type]->fieldArray['itemnumber'];
+                    $queryPrevPrefix = $itemnumberField . ' < ' .
+                        $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                            $origRow[$itemnumberField],
+                            $tablename
+                        );
+                    $queryNextPrefix = $itemnumberField . ' > ' .
+                        $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                            $origRow[$itemnumberField],
+                            $tablename
+                        );
+                    $prevOrderby = $itemnumberField . ' DESC';
+                    $nextOrderby = $itemnumberField . ' ASC';
+                    $bDefaultOrder = false;
+                } else {
+                    if(
+                        isset($itemTableConf[$this->type]) &&
+                        is_array($itemTableConf[$this->type]) &&
+                        isset($itemTableConf[$this->type]['orderBy'])
+                    ) {
+                        $orderByFieldArray =
+                            GeneralUtility::trimExplode(
+                                ',',
+                                $itemTableConf[$this->type]['orderBy']
+                            );
+                        $count = count($orderByFieldArray);
 
-						if ($count) {
-							$bDefaultOrder = false;
-							$queryPrevPrefixArray = [];
-							$queryNextPrefixArray = [];
-							$prevOrderbyArray = [];
-							$nextOrderbyArray = [];
-							$limitArray = [];
+                        if ($count) {
+                            $bDefaultOrder = false;
+                            $queryPrevPrefixArray = [];
+                            $queryNextPrefixArray = [];
+                            $prevOrderbyArray = [];
+                            $nextOrderbyArray = [];
+                            $limitArray = [];
 
-							foreach($orderByFieldArray as $i => $orderByFieldLine) {
-								$bIsDesc = (stripos($orderByFieldLine, 'DESC') !== false);
-								$bIsLast = ($i == $count - 1);
-								$orderByField = str_ireplace('ASC', '', $orderByFieldLine);
-								$orderByField = trim(str_ireplace('DESC', '', $orderByField));
-								$comparatorPrev = ($bIsDesc ? '>' : '<');
-								$comparatorNext = ($bIsDesc ? '<' : '>');
-								$comparand = $GLOBALS['TYPO3_DB']->fullQuoteStr($origRow[$orderByField], $tablename);
+                            foreach($orderByFieldArray as $i => $orderByFieldLine) {
+                                $bIsDesc = (stripos($orderByFieldLine, 'DESC') !== false);
+                                $bIsLast = ($i == $count - 1);
+                                $orderByField = str_ireplace('ASC', '', $orderByFieldLine);
+                                $orderByField = trim(str_ireplace('DESC', '', $orderByField));
+                                $comparatorPrev = ($bIsDesc ? '>' : '<');
+                                $comparatorNext = ($bIsDesc ? '<' : '>');
+                                $comparand = $GLOBALS['TYPO3_DB']->fullQuoteStr($origRow[$orderByField], $tablename);
 
-								$newPrevPrevix = $orderByField . ' '. $comparatorPrev . ' ' . $comparand;
-								$newNextPrevix = $orderByField . ' ' . $comparatorNext . ' ' . $comparand;
+                                $newPrevPrevix = $orderByField . ' '. $comparatorPrev . ' ' . $comparand;
+                                $newNextPrevix = $orderByField . ' ' . $comparatorNext . ' ' . $comparand;
 
-								$ascOperatorPrev = ($bIsDesc ? 'ASC' : 'DESC');
-								$ascOperatorNext = ($bIsDesc ? 'DESC' : 'ASC');
-								$prevOrderbyArray[] = $orderByField . ' ' . $ascOperatorPrev;
-								$nextOrderbyArray[] = $orderByField . ' ' . $ascOperatorNext;
+                                $ascOperatorPrev = ($bIsDesc ? 'ASC' : 'DESC');
+                                $ascOperatorNext = ($bIsDesc ? 'DESC' : 'ASC');
+                                $prevOrderbyArray[] = $orderByField . ' ' . $ascOperatorPrev;
+                                $nextOrderbyArray[] = $orderByField . ' ' . $ascOperatorNext;
 
-								if ($bIsLast) {
-									$lastPrevPrevix = implode(' AND ',$limitArray) . (count($limitArray) > 0 ? ' AND ' : '') . $newPrevPrevix;
-									$lastNextPrevix = implode(' AND ',$limitArray) . (count($limitArray) > 0 ? ' AND ' : '') .  $newNextPrevix;
-								} else {
-									$limitArray[] = $orderByField . '=' . $comparand;
-									$queryPrevPrefixArray[] = $newPrevPrevix;
-									$queryNextPrefixArray[] = $newNextPrevix;
-								}
-							}
-							$queryNextPrefix = '(' . implode(' AND ', $queryNextPrefixArray) . (count($queryNextPrefixArray) > 0 ? ' OR ' : '') . $lastNextPrevix . ')';
-							$queryPrevPrefix = '(' . implode(' AND ', $queryPrevPrefixArray) . (count($queryNextPrefixArray) > 0 ? ' OR ' : '') . $lastPrevPrevix . ')';
-							$prevOrderby = implode(',', $prevOrderbyArray);
-							$nextOrderby = implode(',', $nextOrderbyArray);
-						}
-					}
-				}
-				if ($bDefaultOrder) {
-					$queryPrevPrefix = 'uid < ' . intval($this->uid);
-					$queryNextPrefix = 'uid > ' . intval($this->uid);
+                                if ($bIsLast) {
+                                    $lastPrevPrevix = implode(' AND ',$limitArray) . (count($limitArray) > 0 ? ' AND ' : '') . $newPrevPrevix;
+                                    $lastNextPrevix = implode(' AND ',$limitArray) . (count($limitArray) > 0 ? ' AND ' : '') .  $newNextPrevix;
+                                } else {
+                                    $limitArray[] = $orderByField . '=' . $comparand;
+                                    $queryPrevPrefixArray[] = $newPrevPrevix;
+                                    $queryNextPrefixArray[] = $newNextPrevix;
+                                }
+                            }
+                            $queryNextPrefix = '(' . implode(' AND ', $queryNextPrefixArray) . (count($queryNextPrefixArray) > 0 ? ' OR ' : '') . $lastNextPrevix . ')';
+                            $queryPrevPrefix = '(' . implode(' AND ', $queryPrevPrefixArray) . (count($queryNextPrefixArray) > 0 ? ' OR ' : '') . $lastPrevPrevix . ')';
+                            $prevOrderby = implode(',', $prevOrderbyArray);
+                            $nextOrderby = implode(',', $nextOrderbyArray);
+                        }
+                    }
+                }
+                if ($bDefaultOrder) {
+                    $queryPrevPrefix = 'uid < ' . intval($this->uid);
+                    $queryNextPrefix = 'uid > ' . intval($this->uid);
 
-					$prevOrderby = 'uid DESC';
-					$nextOrderby = 'uid ASC';
-				}
+                    $prevOrderby = 'uid DESC';
+                    $nextOrderby = 'uid ASC';
+                }
 
-				$prevOrderby = $itemTableArray[$this->type]->getTableObj()->transformOrderby($prevOrderby);
-				$nextOrderby = $itemTableArray[$this->type]->getTableObj()->transformOrderby($nextOrderby);
-				$whereFilter = '';
-				if (
-					isset($itemTableConf[$this->type]['filter.']) &&
-					isset($itemTableConf[$this->type]['filter.']['regexp.'])
-				) {
-					if (
+                $prevOrderby = $itemTableArray[$this->type]->getTableObj()->transformOrderby($prevOrderby);
+                $nextOrderby = $itemTableArray[$this->type]->getTableObj()->transformOrderby($nextOrderby);
+                $whereFilter = '';
+                if (
+                    isset($itemTableConf[$this->type]['filter.']) &&
+                    isset($itemTableConf[$this->type]['filter.']['regexp.'])
+                ) {
+                    if (
                         isset($itemTableConf[$this->type]['filter.']['regexp.']['field.']) &&
                         is_array($itemTableConf[$this->type]['filter.']['regexp.']['field.'])
                     ) {
-						foreach ($itemTableConf[$this->type]['filter.']['field.'] as $field => $value) {
-							$whereFilter .= ' AND ' . $field . ' REGEXP ' .
-								$GLOBALS['TYPO3_DB']->fullQuoteStr(
-									quotemeta($value),
-									$itemTableArray[$this->type]->getTableObj()->name
-								);
-						}
-					}
-				}
-				$queryprev = '';
-				if ($wherePid != '') {
-					$wherePid = ' AND ' . $wherePid;
-				}
+                        foreach ($itemTableConf[$this->type]['filter.']['field.'] as $field => $value) {
+                            $whereFilter .= ' AND ' . $field . ' REGEXP ' .
+                                $GLOBALS['TYPO3_DB']->fullQuoteStr(
+                                    quotemeta($value),
+                                    $itemTableArray[$this->type]->getTableObj()->name
+                                );
+                        }
+                    }
+                }
+                $queryprev = '';
+                if ($wherePid != '') {
+                    $wherePid = ' AND ' . $wherePid;
+                }
 
-				$wherestock = (
-					(
-						$this->conf['showNotinStock'] ||
-						!isset($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock']) ||
-						!is_array($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock'])
-					) ?
-						'' :
-						' AND (inStock <> 0) '
+                $wherestock = (
+                    (
+                        $this->conf['showNotinStock'] ||
+                        !isset($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock']) ||
+                        !is_array($GLOBALS['TCA'][$itemTableArray[$this->type]->getTableObj()->name]['columns']['inStock'])
+                    ) ?
+                        '' :
+                        ' AND (inStock <> 0) '
                 ) . $whereFilter;
-				$queryprev = $queryPrevPrefix . $whereCat . $wherePid . $wherestock . $itemTableArray[$this->type]->getTableObj()->enableFields();
+                $queryprev = $queryPrevPrefix . $whereCat . $wherePid . $wherestock . $itemTableArray[$this->type]->getTableObj()->enableFields();
 
-				$resprev =
-					$itemTableArray[$this->type]->getTableObj()->exec_SELECTquery(
-						'*',
-						$queryprev,
-						'',
-						$GLOBALS['TYPO3_DB']->stripOrderBy($prevOrderby),
-						'1',
-						$categoryJoin
-					);
+                $resprev =
+                    $itemTableArray[$this->type]->getTableObj()->exec_SELECTquery(
+                        '*',
+                        $queryprev,
+                        '',
+                        $GLOBALS['TYPO3_DB']->stripOrderBy($prevOrderby),
+                        '1',
+                        $categoryJoin
+                    );
 
-				if ($rowprev = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resprev) ) {
-					$addQueryString=[];
-					$addQueryString[$this->type] = $rowprev['uid'];
+                if ($rowprev = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resprev) ) {
+                    $addQueryString=[];
+                    $addQueryString[$this->type] = $rowprev['uid'];
 
-					if ($useBackPid) {
-						$addQueryString['backPID'] = $backPID;
-					} else if ($cat) {
-						$addQueryString[$viewCatViewTable->getPivar()] = $cat;
-					}
+                    if ($useBackPid) {
+                        $addQueryString['backPID'] = $backPID;
+                    } else if ($cat) {
+                        $addQueryString[$viewCatViewTable->getPivar()] = $cat;
+                    }
                     $prevUrl = FrontendUtility::getTypoLink_URL(
                         $cObj,
                         $GLOBALS['TSFE']->id,
@@ -1221,36 +1221,36 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                         []
                     );
 
-					$wrappedSubpartArray['###LINK_PREV_SINGLE###'] =
-						[
-							'<a href="' . htmlspecialchars($prevUrl) . '">',
-							'</a>'
-						];
-				} else {
-					$subpartArray['###LINK_PREV_SINGLE###'] = '';
-				}
-				$GLOBALS['TYPO3_DB']->sql_free_result($resprev);
-				$querynext = $queryNextPrefix . $whereCat . $wherePid . $wherestock . $itemTableArray[$this->type]->getTableObj()->enableFields();
-				// $resnext = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $querynext, $nextOrderby);
-				$resnext =
-					$itemTableArray[$this->type]->getTableObj()->exec_SELECTquery(
-						'*',
-						$querynext,
-						'',
-						$GLOBALS['TYPO3_DB']->stripOrderBy($nextOrderby),
-						'1',
-						$categoryJoin
-					);
+                    $wrappedSubpartArray['###LINK_PREV_SINGLE###'] =
+                        [
+                            '<a href="' . htmlspecialchars($prevUrl) . '">',
+                            '</a>'
+                        ];
+                } else {
+                    $subpartArray['###LINK_PREV_SINGLE###'] = '';
+                }
+                $GLOBALS['TYPO3_DB']->sql_free_result($resprev);
+                $querynext = $queryNextPrefix . $whereCat . $wherePid . $wherestock . $itemTableArray[$this->type]->getTableObj()->enableFields();
+                // $resnext = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_products', $querynext, $nextOrderby);
+                $resnext =
+                    $itemTableArray[$this->type]->getTableObj()->exec_SELECTquery(
+                        '*',
+                        $querynext,
+                        '',
+                        $GLOBALS['TYPO3_DB']->stripOrderBy($nextOrderby),
+                        '1',
+                        $categoryJoin
+                    );
 
-	// TODO: remove the SQL queries if not LINK_NEXT markers are in the template subpart
-				if ($rownext = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resnext) ) {
-					$addQueryString=[];
-					$addQueryString[$this->type] = $rownext['uid'];
-					if ($useBackPid) {
-						$addQueryString['backPID'] = $backPID;
-					} else if ($cat) {
-						$addQueryString[$viewCatViewTable->getPivar()] = $cat;
-					}
+    // TODO: remove the SQL queries if not LINK_NEXT markers are in the template subpart
+                if ($rownext = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resnext) ) {
+                    $addQueryString=[];
+                    $addQueryString[$this->type] = $rownext['uid'];
+                    if ($useBackPid) {
+                        $addQueryString['backPID'] = $backPID;
+                    } else if ($cat) {
+                        $addQueryString[$viewCatViewTable->getPivar()] = $cat;
+                    }
                     $nextUrl = FrontendUtility::getTypoLink_URL(
                         $cObj,
                         $GLOBALS['TSFE']->id,
@@ -1266,66 +1266,66 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                         '',
                         []
                     );
-					$wrappedSubpartArray['###LINK_NEXT_SINGLE###'] =
-						[
-							'<a href="' . htmlspecialchars($nextUrl) . '">',
-							'</a>'
-						];
-				} else {
-					$subpartArray['###LINK_NEXT_SINGLE###'] = '';
-				}
-				$GLOBALS['TYPO3_DB']->sql_free_result($resnext);
+                    $wrappedSubpartArray['###LINK_NEXT_SINGLE###'] =
+                        [
+                            '<a href="' . htmlspecialchars($nextUrl) . '">',
+                            '</a>'
+                        ];
+                } else {
+                    $subpartArray['###LINK_NEXT_SINGLE###'] = '';
+                }
+                $GLOBALS['TYPO3_DB']->sql_free_result($resnext);
 
-				if ($this->type == 'product') {
-					$itemTableViewArray[$this->type]->getVariant()->removeEmptyMarkerSubpartArray(
-						$markerArray,
-						$subpartArray,
-						$wrappedSubpartArray,
-						$row,
-						$this->conf,
-						$itemTableArray[$this->type]->hasAdditional($row, 'isSingle'),
-						!$itemTableArray[$this->type]->hasAdditional($row, 'noGiftService')
-					);
-				}
+                if ($this->type == 'product') {
+                    $itemTableViewArray[$this->type]->getVariant()->removeEmptyMarkerSubpartArray(
+                        $markerArray,
+                        $subpartArray,
+                        $wrappedSubpartArray,
+                        $row,
+                        $this->conf,
+                        $itemTableArray[$this->type]->hasAdditional($row, 'isSingle'),
+                        !$itemTableArray[$this->type]->hasAdditional($row, 'noGiftService')
+                    );
+                }
 
-				$relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
-				$relatedListView->init(
-					$this->pidListObj->getPidlist(),
-					$this->pidListObj->getRecursive()
-				);
+                $relatedListView = GeneralUtility::makeInstance('tx_ttproducts_relatedlist_view');
+                $relatedListView->init(
+                    $this->pidListObj->getPidlist(),
+                    $this->pidListObj->getRecursive()
+                );
 
-				$listMarkerArray = $relatedListView->getListMarkerArray(
-					'SINGLE',
-					$templateCode,
-					$viewTagArray,
-					$itemTableArray[$this->type]->getFuncTablename(),
-					$this->uid,
-					$this->uidArray,
-					$prodRow,
+                $listMarkerArray = $relatedListView->getListMarkerArray(
+                    'SINGLE',
+                    $templateCode,
+                    $viewTagArray,
+                    $itemTableArray[$this->type]->getFuncTablename(),
+                    $this->uid,
+                    $this->uidArray,
+                    $prodRow,
                     true,
                     $multiOrderArray = [],
-					$useArticles,
-					$pageAsCategory,
-					$this->pid,
-					$errorCode
-				);
+                    $useArticles,
+                    $pageAsCategory,
+                    $this->pid,
+                    $errorCode
+                );
 
-				$listUncachedMarkerArray =
-					$relatedListView->getListUncachedMarkerArray(
-						$this->uid,
-						$conf,
-						$funcTablename,
-						$viewTagArray
-					);
+                $listUncachedMarkerArray =
+                    $relatedListView->getListUncachedMarkerArray(
+                        $this->uid,
+                        $conf,
+                        $funcTablename,
+                        $viewTagArray
+                    );
 
-				if (
-					$this->type == 'product' &&
-					$listMarkerArray !== false &&
-					is_array($listMarkerArray) &&
-					!empty($this->uidArray['article'])
-				) {
-					$uid = $this->uidArray['article'];
-					$listArticleMarkerArray =
+                if (
+                    $this->type == 'product' &&
+                    $listMarkerArray !== false &&
+                    is_array($listMarkerArray) &&
+                    !empty($this->uidArray['article'])
+                ) {
+                    $uid = $this->uidArray['article'];
+                    $listArticleMarkerArray =
                         $relatedListView->getListMarkerArray(
                             'SINGLE',
                             $templateCode,
@@ -1341,51 +1341,51 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                             $errorCode
                         );
 
-					if (
-						$listArticleMarkerArray !== false &&
-						is_array($listArticleMarkerArray)
-					) {
-						$listMarkerArray = array_merge($listMarkerArray, $listArticleMarkerArray);
-					}
-				}
+                    if (
+                        $listArticleMarkerArray !== false &&
+                        is_array($listArticleMarkerArray)
+                    ) {
+                        $listMarkerArray = array_merge($listMarkerArray, $listArticleMarkerArray);
+                    }
+                }
 
-				if ($listMarkerArray && is_array($listMarkerArray)) {
-					$quantityMarkerArray = [];
+                if ($listMarkerArray && is_array($listMarkerArray)) {
+                    $quantityMarkerArray = [];
 
-					foreach ($listMarkerArray as $marker => $markerValue) {
-						$markerValue = $templateService->substituteMarkerArray($markerValue, $markerArray);
-						$markerArray[$marker] = $markerValue;
-					}
-				}
+                    foreach ($listMarkerArray as $marker => $markerValue) {
+                        $markerValue = $templateService->substituteMarkerArray($markerValue, $markerArray);
+                        $markerArray[$marker] = $markerValue;
+                    }
+                }
 
-				$jsMarkerArray = [];
-				$javaScriptMarker->getMarkerArray(
-					$jsMarkerArray,
-					$markerArray,
-					$cObj
-				);
+                $jsMarkerArray = [];
+                $javaScriptMarker->getMarkerArray(
+                    $jsMarkerArray,
+                    $markerArray,
+                    $cObj
+                );
 
-				$tabulatorMarkerArray = [];
-				FrontendUtility::addTab(
-					$templateCode,
-					$tabulatorMarkerArray,
-					$subpartArray,
-					$wrappedSubpartArray,
-					'',
-					'',
-					''
-				);
+                $tabulatorMarkerArray = [];
+                FrontendUtility::addTab(
+                    $templateCode,
+                    $tabulatorMarkerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray,
+                    '',
+                    '',
+                    ''
+                );
 
-				$markerArray = array_merge($categoryMarkerArray, $jsMarkerArray, $tabulatorMarkerArray, $listUncachedMarkerArray, $markerArray);
-				$hiddenText = '';
-				$markerArray['###HIDDENFIELDS###'] = $hiddenText; // TODO
+                $markerArray = array_merge($categoryMarkerArray, $jsMarkerArray, $tabulatorMarkerArray, $listUncachedMarkerArray, $markerArray);
+                $hiddenText = '';
+                $markerArray['###HIDDENFIELDS###'] = $hiddenText; // TODO
 
-				if (isset($this->conf['id_shop'])) {
-				// edit jf begin
-				// Rootline bis Shop-Root holen
-				// Breadcrumb aufbauen
-				// Seiten <title> aendern
-				
+                if (isset($this->conf['id_shop'])) {
+                // edit jf begin
+                // Rootline bis Shop-Root holen
+                // Breadcrumb aufbauen
+                // Seiten <title> aendern
+                
                     // Hole rootline, ausgehend von Kategorie des aktuellen Produktes
                     // Speichere uids bis Shop-Root
                     $breadcrumbArray = [];
@@ -1416,29 +1416,29 @@ class tx_ttproducts_single_view implements \TYPO3\CMS\Core\SingletonInterface {
                     // edit jf end
                 }
 
-				// TODO: Bug #44270
+                // TODO: Bug #44270
                 $markerArray = $markerObj->reduceMarkerArray($itemFrameWork, $markerArray);
 
-					// Substitute
-				$content = $templateService->substituteMarkerArrayCached(
-					$itemFrameWork,
-					$markerArray,
-					$subpartArray,
-					$wrappedSubpartArray
-				);
+                    // Substitute
+                $content = $templateService->substituteMarkerArrayCached(
+                    $itemFrameWork,
+                    $markerArray,
+                    $subpartArray,
+                    $wrappedSubpartArray
+                );
 
-				if ($content == '') {
-					$errorCode[0] = 'internal_error';
-					$errorCode[1] = 'TTP_3';
-					$errorCode[2] = 'TYPO3 function';
-				}
-			}
-		} else {
-			$errorCode[0] = 'wrong_parameter';
-			$errorCode[1] = ($this->type ? $this->type : 'product');
-			$errorCode[2] = intval($this->uidArray[$this->type] ?? 0);
-			$errorCode[3] = $this->pidListObj->getPidlist();
-		}
-		return $content;
-	} // printView
+                if ($content == '') {
+                    $errorCode[0] = 'internal_error';
+                    $errorCode[1] = 'TTP_3';
+                    $errorCode[2] = 'TYPO3 function';
+                }
+            }
+        } else {
+            $errorCode[0] = 'wrong_parameter';
+            $errorCode[1] = ($this->type ? $this->type : 'product');
+            $errorCode[2] = intval($this->uidArray[$this->type] ?? 0);
+            $errorCode[3] = $this->pidListObj->getPidlist();
+        }
+        return $content;
+    } // printView
 }

--- a/view/class.tx_ttproducts_static_tax_view.php
+++ b/view/class.tx_ttproducts_static_tax_view.php
@@ -39,7 +39,7 @@
 
 
 class tx_ttproducts_static_tax_view extends tx_ttproducts_table_base_view {
-	public $marker = 'STATICTAX';
+    public $marker = 'STATICTAX';
 
 }
 

--- a/view/class.tx_ttproducts_table_base_view.php
+++ b/view/class.tx_ttproducts_table_base_view.php
@@ -42,388 +42,388 @@ use JambageCom\TtProducts\Model\Field\FieldInterface;
 
 
 abstract class tx_ttproducts_table_base_view implements \TYPO3\CMS\Core\SingletonInterface {
-	private $bHasBeenInitialised = false;
-	public $piVar;
-	public $modelObj;
-	public $marker;		// can be overridden
-	public $tablesWithoutView = array('tt_products_emails');
+    private $bHasBeenInitialised = false;
+    public $piVar;
+    public $modelObj;
+    public $marker;		// can be overridden
+    public $tablesWithoutView = array('tt_products_emails');
 
-	public function init ($modelObj) {
-		$this->modelObj = $modelObj;
-		$this->bHasBeenInitialised = true;
+    public function init ($modelObj) {
+        $this->modelObj = $modelObj;
+        $this->bHasBeenInitialised = true;
 
-		return true;
-	}
+        return true;
+    }
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
 
-	public function destruct () {
-		$this->bHasBeenInitialised = false;
-	}
+    public function destruct () {
+        $this->bHasBeenInitialised = false;
+    }
 
-	public function getModelObj () {
-		return $this->modelObj;
-	}
+    public function getModelObj () {
+        return $this->modelObj;
+    }
 
-	public function getFieldObj ($field) {
-		$classname = $this->getFieldClass($field);
-		if (
-			$classname
-		) {
-			$result = $this->getObj($classname);
-		}
-		return $result;
-	}
+    public function getFieldObj ($field) {
+        $classname = $this->getFieldClass($field);
+        if (
+            $classname
+        ) {
+            $result = $this->getObj($classname);
+        }
+        return $result;
+    }
 
-	public function getPivar () {
-		return $this->piVar;
-	}
+    public function getPivar () {
+        return $this->piVar;
+    }
 
-	public function setPivar ($piVar) {
-		$this->piVar = $piVar;
-	}
+    public function setPivar ($piVar) {
+        $this->piVar = $piVar;
+    }
 
-	public function setMarker ($marker) {
-		$this->marker = $marker;
-	}
+    public function setMarker ($marker) {
+        $this->marker = $marker;
+    }
 
-	public function getMarker () {
-		return $this->marker;
-	}
+    public function getMarker () {
+        return $this->marker;
+    }
 
-	public function getOuterSubpartMarker () {
-		$marker = $this->getMarker();
-		return '###' . $marker . '_ITEMS###';
-	}
+    public function getOuterSubpartMarker () {
+        $marker = $this->getMarker();
+        return '###' . $marker . '_ITEMS###';
+    }
 
-	public function getInnerSubpartMarker () {
-		$marker = $this->getMarker();
-		return '###ITEM_' . $marker . '###';
-	}
+    public function getInnerSubpartMarker () {
+        $marker = $this->getMarker();
+        return '###ITEM_' . $marker . '###';
+    }
 
-	public function getObj ($className) {
+    public function getObj ($className) {
 
-		$classNameView = $className . '_view';
-		$fieldViewObj = GeneralUtility::makeInstance('' . $classNameView);	// fetch and store it as persistent object
-		if (!is_object($fieldViewObj)) {
-			throw new RuntimeException('Error in tt_products: The class "' . $classNameView . '" is not found.', 50001);
-		}
+        $classNameView = $className . '_view';
+        $fieldViewObj = GeneralUtility::makeInstance('' . $classNameView);	// fetch and store it as persistent object
+        if (!is_object($fieldViewObj)) {
+            throw new RuntimeException('Error in tt_products: The class "' . $classNameView . '" is not found.', 50001);
+        }
 
-		if ($fieldViewObj->needsInit()) {
-			$fieldObj = GeneralUtility::makeInstance('' . $className);	// fetch and store it as persistent object
+        if ($fieldViewObj->needsInit()) {
+            $fieldObj = GeneralUtility::makeInstance('' . $className);	// fetch and store it as persistent object
 
-			if (!is_object($fieldObj)) {
-				throw new RuntimeException('Error in tt_products: The class "' . $className . '" is not found.', 50002);
-			}
+            if (!is_object($fieldObj)) {
+                throw new RuntimeException('Error in tt_products: The class "' . $className . '" is not found.', 50002);
+            }
 
-			if (
-				method_exists($fieldObj, 'needsInit') &&
-				$fieldObj->needsInit()
-			) {
-				$fieldObj->init();
-			}
-			$fieldViewObj->init($fieldObj);
-		}
-		return $fieldViewObj;
-	}
+            if (
+                method_exists($fieldObj, 'needsInit') &&
+                $fieldObj->needsInit()
+            ) {
+                $fieldObj->init();
+            }
+            $fieldViewObj->init($fieldObj);
+        }
+        return $fieldViewObj;
+    }
 
-	public function getFieldClass ($fieldname) {
-		$result = $this->getModelObj()->getFieldClass($fieldname);
-		return $result;
-	}
+    public function getFieldClass ($fieldname) {
+        $result = $this->getModelObj()->getFieldClass($fieldname);
+        return $result;
+    }
 
-	public function getTagMarkerArray (
-		$tagArray,
-		$parentMarker
-	) {
-		$resultArray = [];
-		$search = $parentMarker . '_' . $this->getMarker() . '_';
-		$searchLen = strlen($search);
-		foreach ($tagArray as $marker => $k) {
-			if (substr($marker, 0, $searchLen) == $search) {
-				$tmp = substr($marker, $searchLen, strlen($marker) - $searchLen);
-				$resultArray[] = $tmp;
-			}
-		}
-		return $resultArray;
-	}
+    public function getTagMarkerArray (
+        $tagArray,
+        $parentMarker
+    ) {
+        $resultArray = [];
+        $search = $parentMarker . '_' . $this->getMarker() . '_';
+        $searchLen = strlen($search);
+        foreach ($tagArray as $marker => $k) {
+            if (substr($marker, 0, $searchLen) == $search) {
+                $tmp = substr($marker, $searchLen, strlen($marker) - $searchLen);
+                $resultArray[] = $tmp;
+            }
+        }
+        return $resultArray;
+    }
 
-	public function setMarkersEmpty (
-		$tagArray,
-		$emptyMarkerArray,
-		&$resultMarkerArray
-	) {
-		if (isset($tagArray) && is_array($tagArray)) {
-			foreach ($tagArray as $theTag => $v) {
-				foreach ($emptyMarkerArray as $theMarker) {
-					if (
-						strpos($theTag, $theMarker) === 0 &&
-						!isset($resultMarkerArray['###' . $theTag . '###'])
-					) {
-						$resultMarkerArray['###' . $theTag . '###'] = '';
-					}
-				}
-			}
-		}
-	}
+    public function setMarkersEmpty (
+        $tagArray,
+        $emptyMarkerArray,
+        &$resultMarkerArray
+    ) {
+        if (isset($tagArray) && is_array($tagArray)) {
+            foreach ($tagArray as $theTag => $v) {
+                foreach ($emptyMarkerArray as $theMarker) {
+                    if (
+                        strpos($theTag, $theMarker) === 0 &&
+                        !isset($resultMarkerArray['###' . $theTag . '###'])
+                    ) {
+                        $resultMarkerArray['###' . $theTag . '###'] = '';
+                    }
+                }
+            }
+        }
+    }
 
-	public function getItemSubpartArrays (
-		&$templateCode,
-		$functablename,
-		$row,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '',
-		$checkPriceZero = false
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableconf = $cnf->getTableConf($functablename, $theCode);
+    public function getItemSubpartArrays (
+        &$templateCode,
+        $functablename,
+        $row,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '',
+        $checkPriceZero = false
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableconf = $cnf->getTableConf($functablename, $theCode);
 
-		if (
-			isset($row) &&
-			is_array($row) &&
-			!empty($row)
-		) {
-			$newRow = $row;
-			$addedFieldArray = [];
-			foreach ($row as $field => $value) {
+        if (
+            isset($row) &&
+            is_array($row) &&
+            !empty($row)
+        ) {
+            $newRow = $row;
+            $addedFieldArray = [];
+            foreach ($row as $field => $value) {
 
-				$classname = $this->getFieldClass($field);
-				if (
-					$classname
-				) {
-					$fieldViewObj = $this->getObj($classname);
-					if (method_exists($fieldViewObj, 'modifyItemSubpartRow')) {
-						$newRow =
-							$fieldViewObj->modifyItemSubpartRow(
-								$field,
-								$newRow,
-								$addedFieldArray
-							);
-					}
-				}
-			}
-			$row = $newRow;
-			$comparatorArray =
-				['EQ' => '==', 'NE' => '!=', 'LT' => '<', 'LE' => '<=', 'GT' => '>', 'GE' => '>='];
-			$operatorArray = ['AND', 'OR'];
-			$functionArray = ['EMPTY' => 'empty'];
-			$binaryArray = ['NOT' => '!'];
+                $classname = $this->getFieldClass($field);
+                if (
+                    $classname
+                ) {
+                    $fieldViewObj = $this->getObj($classname);
+                    if (method_exists($fieldViewObj, 'modifyItemSubpartRow')) {
+                        $newRow =
+                            $fieldViewObj->modifyItemSubpartRow(
+                                $field,
+                                $newRow,
+                                $addedFieldArray
+                            );
+                    }
+                }
+            }
+            $row = $newRow;
+            $comparatorArray =
+                ['EQ' => '==', 'NE' => '!=', 'LT' => '<', 'LE' => '<=', 'GT' => '>', 'GE' => '>='];
+            $operatorArray = ['AND', 'OR'];
+            $functionArray = ['EMPTY' => 'empty'];
+            $binaryArray = ['NOT' => '!'];
 
-			// $markerKey = $this->marker.'_'.$upperField.'_';
-			if (is_array($tagArray)) {
-				foreach ($tagArray as $tag => $v1) {
-					if (strpos($tag, $this->marker) === 0) {
+            // $markerKey = $this->marker.'_'.$upperField.'_';
+            if (is_array($tagArray)) {
+                foreach ($tagArray as $tag => $v1) {
+                    if (strpos($tag, $this->marker) === 0) {
 
-						$bCondition = false;
-						$tagPartArray = explode('_', $tag);
-						$tagCount = count($tagPartArray);
-						$bTagProcessing = false;
-						$fnKey = array_search('FN', $tagPartArray);
+                        $bCondition = false;
+                        $tagPartArray = explode('_', $tag);
+                        $tagCount = count($tagPartArray);
+                        $bTagProcessing = false;
+                        $fnKey = array_search('FN', $tagPartArray);
 
-						if ($tagCount > 2 && $fnKey !== false) {
-							$bTagProcessing = true;
-							$tagPartKey = $fnKey + 1;
-							$fieldNameArray = [];
-							for ($i = 1; $i < $fnKey; ++$i) {
-								$fieldNameArray[] = $tagPartArray[$i];
-							}
-							$fieldname = strtolower(implode('_', $fieldNameArray));
-							$binaryOperator = '';
-							$v2 = $binaryArray[$tagPartArray[$tagPartKey]];
+                        if ($tagCount > 2 && $fnKey !== false) {
+                            $bTagProcessing = true;
+                            $tagPartKey = $fnKey + 1;
+                            $fieldNameArray = [];
+                            for ($i = 1; $i < $fnKey; ++$i) {
+                                $fieldNameArray[] = $tagPartArray[$i];
+                            }
+                            $fieldname = strtolower(implode('_', $fieldNameArray));
+                            $binaryOperator = '';
+                            $v2 = $binaryArray[$tagPartArray[$tagPartKey]];
 
-							if ($v2 != '') {
-								$binaryOperator = $v2;
-								$tagPartKey++;
-							}
-							$v3 = $functionArray[$tagPartArray[$tagPartKey]];
+                            if ($v2 != '') {
+                                $binaryOperator = $v2;
+                                $tagPartKey++;
+                            }
+                            $v3 = $functionArray[$tagPartArray[$tagPartKey]];
 
-							if ($v3 != '') {
-								$functionname = $v3;
-								$value = $row[$fieldname];
-								$evalString = 'return ' . $binaryOperator . $functionname . '($value);';
+                            if ($v3 != '') {
+                                $functionname = $v3;
+                                $value = $row[$fieldname];
+                                $evalString = 'return ' . $binaryOperator . $functionname . '($value);';
 
-								$bCondition = eval($evalString);
-							}
-						} else if ($tagCount > 2 && isset($comparatorArray[$tagPartArray[$tagCount - 2]])) {
-							$bTagProcessing = true;
-							$comparator = $tagPartArray[$tagCount - 2];
-							$comparand = $tagPartArray[$tagCount - 1];
-							$fieldname = strtolower($tagPartArray[1]);
-							if ($tagCount > 4) {
-								for ($i = 2; $i <= $tagCount - 3; ++$i) {
-									$fieldname .= '_' . strtolower($tagPartArray[$i]);
-								}
-							}
-							if (!isset($row[$fieldname])) {
-								$upperFieldname = strtoupper($fieldname);
-								$foundDifferentCase = false;
-								foreach ($row as $field => $v2) {
-									if (strtoupper($field) == $upperFieldname) {
-										$foundDifferentCase = true;
-										$fieldname = $field;
-										break;
-									}
-								}
-								if (!$foundDifferentCase) {
-									continue;
-								}
-							}
+                                $bCondition = eval($evalString);
+                            }
+                        } else if ($tagCount > 2 && isset($comparatorArray[$tagPartArray[$tagCount - 2]])) {
+                            $bTagProcessing = true;
+                            $comparator = $tagPartArray[$tagCount - 2];
+                            $comparand = $tagPartArray[$tagCount - 1];
+                            $fieldname = strtolower($tagPartArray[1]);
+                            if ($tagCount > 4) {
+                                for ($i = 2; $i <= $tagCount - 3; ++$i) {
+                                    $fieldname .= '_' . strtolower($tagPartArray[$i]);
+                                }
+                            }
+                            if (!isset($row[$fieldname])) {
+                                $upperFieldname = strtoupper($fieldname);
+                                $foundDifferentCase = false;
+                                foreach ($row as $field => $v2) {
+                                    if (strtoupper($field) == $upperFieldname) {
+                                        $foundDifferentCase = true;
+                                        $fieldname = $field;
+                                        break;
+                                    }
+                                }
+                                if (!$foundDifferentCase) {
+                                    continue;
+                                }
+                            }
 
-							$fieldArray = [$fieldname => [$comparator, intval($comparand)]];
+                            $fieldArray = [$fieldname => [$comparator, intval($comparand)]];
 
-							foreach ($fieldArray as $field => $fieldCondition) {
-								$comparator = $comparatorArray[$fieldCondition['0']];
+                            foreach ($fieldArray as $field => $fieldCondition) {
+                                $comparator = $comparatorArray[$fieldCondition['0']];
 
-								if (isset($row[$field]) && $comparator != '') {
-									$evalString = "return $row[$field]$comparator$fieldCondition[1];";
+                                if (isset($row[$field]) && $comparator != '') {
+                                    $evalString = "return $row[$field]$comparator$fieldCondition[1];";
 
-									$bCondition = eval($evalString);
-								}
-							}
-						}
+                                    $bCondition = eval($evalString);
+                                }
+                            }
+                        }
 
-						if ($bTagProcessing) {
-							if ($bCondition == true) {
-								$wrappedSubpartArray['###' . $tag . '###'] = '';
-							} else {
-								$subpartArray['###' . $tag . '###'] = '';
-							}
-						}
-					}
-				}
-			}
+                        if ($bTagProcessing) {
+                            if ($bCondition == true) {
+                                $wrappedSubpartArray['###' . $tag . '###'] = '';
+                            } else {
+                                $subpartArray['###' . $tag . '###'] = '';
+                            }
+                        }
+                    }
+                }
+            }
 
-			$itemTableObj = $tablesObj->get($functablename, false);
-			$tablename = $itemTableObj->getTablename();
+            $itemTableObj = $tablesObj->get($functablename, false);
+            $tablename = $itemTableObj->getTablename();
 
-			foreach ($row as $field => $value) {
-				$upperField = strtoupper($field);
+            foreach ($row as $field => $value) {
+                $upperField = strtoupper($field);
 
-				if (
-					isset($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
-					is_array($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
-					in_array(
-						$GLOBALS['TCA'][$tablename]['columns'][$field]['config']['type'], ['group', 'inline', 'select']
-					)
-				) {
-					$markerKey = $this->marker . '_HAS_' . $upperField;
-					$markerKeyNot = $this->marker . '_HAS_NO_' . $upperField;
-					if (
-						$tablename != 'tt_products_cat' &&
-						isset($GLOBALS['TCA'][$tablename]['columns'][$field]['foreign_table'])
-					) {
-						$valueArray = [];
-						if ($value > 50) {
-							$value = 50; // do not allow more subpart markers
-						}
-						for ($i = 1; $i <= $value ; ++$i) {
-							$valueArray[] = $i;
-						}
-					} else {
-						$valueArray = GeneralUtility::trimExplode(',', $value);
-					}
+                if (
+                    isset($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
+                    is_array($GLOBALS['TCA'][$tablename]['columns'][$field]) &&
+                    in_array(
+                        $GLOBALS['TCA'][$tablename]['columns'][$field]['config']['type'], ['group', 'inline', 'select']
+                    )
+                ) {
+                    $markerKey = $this->marker . '_HAS_' . $upperField;
+                    $markerKeyNot = $this->marker . '_HAS_NO_' . $upperField;
+                    if (
+                        $tablename != 'tt_products_cat' &&
+                        isset($GLOBALS['TCA'][$tablename]['columns'][$field]['foreign_table'])
+                    ) {
+                        $valueArray = [];
+                        if ($value > 50) {
+                            $value = 50; // do not allow more subpart markers
+                        }
+                        for ($i = 1; $i <= $value ; ++$i) {
+                            $valueArray[] = $i;
+                        }
+                    } else {
+                        $valueArray = GeneralUtility::trimExplode(',', $value);
+                    }
 
-					if (
-						empty($valueArray) ||
-						$valueArray['0'] == 0
-					) {
-						if (isset($tagArray[$markerKeyNot])) {
-							$wrappedSubpartArray['###' . $markerKeyNot . '###'] = ['', ''];
-						}
-					} else {
-						foreach ($valueArray as $k => $partValue) {
-							$partMarkerKey = $markerKey . ($k + 1);
+                    if (
+                        empty($valueArray) ||
+                        $valueArray['0'] == 0
+                    ) {
+                        if (isset($tagArray[$markerKeyNot])) {
+                            $wrappedSubpartArray['###' . $markerKeyNot . '###'] = ['', ''];
+                        }
+                    } else {
+                        foreach ($valueArray as $k => $partValue) {
+                            $partMarkerKey = $markerKey . ($k + 1);
 
-							if (isset($tagArray[$partMarkerKey])) {
-								if ($partValue) {
-									$wrappedSubpartArray['###' . $partMarkerKey . '###'] = ['', ''];
-								} else {
-									$subpartArray['###' . $partMarkerKey . '###'] = '';
-								}
-							}
-						}
+                            if (isset($tagArray[$partMarkerKey])) {
+                                if ($partValue) {
+                                    $wrappedSubpartArray['###' . $partMarkerKey . '###'] = ['', ''];
+                                } else {
+                                    $subpartArray['###' . $partMarkerKey . '###'] = '';
+                                }
+                            }
+                        }
 
-						if (isset($tagArray[$markerKeyNot])) {
-							$subpartArray['###' . $markerKeyNot . '###'] = '';
-						}
-					}
+                        if (isset($tagArray[$markerKeyNot])) {
+                            $subpartArray['###' . $markerKeyNot . '###'] = '';
+                        }
+                    }
 
-					for ($i = count($valueArray); $i < 100; ++$i) {
-						$partMarkerKey = $markerKey . ($i);
-						if (
-							isset($tagArray[$partMarkerKey]) &&
-							!isset($wrappedSubpartArray['###' . $partMarkerKey . '###'])
-						) {
-							$subpartArray['###' . $partMarkerKey . '###'] = '';
-						}
-					}
-				}
+                    for ($i = count($valueArray); $i < 100; ++$i) {
+                        $partMarkerKey = $markerKey . ($i);
+                        if (
+                            isset($tagArray[$partMarkerKey]) &&
+                            !isset($wrappedSubpartArray['###' . $partMarkerKey . '###'])
+                        ) {
+                            $subpartArray['###' . $partMarkerKey . '###'] = '';
+                        }
+                    }
+                }
 
-				$markerKey = $this->marker . '_' . $upperField . '_EMPTY';
+                $markerKey = $this->marker . '_' . $upperField . '_EMPTY';
 
-				if (isset($tagArray[$markerKey])) {
-					if ($value == 0) {
-						$wrappedSubpartArray['###' . $markerKey . '###'] = ['', ''];
-					} else {
-						$subpartArray['###' . $markerKey . '###'] = '';
-					}
-				}
-				$markerKeyNot = $this->marker . '_' . $upperField . '_NOT_EMPTY';
+                if (isset($tagArray[$markerKey])) {
+                    if ($value == 0) {
+                        $wrappedSubpartArray['###' . $markerKey . '###'] = ['', ''];
+                    } else {
+                        $subpartArray['###' . $markerKey . '###'] = '';
+                    }
+                }
+                $markerKeyNot = $this->marker . '_' . $upperField . '_NOT_EMPTY';
 
-				if (isset($tagArray[$markerKeyNot])) {
-					if ($value == 0) {
-						$subpartArray['###' . $markerKeyNot . '###'] = '';
-					} else {
-						$wrappedSubpartArray['###' . $markerKeyNot . '###'] = ['', ''];
-					}
-				}
+                if (isset($tagArray[$markerKeyNot])) {
+                    if ($value == 0) {
+                        $subpartArray['###' . $markerKeyNot . '###'] = '';
+                    } else {
+                        $wrappedSubpartArray['###' . $markerKeyNot . '###'] = ['', ''];
+                    }
+                }
 
-				$classname = $this->getFieldClass($field);
-				if (
-					$classname
-				) {
-					$fieldViewObj = $this->getObj($classname);
-					if (method_exists($fieldViewObj, 'getItemSubpartArrays')) {
-						$itemSubpartArray = [];
-						$fieldViewObj->getItemSubpartArrays(
-							$templateCode,
-							$this->marker,
-							$functablename,
-							$row,
-							$field,
-							$tableconf,
-							$itemSubpartArray,
-							$wrappedSubpartArray,
-							$tagArray,
-							$theCode,
-							$basketExtra,
-							$basketRecs,
-							$id
-						);
-						$subpartArray = array_merge($subpartArray, $itemSubpartArray);
-					}
-				}
-			}
+                $classname = $this->getFieldClass($field);
+                if (
+                    $classname
+                ) {
+                    $fieldViewObj = $this->getObj($classname);
+                    if (method_exists($fieldViewObj, 'getItemSubpartArrays')) {
+                        $itemSubpartArray = [];
+                        $fieldViewObj->getItemSubpartArrays(
+                            $templateCode,
+                            $this->marker,
+                            $functablename,
+                            $row,
+                            $field,
+                            $tableconf,
+                            $itemSubpartArray,
+                            $wrappedSubpartArray,
+                            $tagArray,
+                            $theCode,
+                            $basketExtra,
+                            $basketRecs,
+                            $id
+                        );
+                        $subpartArray = array_merge($subpartArray, $itemSubpartArray);
+                    }
+                }
+            }
 
-			$markerKey = $this->marker . '_NOT_EMPTY';
-			if (isset($tagArray[$markerKey])) {
-				$wrappedSubpartArray['###' . $markerKey . '###'] = '';
-			}
-		} else { // if !empty($row)
-			$itemTableObj = $tablesObj->get($functablename, false);
-			$tablename = $itemTableObj->getTablename();
-			$markerKey = $this->marker . '_NOT_EMPTY';
-			if (isset($tagArray[$markerKey])) {
-				$subpartArray['###' . $markerKey . '###'] = '';
-			}
+            $markerKey = $this->marker . '_NOT_EMPTY';
+            if (isset($tagArray[$markerKey])) {
+                $wrappedSubpartArray['###' . $markerKey . '###'] = '';
+            }
+        } else { // if !empty($row)
+            $itemTableObj = $tablesObj->get($functablename, false);
+            $tablename = $itemTableObj->getTablename();
+            $markerKey = $this->marker . '_NOT_EMPTY';
+            if (isset($tagArray[$markerKey])) {
+                $subpartArray['###' . $markerKey . '###'] = '';
+            }
             if (is_array($tagArray)) {
                 foreach ($tagArray as $tag => $v1) {
                     if (strpos($tag, $this->marker) === 0) {
@@ -434,379 +434,379 @@ abstract class tx_ttproducts_table_base_view implements \TYPO3\CMS\Core\Singleto
         }
     }
 
-	public function getMarkerKey ($markerKey) {
-		if ($markerKey != '') {
-			$marker = $markerKey;
-		} else {
-			if ($this->marker) {
-				$marker = $this->marker;
-			} else {
-				$functablename = $this->getModelObj()->getFuncTablename();
-				$marker = strtoupper($functablename);
-			}
-		}
-		return $marker;
-	}
+    public function getMarkerKey ($markerKey) {
+        if ($markerKey != '') {
+            $marker = $markerKey;
+        } else {
+            if ($this->marker) {
+                $marker = $this->marker;
+            } else {
+                $functablename = $this->getModelObj()->getFuncTablename();
+                $marker = strtoupper($functablename);
+            }
+        }
+        return $marker;
+    }
 
-	public function getId ($row, $midId, $theCode) {
+    public function getId ($row, $midId, $theCode) {
 
-		$functablename = $this->getModelObj()->getFuncTablename();
-		$extTableName = str_replace('_', '-', $functablename);
-		$preId = $extTableName;
+        $functablename = $this->getModelObj()->getFuncTablename();
+        $extTableName = str_replace('_', '-', $functablename);
+        $preId = $extTableName;
 
-		if ($midId) {
-			$preId .= '-' . $midId;
-		}
-		$rc = $preId . '-' . str_replace('_', '-', strtolower($theCode)) . '-' . intval($row['uid']);
-		return $rc;
-	}
+        if ($midId) {
+            $preId .= '-' . $midId;
+        }
+        $rc = $preId . '-' . str_replace('_', '-', strtolower($theCode)) . '-' . intval($row['uid']);
+        return $rc;
+    }
 
-	// This can also add additional fields to the row.
-	public function modifyFieldObject (
-		array $origRow,
-		array $row,
-		array $tableconf,
-		$markerPrefix,
-		$suffix,
-		array $fieldMarkerArray,
-		array $markerArray,
-		&$theMarkerArray
-	) {
+    // This can also add additional fields to the row.
+    public function modifyFieldObject (
+        array $origRow,
+        array $row,
+        array $tableconf,
+        $markerPrefix,
+        $suffix,
+        array $fieldMarkerArray,
+        array $markerArray,
+        &$theMarkerArray
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
         $local_cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
 
-		$newRow = [];
-		foreach ($row as $field => $value) {
-			if (isset($tableconf['field.'][$field . '.'])) {
-				if (!empty($tableconf['field.'][$field . '.']['untouched'])) {
-					$value = $origRow[$field];
-				}
-				$tableconf['field.'][$field . '.']['value'] = $value;
-				$fieldContent = $local_cObj->cObjGetSingle(
-					$tableconf['field.'][$field],
-					$tableconf['field.'][$field . '.'],
-					TT_PRODUCTS_EXT
-				);
+        $newRow = [];
+        foreach ($row as $field => $value) {
+            if (isset($tableconf['field.'][$field . '.'])) {
+                if (!empty($tableconf['field.'][$field . '.']['untouched'])) {
+                    $value = $origRow[$field];
+                }
+                $tableconf['field.'][$field . '.']['value'] = $value;
+                $fieldContent = $local_cObj->cObjGetSingle(
+                    $tableconf['field.'][$field],
+                    $tableconf['field.'][$field . '.'],
+                    TT_PRODUCTS_EXT
+                );
 
-				$value =
-					$templateService->substituteMarkerArray(
-						$fieldContent,
-						$fieldMarkerArray
-					);
-			}
-			$newRow[$field] = $value;
-			$markerKey = $markerPrefix . strtoupper($field . $suffix);
+                $value =
+                    $templateService->substituteMarkerArray(
+                        $fieldContent,
+                        $fieldMarkerArray
+                    );
+            }
+            $newRow[$field] = $value;
+            $markerKey = $markerPrefix . strtoupper($field . $suffix);
 
-			if (!isset($markerArray['###' . $markerKey . '###'])) {
+            if (!isset($markerArray['###' . $markerKey . '###'])) {
 
-				$theMarkerArray['###' . $markerKey . '###'] = $value;
-			}
-		}
-		$marker = $this->getMarker();
+                $theMarkerArray['###' . $markerKey . '###'] = $value;
+            }
+        }
+        $marker = $this->getMarker();
 
-		if (
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker]) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker] as $classRef) {
-				$hookObj = GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'modifyFieldObject')) {
-					$hookObj->modifyFieldObject(
-						$thts,
-						$origRow,
-						$row,
-						$tableconf,
-						$markerPrefix,
-						$suffix,
-						$fieldMarkerArray,
-						$markerArray,
-						$theMarkerArray,
-						$newRow
-					);
-				}
-			}
-		}
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker] as $classRef) {
+                $hookObj = GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'modifyFieldObject')) {
+                    $hookObj->modifyFieldObject(
+                        $thts,
+                        $origRow,
+                        $row,
+                        $tableconf,
+                        $markerPrefix,
+                        $suffix,
+                        $fieldMarkerArray,
+                        $markerArray,
+                        $theMarkerArray,
+                        $newRow
+                    );
+                }
+            }
+        }
 
-		return $newRow;
-	}
+        return $newRow;
+    }
 
-	public function createFieldMarkerArray ($row, $markerPrefix, $suffix) {
-		$fieldMarkerArray = [];
-		foreach ($row as $field => $value) {
+    public function createFieldMarkerArray ($row, $markerPrefix, $suffix) {
+        $fieldMarkerArray = [];
+        foreach ($row as $field => $value) {
             if (is_string($value)) {
                 $viewField = $field;
                 $markerKey = $markerPrefix . strtoupper($viewField . $suffix);
 
                 $fieldMarkerArray['###' . $markerKey . '###'] = $value;
             }
-		}
-		return $fieldMarkerArray;
-	}
+        }
+        return $fieldMarkerArray;
+    }
 
-	// This can also add additional fields to the row.
-	public function getRowMarkerArray (
-		$functablename,
-		$row,
-		$markerKey,
-		&$markerArray,
-		&$variantFieldArray,
-		&$variantMarkerArray,
-		$tagArray,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$bHtml = true,
-		$charset = '',
-		$imageNum = 0,
-		$imageRenderObj = 'image',
-		$id = '',	// id part to be added
-		$prefix = '', // if false, then no table marker will be added
-		$suffix = '',	// this could be a number to discern between repeated rows
-		$linkWrap = '',
-		$bEnableTaxZero = false
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+    // This can also add additional fields to the row.
+    public function getRowMarkerArray (
+        $functablename,
+        $row,
+        $markerKey,
+        &$markerArray,
+        &$variantFieldArray,
+        &$variantMarkerArray,
+        $tagArray,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $bHtml = true,
+        $charset = '',
+        $imageNum = 0,
+        $imageRenderObj = 'image',
+        $id = '',	// id part to be added
+        $prefix = '', // if false, then no table marker will be added
+        $suffix = '',	// this could be a number to discern between repeated rows
+        $linkWrap = '',
+        $bEnableTaxZero = false
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
         $conf = $cnf->getConf();
 
-		$rowMarkerArray = [];
-		if ($prefix === false) {
-			$marker = '';
-		} else {
-			$markerKey = $this->getMarkerKey($markerKey);
-			$marker = $prefix . $markerKey;
-		}
-		$mainId = '';
+        $rowMarkerArray = [];
+        if ($prefix === false) {
+            $marker = '';
+        } else {
+            $markerKey = $this->getMarkerKey($markerKey);
+            $marker = $prefix . $markerKey;
+        }
+        $mainId = '';
 
-		if (isset($row) && is_array($row) && !empty($row['uid'])) {
+        if (isset($row) && is_array($row) && !empty($row['uid'])) {
 
-			$newRow = $row;
-			$addedFieldArray = [];
+            $newRow = $row;
+            $addedFieldArray = [];
 
-			foreach ($row as $field => $value) {
+            foreach ($row as $field => $value) {
 
-				$classname = $this->getFieldClass($field);
-				if (
-					$classname
-				) {
-					$fieldViewObj = $this->getObj($classname);
+                $classname = $this->getFieldClass($field);
+                if (
+                    $classname
+                ) {
+                    $fieldViewObj = $this->getObj($classname);
 
-					if (method_exists($fieldViewObj, 'modifyItemSubpartRow')) {
-						$newRow =
-							$fieldViewObj->modifyItemSubpartRow(
-								$field,
-								$newRow,
-								$addedFieldArray
-							);
-					}
-				}
-				if (strpos($field, FieldInterface::EXTERNAL_FIELD_PREFIX) === 0) {
-					$newField = substr($field, strlen(FieldInterface::EXTERNAL_FIELD_PREFIX));
-					$newRow[$newField] = $value;
-					unset($newRow[$field]);
-				}
-			}
-			$row = $newRow;
-			$functablename = $this->getModelObj()->getFuncTablename();
-			$extTableName = str_replace('_', '-', $functablename);
-			$mainId = $this->getId($row, $id, $theCode);
-			$markerPrefix = ($marker != '' ? $marker . '_' : '');
-			$rowMarkerArray['###' . $markerPrefix . 'ID###'] = $mainId;
-			$rowMarkerArray['###' . $markerPrefix . 'NAME###'] = $extTableName . '-' . $row['uid'];
-			$tableconf = $cnf->getTableConf($functablename, $theCode);
+                    if (method_exists($fieldViewObj, 'modifyItemSubpartRow')) {
+                        $newRow =
+                            $fieldViewObj->modifyItemSubpartRow(
+                                $field,
+                                $newRow,
+                                $addedFieldArray
+                            );
+                    }
+                }
+                if (strpos($field, FieldInterface::EXTERNAL_FIELD_PREFIX) === 0) {
+                    $newField = substr($field, strlen(FieldInterface::EXTERNAL_FIELD_PREFIX));
+                    $newRow[$newField] = $value;
+                    unset($newRow[$field]);
+                }
+            }
+            $row = $newRow;
+            $functablename = $this->getModelObj()->getFuncTablename();
+            $extTableName = str_replace('_', '-', $functablename);
+            $mainId = $this->getId($row, $id, $theCode);
+            $markerPrefix = ($marker != '' ? $marker . '_' : '');
+            $rowMarkerArray['###' . $markerPrefix . 'ID###'] = $mainId;
+            $rowMarkerArray['###' . $markerPrefix . 'NAME###'] = $extTableName . '-' . $row['uid'];
+            $tableconf = $cnf->getTableConf($functablename, $theCode);
 
-			$tabledesc = $cnf->getTableDesc($functablename);
+            $tabledesc = $cnf->getTableDesc($functablename);
 
-			$fieldMarkerArray = $this->createFieldMarkerArray($row, $markerPrefix, $suffix);
+            $fieldMarkerArray = $this->createFieldMarkerArray($row, $markerPrefix, $suffix);
 
-			foreach ($row as $field => $value) {
-				if (
-					in_array($field, $addedFieldArray)
-				) {
-					continue; // do not handle the added fields here. They must be handled with the original field.
-				}
+            foreach ($row as $field => $value) {
+                if (
+                    in_array($field, $addedFieldArray)
+                ) {
+                    continue; // do not handle the added fields here. They must be handled with the original field.
+                }
 
-				if (gettype($value) == 'NULL') {
+                if (gettype($value) == 'NULL') {
                     $value = '';
                 }
 
-				$viewField = str_replace('_uid', '', $field);
-				$bSkip = false;
-				$theMarkerArray = &$rowMarkerArray;
-				$fieldId = $mainId . '-' . $viewField;
-				$markerKey = $markerPrefix . strtoupper($viewField . $suffix);
+                $viewField = str_replace('_uid', '', $field);
+                $bSkip = false;
+                $theMarkerArray = &$rowMarkerArray;
+                $fieldId = $mainId . '-' . $viewField;
+                $markerKey = $markerPrefix . strtoupper($viewField . $suffix);
 
-				if (isset($tagArray[$markerKey . '_ID'])) {
-					$rowMarkerArray['###' . $markerKey . '_ID###'] = $fieldId;
-				}
+                if (isset($tagArray[$markerKey . '_ID'])) {
+                    $rowMarkerArray['###' . $markerKey . '_ID###'] = $fieldId;
+                }
 
-				$classname = false;
+                $classname = false;
 
-				if (
-					is_array($variantFieldArray) &&
-					is_array($variantMarkerArray) &&
-					in_array($field, $variantFieldArray)
-				) {
-					$classname = 'tx_ttproducts_field_text';
-					$theMarkerArray = &$variantMarkerArray;
-				} else {
-					$classname = $this->getFieldClass($field);
-				}
-				
-				$modifiedRow = [$field => $value];
+                if (
+                    is_array($variantFieldArray) &&
+                    is_array($variantMarkerArray) &&
+                    in_array($field, $variantFieldArray)
+                ) {
+                    $classname = 'tx_ttproducts_field_text';
+                    $theMarkerArray = &$variantMarkerArray;
+                } else {
+                    $classname = $this->getFieldClass($field);
+                }
+                
+                $modifiedRow = [$field => $value];
 
-				if (
-					$classname
-				) {
-					$fieldViewObj = $this->getObj($classname);
-					$modifiedRow =
-						$fieldViewObj->getRowMarkerArray(
-							$functablename,
-							$field,
-							$row,
-							$markerKey,
-							$theMarkerArray,
-							$fieldMarkerArray,
-							$tagArray,
-							$theCode,
-							$fieldId,
-							$basketExtra,
-							$basketRecs,
-							$bSkip,
-							$bHtml,
-							$charset,
-							$prefix,
-							$suffix,
-							$imageNum,
-							$imageRenderObj,
-							$linkWrap,
-							$bEnableTaxZero
-						);
+                if (
+                    $classname
+                ) {
+                    $fieldViewObj = $this->getObj($classname);
+                    $modifiedRow =
+                        $fieldViewObj->getRowMarkerArray(
+                            $functablename,
+                            $field,
+                            $row,
+                            $markerKey,
+                            $theMarkerArray,
+                            $fieldMarkerArray,
+                            $tagArray,
+                            $theCode,
+                            $fieldId,
+                            $basketExtra,
+                            $basketRecs,
+                            $bSkip,
+                            $bHtml,
+                            $charset,
+                            $prefix,
+                            $suffix,
+                            $imageNum,
+                            $imageRenderObj,
+                            $linkWrap,
+                            $bEnableTaxZero
+                        );
 
-					if (isset($modifiedRow) && !is_array($modifiedRow)) { // if a single value has been returned instead of an array
-						$modifiedRow = [$field => $modifiedRow];
-					} else if (!isset($modifiedRow)) { // restore former default value
-						$modifiedRow = [$field => $value];
-					}
-				} else {
-					switch ($field) {
-						case 'ext':
-							$bSkip = true;
-							break;
-						default:
-							// nothing
-							break;
-					}
-				}
-				if (!$bSkip) {
-					$this->modifyFieldObject(
-						$row,
-						$modifiedRow,
-						$tableconf,
-						$markerPrefix,
-						$suffix,
-						$fieldMarkerArray,
-						$markerArray,
-						$theMarkerArray
-					);
-				}
-			}
-		} else {
-			$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-			$tablename = $cnf->getTableName($functablename);
+                    if (isset($modifiedRow) && !is_array($modifiedRow)) { // if a single value has been returned instead of an array
+                        $modifiedRow = [$field => $modifiedRow];
+                    } else if (!isset($modifiedRow)) { // restore former default value
+                        $modifiedRow = [$field => $value];
+                    }
+                } else {
+                    switch ($field) {
+                        case 'ext':
+                            $bSkip = true;
+                            break;
+                        default:
+                            // nothing
+                            break;
+                    }
+                }
+                if (!$bSkip) {
+                    $this->modifyFieldObject(
+                        $row,
+                        $modifiedRow,
+                        $tableconf,
+                        $markerPrefix,
+                        $suffix,
+                        $fieldMarkerArray,
+                        $markerArray,
+                        $theMarkerArray
+                    );
+                }
+            }
+        } else {
+            $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+            $tablename = $cnf->getTableName($functablename);
 // 			$tablename = $this->getModelObj()->getTablename();
-			$tmpMarkerArray = [];
-			$tmpMarkerArray[] = $marker;
+            $tmpMarkerArray = [];
+            $tmpMarkerArray[] = $marker;
 
-			if (isset($GLOBALS['TCA'][$tablename]['columns']) && is_array($GLOBALS['TCA'][$tablename]['columns'])) {
+            if (isset($GLOBALS['TCA'][$tablename]['columns']) && is_array($GLOBALS['TCA'][$tablename]['columns'])) {
 
-				foreach ($GLOBALS['TCA'][$tablename]['columns'] as $theField => $confArray) {
+                foreach ($GLOBALS['TCA'][$tablename]['columns'] as $theField => $confArray) {
 
-					if (
+                    if (
                         $confArray['config']['type'] == 'group' &&
                         isset($confArray['config']['foreign_table'])
                     ) {
-						$foreigntablename = $confArray['config']['foreign_table'];
+                        $foreigntablename = $confArray['config']['foreign_table'];
                         if (
                             $foreigntablename != '' &&
                             !in_array($foreigntablename, $this->tablesWithoutView)
                         ) {
-							$foreignTableViewObj = $tablesObj->get($foreigntablename, true);
-							if (is_object($foreignTableViewObj)) {
-								$foreignMarker = $foreignTableViewObj->getMarker();
-								$tmpMarkerArray[] = $foreignMarker;
-							}
-						}
-					}
-				}
-			}
-			$this->setMarkersEmpty($tagArray, $tmpMarkerArray, $rowMarkerArray);
-		}
+                            $foreignTableViewObj = $tablesObj->get($foreigntablename, true);
+                            if (is_object($foreignTableViewObj)) {
+                                $foreignMarker = $foreignTableViewObj->getMarker();
+                                $tmpMarkerArray[] = $foreignMarker;
+                            }
+                        }
+                    }
+                }
+            }
+            $this->setMarkersEmpty($tagArray, $tmpMarkerArray, $rowMarkerArray);
+        }
 
-		$this->getRowMarkerArrayHooks(
-			$this,
-			$rowMarkerArray,
-			$cObjectMarkerArray,
-			$functablename,
-			$row,
-			$imageNum,
-			$imageRenderObj,
-			$forminfoArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$mainId,
-			$linkWrap,
-			$bEnableTaxZero
-		);
-		$markerArray['###CUR_SYM###'] = ' ' . ($bHtml ?  htmlentities($conf['currencySymbol'], ENT_QUOTES) : $conf['currencySymbol']);
-		$markerArray = array_merge($markerArray, $rowMarkerArray);
-	}
+        $this->getRowMarkerArrayHooks(
+            $this,
+            $rowMarkerArray,
+            $cObjectMarkerArray,
+            $functablename,
+            $row,
+            $imageNum,
+            $imageRenderObj,
+            $forminfoArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $mainId,
+            $linkWrap,
+            $bEnableTaxZero
+        );
+        $markerArray['###CUR_SYM###'] = ' ' . ($bHtml ?  htmlentities($conf['currencySymbol'], ENT_QUOTES) : $conf['currencySymbol']);
+        $markerArray = array_merge($markerArray, $rowMarkerArray);
+    }
 
-	protected function getRowMarkerArrayHooks (
-		$pObj,
-		&$markerArray,
-		&$cObjectMarkerArray,
-		$functablename,
-		$row,
-		$imageNum,
-		$imageRenderObj,
-		&$forminfoArray,
-		$theCode,
-		$basketExtra,
-		$basketRecs,
-		$id,
-		&$linkWrap,
-		$bEnableTaxZero
-	) {
-			// Call all getRowMarkerArray hooks at the end of this method
-		$marker = $this->getMarker();
+    protected function getRowMarkerArrayHooks (
+        $pObj,
+        &$markerArray,
+        &$cObjectMarkerArray,
+        $functablename,
+        $row,
+        $imageNum,
+        $imageRenderObj,
+        &$forminfoArray,
+        $theCode,
+        $basketExtra,
+        $basketRecs,
+        $id,
+        &$linkWrap,
+        $bEnableTaxZero
+    ) {
+            // Call all getRowMarkerArray hooks at the end of this method
+        $marker = $this->getMarker();
 
-		if (
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker]) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker])
         ) {
-			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker] as $classRef) {
-				$hookObj = GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'getRowMarkerArray')) {
-					$hookObj->getRowMarkerArray(
-						$pObj,
-						$markerArray,
-						$cObjectMarkerArray,
-						$functablename,
-						$row,
-						$imageNum,
-						$imageRenderObj,
-						$forminfoArray,
-						$theCode,
-						$basketExtra,
-						$basketRecs,
-						$id,
-						$linkWrap,
-						$bEnableTaxZero
-					);
-				}
-			}
-		}
-	}
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT][$marker] as $classRef) {
+                $hookObj = GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'getRowMarkerArray')) {
+                    $hookObj->getRowMarkerArray(
+                        $pObj,
+                        $markerArray,
+                        $cObjectMarkerArray,
+                        $functablename,
+                        $row,
+                        $imageNum,
+                        $imageRenderObj,
+                        $forminfoArray,
+                        $theCode,
+                        $basketExtra,
+                        $basketRecs,
+                        $id,
+                        $linkWrap,
+                        $bEnableTaxZero
+                    );
+                }
+            }
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_text_view.php
+++ b/view/class.tx_ttproducts_text_view.php
@@ -41,57 +41,57 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_text_view extends tx_ttproducts_table_base_view {
-	public $marker = 'TEXT';
+    public $marker = 'TEXT';
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	array		reference to an item array with all the data of the item
-	 * @param	array		Returns a markerArray ready for substitution with information
-	 * @access private
-	 */
-	public function getRowsMarkerArray (
-		$rowArray,
-		&$markerArray,
-		$parentMarker,
-		$tagArray
-	) {
-		$bFoundTagArray = [];
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	array		reference to an item array with all the data of the item
+     * @param	array		Returns a markerArray ready for substitution with information
+     * @access private
+     */
+    public function getRowsMarkerArray (
+        $rowArray,
+        &$markerArray,
+        $parentMarker,
+        $tagArray
+    ) {
+        $bFoundTagArray = [];
         $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
 
         if (isset($rowArray) && is_array($rowArray) && count($rowArray)) {
-			foreach ($rowArray as $k => $row) {
-				$tag = strtoupper($row['marker']);
-				$bFoundTagArray[$tag] = true;
-				$marker = $parentMarker . '_' . $this->getMarker() . '_' . $tag;
-				$value = $row['note'];
-				$value = ($conf['nl2brNote'] ? nl2br($value) : $value);
+            foreach ($rowArray as $k => $row) {
+                $tag = strtoupper($row['marker']);
+                $bFoundTagArray[$tag] = true;
+                $marker = $parentMarker . '_' . $this->getMarker() . '_' . $tag;
+                $value = $row['note'];
+                $value = ($conf['nl2brNote'] ? nl2br($value) : $value);
 
                 if (FrontendUtility::hasRTEparser()) {
                     $value = FrontendUtility::RTEcssText($cObj, $value);
-				} else if (is_array($conf['parseFunc.'])) {
-					$value = $cObj->parseFunc($value, $conf['parseFunc.']);
-				}
-				$markerArray['###' . $marker . '###'] = $value;
-				$markerTitle = $marker . '_' . strtoupper('title');
-				$markerArray['###' . $markerTitle . '###'] = $row['title'];
-			}
-		}
+                } else if (is_array($conf['parseFunc.'])) {
+                    $value = $cObj->parseFunc($value, $conf['parseFunc.']);
+                }
+                $markerArray['###' . $marker . '###'] = $value;
+                $markerTitle = $marker . '_' . strtoupper('title');
+                $markerArray['###' . $markerTitle . '###'] = $row['title'];
+            }
+        }
 
 
-		if (isset($tagArray) && is_array($tagArray)) {
-			foreach ($tagArray as $tag) {
-				if (!$bFoundTagArray[$tag]) {
-					$marker = $parentMarker . '_' . $this->getMarker() . '_' . $tag;
-					$markerArray['###' . $marker . '###'] = '';
-				}
-			}
-		}
-	}
+        if (isset($tagArray) && is_array($tagArray)) {
+            foreach ($tagArray as $tag) {
+                if (!$bFoundTagArray[$tag]) {
+                    $marker = $parentMarker . '_' . $this->getMarker() . '_' . $tag;
+                    $markerArray['###' . $marker . '###'] = '';
+                }
+            }
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_url_view.php
+++ b/view/class.tx_ttproducts_url_view.php
@@ -42,383 +42,383 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_url_view implements \TYPO3\CMS\Core\SingletonInterface {
-	public $conf;
-	public $urlArray;
+    public $conf;
+    public $urlArray;
 
 
-	/**
-	 * Initialized the marker object
-	 * $basket is the TYPO3 default shopping basket array from ses-data
-	 *
-	 * @param		string		$fieldname is the field in the table you want to create a JavaScript for
-	* @param		array		array urls which should be overridden with marker key as index
-	 * @return	  void
- 	 */
-	public function init ($conf) {
- 		$this->conf = $conf;
-	}
+    /**
+     * Initialized the marker object
+     * $basket is the TYPO3 default shopping basket array from ses-data
+     *
+     * @param		string		$fieldname is the field in the table you want to create a JavaScript for
+    * @param		array		array urls which should be overridden with marker key as index
+     * @return	  void
+     */
+    public function init ($conf) {
+        $this->conf = $conf;
+    }
 
 
-	public function getSingleExcludeList ($excludeList) {
-		$excludeListArray = GeneralUtility::trimExplode(',', $excludeList);
-		$singleExcludeListArray =
-			[
-				'article',
-				'product',
-				'variants',
-				'dam',
-				'fal'
-			];
-		$singleExcludeListArray = array_merge($excludeListArray, $singleExcludeListArray);
+    public function getSingleExcludeList ($excludeList) {
+        $excludeListArray = GeneralUtility::trimExplode(',', $excludeList);
+        $singleExcludeListArray =
+            [
+                'article',
+                'product',
+                'variants',
+                'dam',
+                'fal'
+            ];
+        $singleExcludeListArray = array_merge($excludeListArray, $singleExcludeListArray);
 
-		if (!$singleExcludeListArray[0]) {
-			unset($singleExcludeListArray[0]);
-		}
-		$singleExcludeList = implode(',', $singleExcludeListArray);
-		return $singleExcludeList;
-	}
-
-
-	public function setUrlArray ($urlArray) {
-		$this->urlArray = $urlArray;
-	}
+        if (!$singleExcludeListArray[0]) {
+            unset($singleExcludeListArray[0]);
+        }
+        $singleExcludeList = implode(',', $singleExcludeListArray);
+        return $singleExcludeList;
+    }
 
 
-	/**
-	 * Adds link markers to a wrapped subpart array
-	 */
-	public function getWrappedSubpartArray (
-		&$wrappedSubpartArray,
-		$addQueryString = [],
-		$css_current = '',
-		$useBackPid = true
-	) {
+    public function setUrlArray ($urlArray) {
+        $this->urlArray = $urlArray;
+    }
+
+
+    /**
+     * Adds link markers to a wrapped subpart array
+     */
+    public function getWrappedSubpartArray (
+        &$wrappedSubpartArray,
+        $addQueryString = [],
+        $css_current = '',
+        $useBackPid = true
+    ) {
         $cObj = \JambageCom\Div2007\Utility\FrontendUtility::getContentObjectRenderer();
-		$commandArray =
-			[
-				'basket',
-				'info',
-				'payment',
-				'finalize',
-				'thanks',
-				'search',
-				'memo',
-				'tracking',
-				'billing',
-				'delivery',
-				'agb'
-			];
+        $commandArray =
+            [
+                'basket',
+                'info',
+                'payment',
+                'finalize',
+                'thanks',
+                'search',
+                'memo',
+                'tracking',
+                'billing',
+                'delivery',
+                'agb'
+            ];
 
-		foreach ($commandArray as $command) {
+        foreach ($commandArray as $command) {
 
-			$pidBasket = (!empty($this->conf['PID' . $command]) ? $this->conf['PID' . $command] : $GLOBALS['TSFE']->id);
-			$pageLink = FrontendUtility::getTypoLink_URL(
-				$cObj,
-				$pidBasket,
-				$this->getLinkParams(
-					'',
-					$addQueryString,
-					true,
-					$useBackPid
-				)
-			);
-			$wrappedSubpartArray['###LINK_' . strtoupper($command) . '###'] =
-				['<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>', '</a>'];
-		}
-	}
+            $pidBasket = (!empty($this->conf['PID' . $command]) ? $this->conf['PID' . $command] : $GLOBALS['TSFE']->id);
+            $pageLink = FrontendUtility::getTypoLink_URL(
+                $cObj,
+                $pidBasket,
+                $this->getLinkParams(
+                    '',
+                    $addQueryString,
+                    true,
+                    $useBackPid
+                )
+            );
+            $wrappedSubpartArray['###LINK_' . strtoupper($command) . '###'] =
+                ['<a href="' . htmlspecialchars($pageLink) . '"' . $css_current . '>', '</a>'];
+        }
+    }
 
 
-	/**
-	 * Adds URL markers to a markerArray
-	 */
-	public function addURLMarkers (
-		$pidNext,
-		$markerArray,
-		$addQueryString = [],
-		$excludeList = '',
-		$useBackPid = true,
-		$backPid = 0,
-		$bExcludeSingleVar = true
-	) {
+    /**
+     * Adds URL markers to a markerArray
+     */
+    public function addURLMarkers (
+        $pidNext,
+        $markerArray,
+        $addQueryString = [],
+        $excludeList = '',
+        $useBackPid = true,
+        $backPid = 0,
+        $bExcludeSingleVar = true
+    ) {
         $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-		$charset = 'UTF-8';
-		$urlMarkerArray = [];
-		$conf = [];
-		$target = '';
+        $charset = 'UTF-8';
+        $urlMarkerArray = [];
+        $conf = [];
+        $target = '';
 
-		// disable caching as soon as someone enters products into the basket, enters user data etc.
-		// $addQueryString['no_cache'] = 1;
-			// Add's URL-markers to the $markerArray and returns it
-		$basketPid = ($this->conf['PIDbasket'] ? $this->conf['PIDbasket'] : $GLOBALS['TSFE']->id);
-		$formUrlPid = ($pidNext ? $pidNext : $GLOBALS['TSFE']->id);
-		$singleExcludeList = $this->getSingleExcludeList($excludeList);
+        // disable caching as soon as someone enters products into the basket, enters user data etc.
+        // $addQueryString['no_cache'] = 1;
+            // Add's URL-markers to the $markerArray and returns it
+        $basketPid = ($this->conf['PIDbasket'] ? $this->conf['PIDbasket'] : $GLOBALS['TSFE']->id);
+        $formUrlPid = ($pidNext ? $pidNext : $GLOBALS['TSFE']->id);
+        $singleExcludeList = $this->getSingleExcludeList($excludeList);
 
-		$useBackPid = ($useBackPid && $pidNext && $pidNext != $GLOBALS['TSFE']->id);
+        $useBackPid = ($useBackPid && $pidNext && $pidNext != $GLOBALS['TSFE']->id);
 
-		$urlExcludeList = $excludeList;
-		if (
-			$formUrlPid != $GLOBALS['TSFE']->id &&
-			$bExcludeSingleVar
-		) {
-			$urlExcludeList = $singleExcludeList;
-		}
+        $urlExcludeList = $excludeList;
+        if (
+            $formUrlPid != $GLOBALS['TSFE']->id &&
+            $bExcludeSingleVar
+        ) {
+            $urlExcludeList = $singleExcludeList;
+        }
 
-		$urlConfig = [
-			'FORM_URL' => [
-					'pid' => $formUrlPid,
-					'excludeList' => $urlExcludeList
-				],
-			'FORM_URL_CURRENT' => [
-					'pid' => $GLOBALS['TSFE']->id,
-					'excludeList' => $excludeList
-				]
-		];
+        $urlConfig = [
+            'FORM_URL' => [
+                    'pid' => $formUrlPid,
+                    'excludeList' => $urlExcludeList
+                ],
+            'FORM_URL_CURRENT' => [
+                    'pid' => $GLOBALS['TSFE']->id,
+                    'excludeList' => $excludeList
+                ]
+        ];
 
-		foreach ($urlConfig as $markerKey => $keyConfig) {
-			$url = FrontendUtility::getTypoLink_URL(
-				$cObj,
-				$keyConfig['pid'],
-				$this->getLinkParams(
-					$keyConfig['excludeList'],
-					$addQueryString,
-					true,
-					$useBackPid,
-					$backPid
-				),
-				$target,
-				$conf
-			);
+        foreach ($urlConfig as $markerKey => $keyConfig) {
+            $url = FrontendUtility::getTypoLink_URL(
+                $cObj,
+                $keyConfig['pid'],
+                $this->getLinkParams(
+                    $keyConfig['excludeList'],
+                    $addQueryString,
+                    true,
+                    $useBackPid,
+                    $backPid
+                ),
+                $target,
+                $conf
+            );
 
-			$urlMarkerArray['###' . $markerKey . '###'] = htmlspecialchars($url, ENT_NOQUOTES, $charset);
-			$urlMarkerArray['###' . $markerKey . '_VALUE###'] =
-				$url;
-		}
+            $urlMarkerArray['###' . $markerKey . '###'] = htmlspecialchars($url, ENT_NOQUOTES, $charset);
+            $urlMarkerArray['###' . $markerKey . '_VALUE###'] =
+                $url;
+        }
 
-		$commandArray =
-			[
-				'basket',
-				'info',
-				'payment',
-				'finalize',
-				'thanks',
-				'search',
-				'memo',
-				'tracking',
-				'billing',
-				'delivery',
-				'agb',
-				'user1',
-				'user2',
-				'user3',
-				'user4',
-				'user5'
-			];
+        $commandArray =
+            [
+                'basket',
+                'info',
+                'payment',
+                'finalize',
+                'thanks',
+                'search',
+                'memo',
+                'tracking',
+                'billing',
+                'delivery',
+                'agb',
+                'user1',
+                'user2',
+                'user3',
+                'user4',
+                'user5'
+            ];
 
-		foreach ($commandArray as $command) {
-			$linkPid = (!empty($this->conf['PID' . $command]) ? $this->conf['PID' . $command] : $basketPid);
-			$url = FrontendUtility::getTypoLink_URL(
-				$cObj,
-				$linkPid,
-				$this->getLinkParams(
-					$singleExcludeList,
-					$addQueryString,
-					true,
-					$useBackPid,
-					$backPid
-				),
-				$target,
-				$conf
-			);
-			$urlMarkerArray['###FORM_URL_' . strtoupper($command) . '###'] =
-				htmlspecialchars(
-					$url,
-					ENT_NOQUOTES,
-					$charset
-				);
-			$urlMarkerArray['###FORM_URL_' . strtoupper($command) . '_VALUE###'] =
-				$url;
-		}
+        foreach ($commandArray as $command) {
+            $linkPid = (!empty($this->conf['PID' . $command]) ? $this->conf['PID' . $command] : $basketPid);
+            $url = FrontendUtility::getTypoLink_URL(
+                $cObj,
+                $linkPid,
+                $this->getLinkParams(
+                    $singleExcludeList,
+                    $addQueryString,
+                    true,
+                    $useBackPid,
+                    $backPid
+                ),
+                $target,
+                $conf
+            );
+            $urlMarkerArray['###FORM_URL_' . strtoupper($command) . '###'] =
+                htmlspecialchars(
+                    $url,
+                    ENT_NOQUOTES,
+                    $charset
+                );
+            $urlMarkerArray['###FORM_URL_' . strtoupper($command) . '_VALUE###'] =
+                $url;
+        }
 
-		$urlMarkerArray['###FORM_URL_TARGET###'] = '_self';
+        $urlMarkerArray['###FORM_URL_TARGET###'] = '_self';
 
-		if (
-			isset($this->urlArray) &&
-			is_array($this->urlArray) &&
-			!empty($this->urlArray)
-		) {
-			foreach ($this->urlArray as $k => $urlValue) {
-				$urlMarkerArray['###' . strtoupper($k) . '###'] = $urlValue;
-			}
-		}
+        if (
+            isset($this->urlArray) &&
+            is_array($this->urlArray) &&
+            !empty($this->urlArray)
+        ) {
+            foreach ($this->urlArray as $k => $urlValue) {
+                $urlMarkerArray['###' . strtoupper($k) . '###'] = $urlValue;
+            }
+        }
 
-			// Call all addURLMarkers hooks at the end of this method
-		if (
+            // Call all addURLMarkers hooks at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addURLMarkers']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addURLMarkers'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addURLMarkers'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'addURLMarkers')) {
-					$hookObj->addURLMarkers(
-						$cObj,
-						$pidNext,
-						$urlMarkerArray,
-						$addQueryString,
-						$excludeList,
-						$singleExcludeList,
-						$useBackPid,
-						$backPid,
-						$bExcludeSingleVar
-					);
-				}
-			}
-		}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['addURLMarkers'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'addURLMarkers')) {
+                    $hookObj->addURLMarkers(
+                        $cObj,
+                        $pidNext,
+                        $urlMarkerArray,
+                        $addQueryString,
+                        $excludeList,
+                        $singleExcludeList,
+                        $useBackPid,
+                        $backPid,
+                        $bExcludeSingleVar
+                    );
+                }
+            }
+        }
 
-		if (isset($markerArray) && is_array($markerArray)) {
-			$markerArray = array_merge($markerArray, $urlMarkerArray);
-		} else {
-			$markerArray = $urlMarkerArray;
-		}
-		return $markerArray;
-	} // addURLMarkers
-
-
-	/**
-	 * Returns a url for use in forms and links
-	 */
-	public function addQueryStringParam (&$queryString, $param, $bUsePrefix = false) {
-		$piVars = tx_ttproducts_model_control::getPiVars();
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
-
-		$temp = $piVars[$param] ?? '';
-		$temp = ($temp ? $temp : (GeneralUtility::_GP($param) && ($param != 'pid') ? GeneralUtility::_GP($param) : 0));
-
-		if ($temp) {
-			if ($bUsePrefix) {
-				$queryString[$prefixId . '[' . $param . ']'] = $temp;
-			} else {
-				$queryString[$param] = $temp;
-			}
-		}
-	}
+        if (isset($markerArray) && is_array($markerArray)) {
+            $markerArray = array_merge($markerArray, $urlMarkerArray);
+        } else {
+            $markerArray = $urlMarkerArray;
+        }
+        return $markerArray;
+    } // addURLMarkers
 
 
-	/**
-	 * Returns a url for use in forms and links
-	 */
-	public function getLinkParams (
-		$excludeList = '',
-		$addQueryString = [],
-		$bUsePrefix = false,
-		$useBackPid = true,
-		$backPid = 0,
-		$piVarSingle = 'product',
-		$piVarCat = 'cat'
-	) {
-		$prefixId = tx_ttproducts_model_control::getPrefixId();
+    /**
+     * Returns a url for use in forms and links
+     */
+    public function addQueryStringParam (&$queryString, $param, $bUsePrefix = false) {
+        $piVars = tx_ttproducts_model_control::getPiVars();
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
 
-		$queryString = [];
-		if ($useBackPid) {
-			if (!$backPid) {
-				$backPid = $GLOBALS['TSFE']->id;
-			}
+        $temp = $piVars[$param] ?? '';
+        $temp = ($temp ? $temp : (GeneralUtility::_GP($param) && ($param != 'pid') ? GeneralUtility::_GP($param) : 0));
 
-			if (
-				$bUsePrefix &&
-				empty($addQueryString[$prefixId . '[backPID]'])
-			) {
-				$queryString[$prefixId . '[backPID]'] = $backPid;
-			} else if (empty($addQueryString['backPID'])) {
-				$queryString['backPID'] = $backPid;
-			}
-		}
+        if ($temp) {
+            if ($bUsePrefix) {
+                $queryString[$prefixId . '[' . $param . ']'] = $temp;
+            } else {
+                $queryString[$param] = $temp;
+            }
+        }
+    }
 
-		if ($excludeList != '' && $bUsePrefix) {
-			$excludeArray = explode(',', $excludeList);
-			foreach ($excludeArray as $k => $v) {
-				$excludeArray[$k] = $prefixId . '[' . $v . ']';
-			}
-			$excludeList = implode(',', $excludeArray);
-		}
 
-		$this->addQueryStringParam($queryString, 'C', $bUsePrefix);
-		if ($piVarSingle != '') {
-			$this->addQueryStringParam($queryString, $piVarSingle, $bUsePrefix);
-		}
-		if ($piVarCat != '') {
-			$this->addQueryStringParam($queryString, $piVarCat, $bUsePrefix);
-		}
+    /**
+     * Returns a url for use in forms and links
+     */
+    public function getLinkParams (
+        $excludeList = '',
+        $addQueryString = [],
+        $bUsePrefix = false,
+        $useBackPid = true,
+        $backPid = 0,
+        $piVarSingle = 'product',
+        $piVarCat = 'cat'
+    ) {
+        $prefixId = tx_ttproducts_model_control::getPrefixId();
 
-		$listPointerParam = tx_ttproducts_model_control::getPointerPiVar('LIST');
-		$this->addQueryStringParam($queryString, $listPointerParam, $bUsePrefix);
-		$catlistPointerParam = tx_ttproducts_model_control::getPointerPiVar('CATLIST');
+        $queryString = [];
+        if ($useBackPid) {
+            if (!$backPid) {
+                $backPid = $GLOBALS['TSFE']->id;
+            }
 
-		$this->addQueryStringParam($queryString, 'mode', false);
-		$this->addQueryStringParam($queryString, $listPointerParam, $bUsePrefix);
-		$this->addQueryStringParam($queryString, 'newitemdays', $bUsePrefix);
-		$this->addQueryStringParam($queryString, 'searchbox', $bUsePrefix);
-		$this->addQueryStringParam($queryString, 'sword', $bUsePrefix);
+            if (
+                $bUsePrefix &&
+                empty($addQueryString[$prefixId . '[backPID]'])
+            ) {
+                $queryString[$prefixId . '[backPID]'] = $backPid;
+            } else if (empty($addQueryString['backPID'])) {
+                $queryString['backPID'] = $backPid;
+            }
+        }
 
-		if ($bUsePrefix) {
-			$excludeListArray = [];
-			$tmpArray = GeneralUtility::trimExplode(',', $excludeList);
-			if (isset($tmpArray) && is_array($tmpArray) && $tmpArray['0']) {
-				foreach($tmpArray as $param) {
-					if (strpos($param, $prefixId) === false) {
-						$excludeListArray[] = $prefixId . '[' . $param . ']';
-					}
-				}
-				if (count($excludeListArray)) {
-					$excludeList .= ',' . implode(',', $excludeListArray);
-				}
-			}
-		}
+        if ($excludeList != '' && $bUsePrefix) {
+            $excludeArray = explode(',', $excludeList);
+            foreach ($excludeArray as $k => $v) {
+                $excludeArray[$k] = $prefixId . '[' . $v . ']';
+            }
+            $excludeList = implode(',', $excludeArray);
+        }
 
-		if (is_array($addQueryString)) {
-			foreach ($addQueryString as $param => $value) {
-				if ($bUsePrefix) {
-					$queryString[$prefixId . '[' . $param . ']'] = $value;
-				} else {
-					$queryString[$param] = $value;
-				}
-			}
-		}
+        $this->addQueryStringParam($queryString, 'C', $bUsePrefix);
+        if ($piVarSingle != '') {
+            $this->addQueryStringParam($queryString, $piVarSingle, $bUsePrefix);
+        }
+        if ($piVarCat != '') {
+            $this->addQueryStringParam($queryString, $piVarCat, $bUsePrefix);
+        }
 
-		foreach($queryString as $key => $val) {
-			if (
-				$val == '' ||
-				(
-					strlen($excludeList) &&
-					GeneralUtility::inList($excludeList, $key)
-				)
-			) {
-				unset($queryString[$key]);
-			}
-		}
+        $listPointerParam = tx_ttproducts_model_control::getPointerPiVar('LIST');
+        $this->addQueryStringParam($queryString, $listPointerParam, $bUsePrefix);
+        $catlistPointerParam = tx_ttproducts_model_control::getPointerPiVar('CATLIST');
 
-			// Call all getLinkParams hooks at the end of this method
-		if (
+        $this->addQueryStringParam($queryString, 'mode', false);
+        $this->addQueryStringParam($queryString, $listPointerParam, $bUsePrefix);
+        $this->addQueryStringParam($queryString, 'newitemdays', $bUsePrefix);
+        $this->addQueryStringParam($queryString, 'searchbox', $bUsePrefix);
+        $this->addQueryStringParam($queryString, 'sword', $bUsePrefix);
+
+        if ($bUsePrefix) {
+            $excludeListArray = [];
+            $tmpArray = GeneralUtility::trimExplode(',', $excludeList);
+            if (isset($tmpArray) && is_array($tmpArray) && $tmpArray['0']) {
+                foreach($tmpArray as $param) {
+                    if (strpos($param, $prefixId) === false) {
+                        $excludeListArray[] = $prefixId . '[' . $param . ']';
+                    }
+                }
+                if (count($excludeListArray)) {
+                    $excludeList .= ',' . implode(',', $excludeListArray);
+                }
+            }
+        }
+
+        if (is_array($addQueryString)) {
+            foreach ($addQueryString as $param => $value) {
+                if ($bUsePrefix) {
+                    $queryString[$prefixId . '[' . $param . ']'] = $value;
+                } else {
+                    $queryString[$param] = $value;
+                }
+            }
+        }
+
+        foreach($queryString as $key => $val) {
+            if (
+                $val == '' ||
+                (
+                    strlen($excludeList) &&
+                    GeneralUtility::inList($excludeList, $key)
+                )
+            ) {
+                unset($queryString[$key]);
+            }
+        }
+
+            // Call all getLinkParams hooks at the end of this method
+        if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getLinkParams']) &&
             is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getLinkParams'])
         ) {
-			foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getLinkParams'] as $classRef) {
-				$hookObj= GeneralUtility::makeInstance($classRef);
-				if (method_exists($hookObj, 'getLinkParams')) {
-					$hookObj->getLinkParams(
-						$this,
-						$queryString,
-						$excludeList,
-						$addQueryString,
-						$bUsePrefix,
-						$useBackPid,
-						$piVarSingle,
-						$piVarCat
-					);
-				}
-			}
-		}
+            foreach  ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][TT_PRODUCTS_EXT]['getLinkParams'] as $classRef) {
+                $hookObj= GeneralUtility::makeInstance($classRef);
+                if (method_exists($hookObj, 'getLinkParams')) {
+                    $hookObj->getLinkParams(
+                        $this,
+                        $queryString,
+                        $excludeList,
+                        $addQueryString,
+                        $bUsePrefix,
+                        $useBackPid,
+                        $piVarSingle,
+                        $piVarCat
+                    );
+                }
+            }
+        }
 
-		return $queryString;
-	}
+        return $queryString;
+    }
 }
 

--- a/view/class.tx_ttproducts_user_view.php
+++ b/view/class.tx_ttproducts_user_view.php
@@ -41,22 +41,22 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_user_view  {
 
-	public function printView (
-		$pibaseClass,
-		$templateCode,
-		$theCode
-	) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$content = '';
-		$num = $theCode{4};
+    public function printView (
+        $pibaseClass,
+        $templateCode,
+        $theCode
+    ) {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $content = '';
+        $num = $theCode{4};
 
-		$pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
-		$cObj = $pibaseObj->cObj;
+        $pibaseObj = GeneralUtility::makeInstance('' . $pibaseClass);
+        $cObj = $pibaseObj->cObj;
 
-		if (isset($conf['USEROBJ' . $num . '.']) && is_array($conf['USEROBJ' . $num . '.'])) {
-			$content = $cObj->cObjGetSingle($conf['USEROBJ' . $num], $conf['USEROBJ' . $num . '.']);
-		}
+        if (isset($conf['USEROBJ' . $num . '.']) && is_array($conf['USEROBJ' . $num . '.'])) {
+            $content = $cObj->cObjGetSingle($conf['USEROBJ' . $num], $conf['USEROBJ' . $num . '.']);
+        }
 
 // Test Fancybox Anfang
 
@@ -94,7 +94,7 @@ $content .= '<script type="text/javascript">
 
 // Test Fancybox Ende
 
-		return $content;
-	}
+        return $content;
+    }
 }
 

--- a/view/class.tx_ttproducts_variant_dummy_view.php
+++ b/view/class.tx_ttproducts_variant_dummy_view.php
@@ -40,34 +40,34 @@
 
 
 class tx_ttproducts_variant_dummy_view implements tx_ttproducts_variant_view_int, \TYPO3\CMS\Core\SingletonInterface {
-	public $modelObj;
+    public $modelObj;
 
-	public function init($modelObj) {
-		$this->modelObj = $modelObj;
-	}
+    public function init($modelObj) {
+        $this->modelObj = $modelObj;
+    }
 
-	public function getVariantSubpartMarkerArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$tempContent,
-		$bUseSelects,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	) {
-	}
+    public function getVariantSubpartMarkerArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $tempContent,
+        $bUseSelects,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    ) {
+    }
 
-	public function removeEmptyMarkerSubpartArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	) {
-	}
+    public function removeEmptyMarkerSubpartArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    ) {
+    }
 }
 

--- a/view/class.tx_ttproducts_variant_view.php
+++ b/view/class.tx_ttproducts_variant_view.php
@@ -39,96 +39,96 @@
 
 
 class tx_ttproducts_variant_view implements tx_ttproducts_variant_view_int, \TYPO3\CMS\Core\SingletonInterface {
-	public $modelObj;
+    public $modelObj;
 
 
-	public function init($modelObj) {
-		$this->modelObj = $modelObj;
-	}
+    public function init($modelObj) {
+        $this->modelObj = $modelObj;
+    }
 
-	public function getVariantSubpartMarkerArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$tempContent,
-		$bUseSelects,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	) {
-		$this->removeEmptyMarkerSubpartArray(
-			$markerArray,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$row,
-			$conf,
-			$bHasAdditional,
-			$bGiftService
-		);
-	}
+    public function getVariantSubpartMarkerArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $tempContent,
+        $bUseSelects,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    ) {
+        $this->removeEmptyMarkerSubpartArray(
+            $markerArray,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $row,
+            $conf,
+            $bHasAdditional,
+            $bGiftService
+        );
+    }
 
-	public function removeEmptyMarkerSubpartArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	) {
-		$areaArray = [];
-		$remMarkerArray = [];
-		$variantConf = $this->modelObj->conf;
+    public function removeEmptyMarkerSubpartArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    ) {
+        $areaArray = [];
+        $remMarkerArray = [];
+        $variantConf = $this->modelObj->conf;
 
         $maxKey = 0;
-		if (is_array($variantConf)) {
-			foreach ($variantConf as $key => $field) {
-				if ($field != 'additional') {	// no additional here
-					if (
-						!isset($row[$field]) ||
-						trim($row[$field]) == '' ||
-						!$conf['select' . ucfirst($field)]
-					) {
-						$remSubpartArray[] = 'display_variant' . $key;
-					} else {
-						$remMarkerArray[] = 'display_variant' . $key;
-					}
-				}
-				if ($key > $maxKey) {
+        if (is_array($variantConf)) {
+            foreach ($variantConf as $key => $field) {
+                if ($field != 'additional') {	// no additional here
+                    if (
+                        !isset($row[$field]) ||
+                        trim($row[$field]) == '' ||
+                        !$conf['select' . ucfirst($field)]
+                    ) {
+                        $remSubpartArray[] = 'display_variant' . $key;
+                    } else {
+                        $remMarkerArray[] = 'display_variant' . $key;
+                    }
+                }
+                if ($key > $maxKey) {
                     $maxKey = $key;
-				}
-			}
-		}
+                }
+            }
+        }
 
         for ($i = $maxKey + 1; $i <= 32; ++$i) { // remove more variants from the future
             $remSubpartArray[] = 'display_variant' . $i;
         }
 
-		if ($bHasAdditional) {
-			$remSubpartArray[] = 'display_variant5_isNotSingle';
-			$remMarkerArray[] = 'display_variant5_isSingle';
-		} else {
-			$remSubpartArray[] = 'display_variant5_isSingle';
-			$remMarkerArray[] = 'display_variant5_isNotSingle';
-		}
+        if ($bHasAdditional) {
+            $remSubpartArray[] = 'display_variant5_isNotSingle';
+            $remMarkerArray[] = 'display_variant5_isSingle';
+        } else {
+            $remSubpartArray[] = 'display_variant5_isSingle';
+            $remMarkerArray[] = 'display_variant5_isNotSingle';
+        }
 
-		if ($bGiftService) {
-			$remSubpartArray[] = 'display_variant5_NoGiftService';
-			$remMarkerArray[] = 'display_variant5_giftService';
-		} else {
-			$remSubpartArray[] = 'display_variant5_giftService';
-			$remMarkerArray[] = 'display_variant5_NoGiftService';
-		}
+        if ($bGiftService) {
+            $remSubpartArray[] = 'display_variant5_NoGiftService';
+            $remMarkerArray[] = 'display_variant5_giftService';
+        } else {
+            $remSubpartArray[] = 'display_variant5_giftService';
+            $remMarkerArray[] = 'display_variant5_NoGiftService';
+        }
 
-		foreach ($remSubpartArray as $k => $subpart) {
-			$subpartArray['###' . $subpart . '###'] = '';
-		}
+        foreach ($remSubpartArray as $k => $subpart) {
+            $subpartArray['###' . $subpart . '###'] = '';
+        }
 
-		foreach ($remMarkerArray as $k => $marker) {
-			$markerArray['<!-- ###' . $marker . '### -->'] = '';
-			$wrappedSubpartArray['###' . $marker . '###'] = '';
-		}
-	}
+        foreach ($remMarkerArray as $k => $marker) {
+            $markerArray['<!-- ###' . $marker . '### -->'] = '';
+            $wrappedSubpartArray['###' . $marker . '###'] = '';
+        }
+    }
 }
 

--- a/view/class.tx_ttproducts_voucher_view.php
+++ b/view/class.tx_ttproducts_voucher_view.php
@@ -43,73 +43,73 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 class tx_ttproducts_voucher_view extends tx_ttproducts_table_base_view {
-	public $amount;
-	public $code;
-	public $bValid;
-	public $marker = 'VOUCHER';
-	public $usedCodeArray = [];
+    public $amount;
+    public $code;
+    public $bValid;
+    public $marker = 'VOUCHER';
+    public $usedCodeArray = [];
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for the voucher
-	 *
-	 * @return	void
-	 * @access private
-	 */
-	public function getSubpartMarkerArray (
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$charset = ''
-	) {
-		$modelObj = $this->getModelObj();
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
-		$subpartArray['###SUB_VOUCHERCODE###'] = '';
-		$code = $modelObj->getVoucherCode();
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for the voucher
+     *
+     * @return	void
+     * @access private
+     */
+    public function getSubpartMarkerArray (
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $charset = ''
+    ) {
+        $modelObj = $this->getModelObj();
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $subpartArray['###SUB_VOUCHERCODE###'] = '';
+        $code = $modelObj->getVoucherCode();
         $wrappedSubpartArray['###SUB_VOUCHERCODE_START###'] = [];
 
-		if (
-			$modelObj->getValid() &&
-			$code != ''
-		) {
-			$subpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = '';
-			$wrappedSubpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = [];
-		} else {
-			if (!empty($code)) {
-				$tmp = $languageObj->getLabel('voucher_invalid');
-				$tmpArray = explode('|', $tmp);
-				$subpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = $tmpArray[0] . htmlspecialchars($modelObj->getVoucherCode()) . $tmpArray[1];
-				$wrappedSubpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = [];
-			} else {
-				$subpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = '';
-				$subpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = '';
-			}
-		}
-	}
+        if (
+            $modelObj->getValid() &&
+            $code != ''
+        ) {
+            $subpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = '';
+            $wrappedSubpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = [];
+        } else {
+            if (!empty($code)) {
+                $tmp = $languageObj->getLabel('voucher_invalid');
+                $tmpArray = explode('|', $tmp);
+                $subpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = $tmpArray[0] . htmlspecialchars($modelObj->getVoucherCode()) . $tmpArray[1];
+                $wrappedSubpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = [];
+            } else {
+                $subpartArray['###SUB_VOUCHERCODE_DISCOUNT###'] = '';
+                $subpartArray['###SUB_VOUCHERCODE_DISCOUNTWRONG###'] = '';
+            }
+        }
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for the voucher
-	 *
-	 * @return	void
-	 * @access private
-	 */
-	public function getMarkerArray (
-		&$markerArray
-	) {
-		$priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
-		$modelObj = $this->getModelObj();
-		$markerArray['###INSERT_VOUCHERCODE###'] = 'recs[tt_products][vouchercode]';
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for the voucher
+     *
+     * @return	void
+     * @access private
+     */
+    public function getMarkerArray (
+        &$markerArray
+    ) {
+        $priceViewObj = GeneralUtility::makeInstance('tx_ttproducts_field_price_view');
+        $modelObj = $this->getModelObj();
+        $markerArray['###INSERT_VOUCHERCODE###'] = 'recs[tt_products][vouchercode]';
 
-		$voucherCode = $modelObj->getVoucherCode();
-		if (!$voucherCode) {
-			$voucherCode = $modelObj->getLastVoucherCodeUsed();
-		}
+        $voucherCode = $modelObj->getVoucherCode();
+        if (!$voucherCode) {
+            $voucherCode = $modelObj->getLastVoucherCodeUsed();
+        }
 
-		$amount = $modelObj->getRebateAmount();
-		$markerArray['###VALUE_VOUCHERCODE###'] = htmlspecialchars($voucherCode);
-		$markerArray['###VOUCHER_DISCOUNT###'] = $priceViewObj->priceFormat(abs($amount));
-	} // getMarkerArray
+        $amount = $modelObj->getRebateAmount();
+        $markerArray['###VALUE_VOUCHERCODE###'] = htmlspecialchars($voucherCode);
+        $markerArray['###VOUCHER_DISCOUNT###'] = $priceViewObj->priceFormat(abs($amount));
+    } // getMarkerArray
 }
 

--- a/view/field/class.tx_ttproducts_field_base_view.php
+++ b/view/field/class.tx_ttproducts_field_base_view.php
@@ -40,150 +40,150 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
 abstract class tx_ttproducts_field_base_view implements tx_ttproducts_field_view_int, \TYPO3\CMS\Core\SingletonInterface {
-	private $bHasBeenInitialised = false;
-	public $modelObj;
-	public $cObj;
-	public $conf;		// original configuration
-	public $config;		// modified configuration
+    private $bHasBeenInitialised = false;
+    public $modelObj;
+    public $cObj;
+    public $conf;		// original configuration
+    public $config;		// modified configuration
 
 
-	public function init ($modelObj) {
-		$this->modelObj = $modelObj;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$this->conf = $cnf->getConf();
-		$this->config = $cnf->getConfig();
+    public function init ($modelObj) {
+        $this->modelObj = $modelObj;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $this->conf = $cnf->getConf();
+        $this->config = $cnf->getConfig();
 
-		$this->bHasBeenInitialised = true;
-	}
+        $this->bHasBeenInitialised = true;
+    }
 
-	public function needsInit () {
-		return !$this->bHasBeenInitialised;
-	}
+    public function needsInit () {
+        return !$this->bHasBeenInitialised;
+    }
 
-	public function getModelObj () {
-		return $this->modelObj;
-	}
+    public function getModelObj () {
+        return $this->modelObj;
+    }
 
-	public function getRepeatedRowSubpartArrays (
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$markerKey,
-		$row,
-		$fieldname,
-		$key,
-		$value,
-		$tableConf,
-		$tagArray
-	) {
-		// overwrite this!
-		return false;
-	}
+    public function getRepeatedRowSubpartArrays (
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $markerKey,
+        $row,
+        $fieldname,
+        $key,
+        $value,
+        $tableConf,
+        $tagArray
+    ) {
+        // overwrite this!
+        return false;
+    }
 
-	public function getRepeatedRowMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$functablename,
-		$row,
-		$fieldname,
-		$key,
-		$value,
-		$tableConf,
-		$tagArray,
-		$theCode = '',
-		$id='1'
-	) {
-		// overwrite this!
-		return false;
-	}
+    public function getRepeatedRowMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $functablename,
+        $row,
+        $fieldname,
+        $key,
+        $value,
+        $tableConf,
+        $tagArray,
+        $theCode = '',
+        $id='1'
+    ) {
+        // overwrite this!
+        return false;
+    }
 
-	public function getRepeatedSubpartArrays (
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$templateCode,
-		$markerKey,
-		$functablename,
-		$row,
-		$fieldname,
-		$tableConf,
-		$tagArray,
-		$theCode = '',
-		$id = '1'
-	) {
+    public function getRepeatedSubpartArrays (
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $templateCode,
+        $markerKey,
+        $functablename,
+        $row,
+        $fieldname,
+        $tableConf,
+        $tagArray,
+        $theCode = '',
+        $id = '1'
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
-		$result = false;
-		$newContent = '';
-		$markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
-		$upperField = strtoupper($fieldname);
-		$templateAreaList = $markerKey . '_' . $upperField . '_LIST';
-		$t = [];
-		$t['listFrameWork'] = $templateService->getSubpart($templateCode, '###' . $templateAreaList . '###');
-		$templateAreaSingle = $markerKey . '_' . $upperField . '_SINGLE';
-		$t['singleFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###' . $templateAreaSingle . '###');
+        $result = false;
+        $newContent = '';
+        $markerObj = GeneralUtility::makeInstance('tx_ttproducts_marker');
+        $upperField = strtoupper($fieldname);
+        $templateAreaList = $markerKey . '_' . $upperField . '_LIST';
+        $t = [];
+        $t['listFrameWork'] = $templateService->getSubpart($templateCode, '###' . $templateAreaList . '###');
+        $templateAreaSingle = $markerKey . '_' . $upperField . '_SINGLE';
+        $t['singleFrameWork'] = $templateService->getSubpart($t['listFrameWork'], '###' . $templateAreaSingle . '###');
 
-		if ($t['singleFrameWork'] != '') {
-			$repeatedTagArray = $markerObj->getAllMarkers($t['singleFrameWork']);
+        if ($t['singleFrameWork'] != '') {
+            $repeatedTagArray = $markerObj->getAllMarkers($t['singleFrameWork']);
 
-			$value = $row[$fieldname];
-			$valueArray = GeneralUtility::trimExplode(',', $value);
+            $value = $row[$fieldname];
+            $valueArray = GeneralUtility::trimExplode(',', $value);
 
-			if (isset($valueArray) && is_array($valueArray) && $valueArray['0'] != '') {
+            if (isset($valueArray) && is_array($valueArray) && $valueArray['0'] != '') {
 
-				$content = '';
-				foreach($valueArray as $key => $value) {
-					$repeatedMarkerArray = [];
-					$repeatedSubpartArray = [];
-					$repeatedWrappedSubpartArray = [];
+                $content = '';
+                foreach($valueArray as $key => $value) {
+                    $repeatedMarkerArray = [];
+                    $repeatedSubpartArray = [];
+                    $repeatedWrappedSubpartArray = [];
 
-					$resultRowMarker = $this->getRepeatedRowMarkerArray(
-						$repeatedMarkerArray,
-						$markerKey,
-						$functablename,
-						$row,
-						$fieldname,
-						$key,
-						$value,
-						$tableConf,
-						$tagArray,
-						$theCode,
-						$id
-					);
+                    $resultRowMarker = $this->getRepeatedRowMarkerArray(
+                        $repeatedMarkerArray,
+                        $markerKey,
+                        $functablename,
+                        $row,
+                        $fieldname,
+                        $key,
+                        $value,
+                        $tableConf,
+                        $tagArray,
+                        $theCode,
+                        $id
+                    );
 
-					$this->getRepeatedRowSubpartArrays(
-						$repeatedSubpartArray,
-						$repeatedWrappedSubpartArray,
-						$markerKey,
-						$row,
-						$fieldname,
-						$key,
-						$value,
-						$tableConf,
-						$tagArray
-					);
+                    $this->getRepeatedRowSubpartArrays(
+                        $repeatedSubpartArray,
+                        $repeatedWrappedSubpartArray,
+                        $markerKey,
+                        $row,
+                        $fieldname,
+                        $key,
+                        $value,
+                        $tableConf,
+                        $tagArray
+                    );
 
-					$newContent = $templateService->substituteMarkerArrayCached(
-						$t['singleFrameWork'],
-						$repeatedMarkerArray,
-						$repeatedSubpartArray,
-						$repeatedWrappedSubpartArray
-					);
+                    $newContent = $templateService->substituteMarkerArrayCached(
+                        $t['singleFrameWork'],
+                        $repeatedMarkerArray,
+                        $repeatedSubpartArray,
+                        $repeatedWrappedSubpartArray
+                    );
 
-					$result = $resultRowMarker;
-					if ($result) {
-						$content .= $newContent;
-					}
-				}
+                    $result = $resultRowMarker;
+                    if ($result) {
+                        $content .= $newContent;
+                    }
+                }
 
-				$newContent = $templateService->substituteMarkerArrayCached(
-					$t['listFrameWork'],
-					[],
-					['###' . $templateAreaSingle . '###' => $content],
-					[]
-				);
-			}
-		}
-		$subpartArray['###' . $templateAreaList . '###'] = $newContent;
+                $newContent = $templateService->substituteMarkerArrayCached(
+                    $t['listFrameWork'],
+                    [],
+                    ['###' . $templateAreaSingle . '###' => $content],
+                    []
+                );
+            }
+        }
+        $subpartArray['###' . $templateAreaList . '###'] = $newContent;
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_creditpoints_view.php
+++ b/view/field/class.tx_ttproducts_field_creditpoints_view.php
@@ -39,68 +39,68 @@
 
 
 class tx_ttproducts_field_creditpoints_view extends tx_ttproducts_field_base_view {
-	protected $addedFieldArray = ['creditpoints_missing', 'creditpoints_remaining'];
+    protected $addedFieldArray = ['creditpoints_missing', 'creditpoints_remaining'];
 
-	public function modifyItemSubpartRow ($fieldname, $row, &$addedFieldArray) {
-		$modelObj = $this->getModelObj();
-		$rc = $row;
-		$creditpointsMissing = 0;
-		$creditpointsRemaining = 0;
-		$modelObj->getMissingCreditpoints($fieldname, $row, $creditpointsMissing, $creditpointsRemaining);
-		$rc['creditpoints_missing'] = $creditpointsMissing;
-		$rc['creditpoints_remaining'] = $creditpointsRemaining;
-		$addedFieldArray = array_merge($addedFieldArray, $this->addedFieldArray);
-		return $rc;
-	}
+    public function modifyItemSubpartRow ($fieldname, $row, &$addedFieldArray) {
+        $modelObj = $this->getModelObj();
+        $rc = $row;
+        $creditpointsMissing = 0;
+        $creditpointsRemaining = 0;
+        $modelObj->getMissingCreditpoints($fieldname, $row, $creditpointsMissing, $creditpointsRemaining);
+        $rc['creditpoints_missing'] = $creditpointsMissing;
+        $rc['creditpoints_remaining'] = $creditpointsRemaining;
+        $addedFieldArray = array_merge($addedFieldArray, $this->addedFieldArray);
+        return $rc;
+    }
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		$modifiedRow = [];
-		$value =
-			$this->getModelObj()->getFieldValue(
-				$dummy,
-				$row,
-				$fieldname,
-				$basketExtra,
-				$basketRecs,
-				$dummy
-			);
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+        $modifiedRow = [];
+        $value =
+            $this->getModelObj()->getFieldValue(
+                $dummy,
+                $row,
+                $fieldname,
+                $basketExtra,
+                $basketRecs,
+                $dummy
+            );
 
-		$value = number_format($value,'0');
-		$modifiedRow[$fieldname] = $value;
-		foreach ($this->addedFieldArray as $addedField) {
-			$value =
-				$this->getModelObj()->getFieldValue(
-					$dummy,
-					$row,
-					$addedField,
-					$basketExtra,
-					$basketRecs,
-					$dummy
-				);
-			$modifiedRow[$addedField] = number_format($value,'0');
-		}
-		return $modifiedRow;
-	}
+        $value = number_format($value,'0');
+        $modifiedRow[$fieldname] = $value;
+        foreach ($this->addedFieldArray as $addedField) {
+            $value =
+                $this->getModelObj()->getFieldValue(
+                    $dummy,
+                    $row,
+                    $addedField,
+                    $basketExtra,
+                    $basketRecs,
+                    $dummy
+                );
+            $modifiedRow[$addedField] = number_format($value,'0');
+        }
+        return $modifiedRow;
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_datafield_view.php
+++ b/view/field/class.tx_ttproducts_field_datafield_view.php
@@ -60,75 +60,75 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
         return $result;
     }
 
-	public function getLinkArray (
-		&$wrappedSubpartArray,
-		$tagArray,
-		$marker,
-		$dirname,
-		$dataFile,
-		$fieldname,
-		$tableConf
-	) {
+    public function getLinkArray (
+        &$wrappedSubpartArray,
+        $tagArray,
+        $marker,
+        $dirname,
+        $dataFile,
+        $fieldname,
+        $tableConf
+    ) {
         $cObj = FrontendUtility::getContentObjectRenderer();
-		if (isset($tagArray[$marker])) {
-			if (
-				isset($tableConf['fieldLink.']) &&
-				is_array($tableConf['fieldLink.']) &&
-				isset($tableConf['fieldLink.'][$fieldname.'.'])
-			) {
-				$typolinkConf = $tableConf['fieldLink.'][$fieldname.'.'];
-			} else {
-				$typolinkConf = [];
-			}
-			$typolinkConf['parameter'] = ($dirname != '' ? $dirname . '/' : '') . $dataFile;
-			$linkTxt = microtime();
-			$typoLink = $cObj->typoLink($linkTxt, $typolinkConf);
-			$wrappedSubpartArray['###' . $marker . '###'] = GeneralUtility::trimExplode($linkTxt, $typoLink);
-		}
-	}
+        if (isset($tagArray[$marker])) {
+            if (
+                isset($tableConf['fieldLink.']) &&
+                is_array($tableConf['fieldLink.']) &&
+                isset($tableConf['fieldLink.'][$fieldname.'.'])
+            ) {
+                $typolinkConf = $tableConf['fieldLink.'][$fieldname.'.'];
+            } else {
+                $typolinkConf = [];
+            }
+            $typolinkConf['parameter'] = ($dirname != '' ? $dirname . '/' : '') . $dataFile;
+            $linkTxt = microtime();
+            $typoLink = $cObj->typoLink($linkTxt, $typolinkConf);
+            $wrappedSubpartArray['###' . $marker . '###'] = GeneralUtility::trimExplode($linkTxt, $typoLink);
+        }
+    }
 
 
-	public function getRepeatedRowSubpartArrays (
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$markerKey,
-		$row,
-		$fieldname,
-		$key,
-		$value,
-		$tableConf,
-		$tagArray
-	) {
-		$dirname = $this->modelObj->getDirname($row, $fieldname);
-		$upperField = strtoupper($fieldname);
-		$marker = $markerKey . '_LINK_' . $upperField;
+    public function getRepeatedRowSubpartArrays (
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $markerKey,
+        $row,
+        $fieldname,
+        $key,
+        $value,
+        $tableConf,
+        $tagArray
+    ) {
+        $dirname = $this->modelObj->getDirname($row, $fieldname);
+        $upperField = strtoupper($fieldname);
+        $marker = $markerKey . '_LINK_' . $upperField;
 
-		$this->getLinkArray(
-			$wrappedSubpartArray,
-			$tagArray,
-			$marker,
-			$dirname,
-			$value,
-			$fieldname,
-			$tableConf
-		);
-	}
+        $this->getLinkArray(
+            $wrappedSubpartArray,
+            $tagArray,
+            $marker,
+            $dirname,
+            $value,
+            $fieldname,
+            $tableConf
+        );
+    }
 
-	public function getItemSubpartArrays (
-		&$templateCode,
-		$markerKey,
-		$functablename,
-		&$row,
-		$fieldname,
-		$tableConf,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		&$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '1'
-	) {
+    public function getItemSubpartArrays (
+        &$templateCode,
+        $markerKey,
+        $functablename,
+        &$row,
+        $fieldname,
+        $tableConf,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        &$tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '1'
+    ) {
         $upperField = '';
         $funcFieldname = $this->getFuncFieldname($row, $fieldname);
         if ($funcFieldname != '') {
@@ -163,7 +163,7 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
                         $wrappedSubpartArray,
                         $tagArray,
                         $marker,
-						$dirname,
+                        $dirname,
                         $dataFile,
                         $funcFieldname,
                         $tableConf
@@ -176,7 +176,7 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
                     $wrappedSubpartArray,
                     $tagArray,
                     $marker,
-					$dirname,
+                    $dirname,
                     $dataFileArray[0],
                     $fieldname,
                     $tableConf
@@ -196,62 +196,62 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
                 }
             }
         }
-	}
+    }
 
 
-	public function getRepeatedRowMarkerArray (
-		&$markerArray,
-		$markerKey,
-		$functablename,
-		$row,
-		$fieldname,
-		$key,
-		$value,
-		$tableConf,
-		$tagArray,
-		$theCode='',
-		$id='1'
-	) {
-		$dirname = $this->modelObj->getDirname($row, $fieldname);
-		$upperField = strtoupper($fieldname);
-		$marker = $markerKey . '_' . $upperField;
+    public function getRepeatedRowMarkerArray (
+        &$markerArray,
+        $markerKey,
+        $functablename,
+        $row,
+        $fieldname,
+        $key,
+        $value,
+        $tableConf,
+        $tagArray,
+        $theCode='',
+        $id='1'
+    ) {
+        $dirname = $this->modelObj->getDirname($row, $fieldname);
+        $upperField = strtoupper($fieldname);
+        $marker = $markerKey . '_' . $upperField;
 
-		$imageRenderObj = 'datasheetIcon';
-		$imageConf = $this->conf[$imageRenderObj . '.'];
+        $imageRenderObj = 'datasheetIcon';
+        $imageConf = $this->conf[$imageRenderObj . '.'];
 
-		$this->getSingleValueArray(
-			$markerArray,
-			$marker,
-			$tagArray,
-			$theCode,
-			$imageConf,
-			$dirname,
-			$value
-		);
-		$marker1 = 'ICON_' . strtoupper($fieldname);
-		$this->getIconMarker(
-			$markerArray,
-			$marker1,
-			$tagArray,
-			$theCode,
-			'datasheetIcon',
-			$value
-		);
+        $this->getSingleValueArray(
+            $markerArray,
+            $marker,
+            $tagArray,
+            $theCode,
+            $imageConf,
+            $dirname,
+            $value
+        );
+        $marker1 = 'ICON_' . strtoupper($fieldname);
+        $this->getIconMarker(
+            $markerArray,
+            $marker1,
+            $tagArray,
+            $theCode,
+            'datasheetIcon',
+            $value
+        );
 
-		return true;
-	}
+        return true;
+    }
 
 
-	public function getSingleValueArray (
-		&$markerArray,
-		$marker,
-		$tagArray,
+    public function getSingleValueArray (
+        &$markerArray,
+        $marker,
+        $tagArray,
         $theCode,
-		$imageConf,
-		$dirname,
-		$dataFile
-	) {
-		$imageConf['file'] = $dirname . '/' . $dataFile;
+        $imageConf,
+        $dirname,
+        $dataFile
+    ) {
+        $imageConf['file'] = $dirname . '/' . $dataFile;
 // 		$iconImgCode = $this->cObj->IMAGE($imageConf);
         $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
         $iconImgCode =
@@ -261,125 +261,125 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
             );
 
 
-		if (isset($tagArray[$marker])) {
-			$markerArray['###' . $marker . '###'] = $iconImgCode; // new marker now
-		}
+        if (isset($tagArray[$marker])) {
+            $markerArray['###' . $marker . '###'] = $iconImgCode; // new marker now
+        }
 
-		if (isset($tagArray[$marker . '_FILE'])) {
-			$markerArray['###' . $marker . '_FILE###'] = basename($imageConf['file']);
-		}
-	}
+        if (isset($tagArray[$marker . '_FILE'])) {
+            $markerArray['###' . $marker . '_FILE###'] = basename($imageConf['file']);
+        }
+    }
 
 
-	public function getIconMarker (
-		&$markerArray,
-		$marker,
-		$tagArray,
+    public function getIconMarker (
+        &$markerArray,
+        $marker,
+        $tagArray,
         $theCode,
-		$imageRenderObj,
-		$filename
-	) {	
-		$extensionPos = strrpos($filename, '.');
-		$extension = '';
-		if ($extensionPos !== false) {
-			$extension = substr($filename, $extensionPos + 1);
-		}
+        $imageRenderObj,
+        $filename
+    ) {	
+        $extensionPos = strrpos($filename, '.');
+        $extension = '';
+        if ($extensionPos !== false) {
+            $extension = substr($filename, $extensionPos + 1);
+        }
 
-		if (!empty($imageRenderObj)) {
+        if (!empty($imageRenderObj)) {
 
             $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-			$imageConf = $this->conf[$imageRenderObj . '.'];
+            $imageConf = $this->conf[$imageRenderObj . '.'];
 
-			if (isset($tagArray[$marker]) && isset($this->conf['datasheetIcon.'])) {
+            if (isset($tagArray[$marker]) && isset($this->conf['datasheetIcon.'])) {
 
-				$imageFilename = '';
+                $imageFilename = '';
 
-				if ($this->conf['datasheetIcon.']['file'] != '{$plugin.tt_products.file.datasheetIcon}') {
-					$imageFilename = $this->conf['datasheetIcon.']['file'];
-				}
+                if ($this->conf['datasheetIcon.']['file'] != '{$plugin.tt_products.file.datasheetIcon}') {
+                    $imageFilename = $this->conf['datasheetIcon.']['file'];
+                }
 
-				foreach ($this->conf['datasheetIcon.'] as $confKey => $confArray) {
-					if (
-						strpos($confKey, '.') == strlen($confKey) - 1 &&
-						isset($confArray) && is_array($confArray) &&
-						$confArray['fileext'] == $extension
-					) {
-						$imageFilename = $confArray['file'];
-						break;
-					}
-				}
+                foreach ($this->conf['datasheetIcon.'] as $confKey => $confArray) {
+                    if (
+                        strpos($confKey, '.') == strlen($confKey) - 1 &&
+                        isset($confArray) && is_array($confArray) &&
+                        $confArray['fileext'] == $extension
+                    ) {
+                        $imageFilename = $confArray['file'];
+                        break;
+                    }
+                }
 
-				if ($imageFilename != '') {
-					$imageConf['file'] = $imageFilename;
+                if ($imageFilename != '') {
+                    $imageConf['file'] = $imageFilename;
                     $iconImgCode =
                         $imageObj->getImageCode(
                             $imageConf,
                             $theCode
                         );
 
-					$markerArray['###' . $marker . '###'] = $iconImgCode;
-				} else {
-					$markerArray['###' . $marker . '###'] = '';
-				}
-			} else {
-				$markerArray['###' . $marker . '###'] = '';
-			}
-		} else if (isset($tagArray[$marker])) {
-			$markerArray['###' . $marker . '###'] = '';
-		}
-	}
+                    $markerArray['###' . $marker . '###'] = $iconImgCode;
+                } else {
+                    $markerArray['###' . $marker . '###'] = '';
+                }
+            } else {
+                $markerArray['###' . $marker . '###'] = '';
+            }
+        } else if (isset($tagArray[$marker])) {
+            $markerArray['###' . $marker . '###'] = '';
+        }
+    }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	string		name of the marker prefix
-	 * @param	array		reference to an item array with all the data of the item
-	 * 				for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	string		name of the marker prefix
+     * @param	array		reference to an item array with all the data of the item
+     * 				for the tt_producst record, $row
+     * @access private
+     */
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
         $funcFieldname = $this->getFuncFieldname($row, $fieldname);
-		$val = $row[$fieldname];
-		$dataFileArray = [];
+        $val = $row[$fieldname];
+        $dataFileArray = [];
         $fileArray = [];
-		$marker1 = 'ICON_' . strtoupper($funcFieldname);
-		$marker2 = $markerKey . '1';
+        $marker1 = 'ICON_' . strtoupper($funcFieldname);
+        $marker2 = $markerKey . '1';
 
-		if (
+        if (
             !empty($imageRenderObj) && 
             $val && 
             (isset($tagArray[$marker1]) || isset($tagArray[$marker2]))
         ) {
             $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-			$imageConf = $this->conf[$imageRenderObj . '.'];
+            $imageConf = $this->conf[$imageRenderObj . '.'];
 
-			if (isset($tagArray[$marker1]) && isset($this->conf['datasheetIcon.'])) {
-				if ($this->conf['datasheetIcon.']['file'] != '{$plugin.tt_products.file.datasheetIcon}') {
-					$imageConf['file'] = $this->conf['datasheetIcon.']['file'];
-					if (isset($imageConf['imageLinkWrap'])) {
+            if (isset($tagArray[$marker1]) && isset($this->conf['datasheetIcon.'])) {
+                if ($this->conf['datasheetIcon.']['file'] != '{$plugin.tt_products.file.datasheetIcon}') {
+                    $imageConf['file'] = $this->conf['datasheetIcon.']['file'];
+                    if (isset($imageConf['imageLinkWrap'])) {
                         unset($imageConf['imageLinkWrap']);
                         if (isset($imageConf['imageLinkWrap.'])) {
                             unset($imageConf['imageLinkWrap.']);
@@ -390,15 +390,15 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
                             $imageConf,
                             $theCode
                         );
-					$markerArray['###' . $marker1 . '###'] = $iconImgCode;
-				} else {
-					$markerArray['###' . $marker1 . '###'] = '';
-				}
-			} else {
-				$markerArray['###' . $marker1 . '###'] = '';
-			}
+                    $markerArray['###' . $marker1 . '###'] = $iconImgCode;
+                } else {
+                    $markerArray['###' . $marker1 . '###'] = '';
+                }
+            } else {
+                $markerArray['###' . $marker1 . '###'] = '';
+            }
 
-			if (
+            if (
                 isset($tagArray[$markerKey]) ||
                 isset($tagArray[$marker2])
             ) {
@@ -418,8 +418,8 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
                 $markerArray['###' . $markerKey . '###'] = implode(',', $fileArray);
             }
 
-			if (isset($tagArray[$marker2])) {
-				$imageConf['file'] = $dataFileArray['0'];
+            if (isset($tagArray[$marker2])) {
+                $imageConf['file'] = $dataFileArray['0'];
                 $iconImgCode =
                     $imageObj->getImageCode(
                         $imageConf,
@@ -428,14 +428,14 @@ class tx_ttproducts_field_datafield_view extends tx_ttproducts_field_base_view {
 
                 $markerArray['###' . $marker2 . '###'] = $iconImgCode;
             }
-		} else {
-			if (isset($tagArray[$marker1])) {
-				$markerArray['###' . $marker1 . '###'] = '';
-			}
-			if (isset($tagArray[$marker2])) {
-				$markerArray['###' . $marker2 . '###'] = '';
-			}
-		}
-	}
+        } else {
+            if (isset($tagArray[$marker1])) {
+                $markerArray['###' . $marker1 . '###'] = '';
+            }
+            if (isset($tagArray[$marker2])) {
+                $markerArray['###' . $marker2 . '###'] = '';
+            }
+        }
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_datetime_view.php
+++ b/view/field/class.tx_ttproducts_field_datetime_view.php
@@ -43,36 +43,36 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_field_datetime_view extends tx_ttproducts_field_base_view {
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
         $cObj = FrontendUtility::getContentObjectRenderer();
-		$stdWrap = 'date_stdWrap.';
-		if ($fieldname == 'usebydate' && $functablename == 'tt_products') {
-			$stdWrap = 'usebyDate_stdWrap.';
-		}
-		$value = $cObj->stdWrap($row[$fieldname], $this->conf[$stdWrap]);
+        $stdWrap = 'date_stdWrap.';
+        if ($fieldname == 'usebydate' && $functablename == 'tt_products') {
+            $stdWrap = 'usebyDate_stdWrap.';
+        }
+        $value = $cObj->stdWrap($row[$fieldname], $this->conf[$stdWrap]);
 
-		return $value;
-	}
+        return $value;
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_delivery_view.php
+++ b/view/field/class.tx_ttproducts_field_delivery_view.php
@@ -48,92 +48,92 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 class tx_ttproducts_field_delivery_view extends tx_ttproducts_field_base_view {
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @param	string		name of the marker prefix
-	 * @param	array		reference to an item array with all the data of the item
-	 * 				for the tt_producst record, $row
-	 * @access private
-	 */
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		$value = '';
-		$result = '';
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @param	string		name of the marker prefix
+     * @param	array		reference to an item array with all the data of the item
+     * 				for the tt_producst record, $row
+     * @access private
+     */
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+        $value = '';
+        $result = '';
 
-		if (isset($row[$fieldname])) {
+        if (isset($row[$fieldname])) {
 
-			$imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableconf = $cnf->getTableConf($functablename, $theCode);
-			$domain = $conf['domain'] ?? '';
-			$cObj = FrontendUtility::getContentObjectRenderer();
+            $imageObj = GeneralUtility::makeInstance('tx_ttproducts_field_image_view');
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableconf = $cnf->getTableConf($functablename, $theCode);
+            $domain = $conf['domain'] ?? '';
+            $cObj = FrontendUtility::getContentObjectRenderer();
 
-			if ($domain == '' || strrpos($domain, '###') !== false) {
-				$domain = $_SERVER['HTTP_HOST'];
-			}
+            if ($domain == '' || strrpos($domain, '###') !== false) {
+                $domain = $_SERVER['HTTP_HOST'];
+            }
 
-			if (
-				isset($tableconf) &&
-				is_array($tableconf) &&
-				isset($tableconf[$fieldname . '.'])
-			) {
-				$value = intval($row[$fieldname]);
-				$deliveryConf = $tableconf[$fieldname . '.'];
+            if (
+                isset($tableconf) &&
+                is_array($tableconf) &&
+                isset($tableconf[$fieldname . '.'])
+            ) {
+                $value = intval($row[$fieldname]);
+                $deliveryConf = $tableconf[$fieldname . '.'];
 
-				if (
-					isset($deliveryConf) &&
-					is_array($deliveryConf) &&
-					isset($deliveryConf[$value . '.'])
-				) {
-					$result = '';
-					$valueConf = $deliveryConf[$value . '.'];
+                if (
+                    isset($deliveryConf) &&
+                    is_array($deliveryConf) &&
+                    isset($deliveryConf[$value . '.'])
+                ) {
+                    $result = '';
+                    $valueConf = $deliveryConf[$value . '.'];
 
-					if (isset($valueConf['text.'])) {
-						$tmpImgCode = $cObj->cObjGetSingle(
-							$valueConf['text'],
-							$valueConf['text.'],
-							TT_PRODUCTS_EXT
-						);
-						$result .= $tmpImgCode;
-					}
+                    if (isset($valueConf['text.'])) {
+                        $tmpImgCode = $cObj->cObjGetSingle(
+                            $valueConf['text'],
+                            $valueConf['text.'],
+                            TT_PRODUCTS_EXT
+                        );
+                        $result .= $tmpImgCode;
+                    }
 
-					if (isset($valueConf['image.'])) {
-						$tmpImgCode =
-							$imageObj->getImageCode(
-								$valueConf['image.'],
-								$theCode,
-								$domain
-							);
-						$result .= $tmpImgCode;
-					}
+                    if (isset($valueConf['image.'])) {
+                        $tmpImgCode =
+                            $imageObj->getImageCode(
+                                $valueConf['image.'],
+                                $theCode,
+                                $domain
+                            );
+                        $result .= $tmpImgCode;
+                    }
 
-				}
-			}
-		}
+                }
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_foreign_table_view.php
+++ b/view/field/class.tx_ttproducts_field_foreign_table_view.php
@@ -43,98 +43,98 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_field_foreign_table_view extends tx_ttproducts_field_base_view {
 
-	public function getItemSubpartArrays (
-		&$templateCode,
-		$markerKey,
-		$functablename,
-		&$row,
-		$fieldname,
-		$tableConf,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		&$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '1'
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTableObj = $tablesObj->get($functablename, false);
-		$tablename = $itemTableObj->getTablename();
-	}
+    public function getItemSubpartArrays (
+        &$templateCode,
+        $markerKey,
+        $functablename,
+        &$row,
+        $fieldname,
+        $tableConf,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        &$tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '1'
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTableObj = $tablesObj->get($functablename, false);
+        $tablename = $itemTableObj->getTablename();
+    }
 
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$bEnableTaxZero = false
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTableObj = $tablesObj->get($functablename, false);
-		$tablename = $itemTableObj->getTablename();
-		$foreigntablename = '';
-		$rowMarkerArray = [];
-		if ($GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['type'] == 'group') {
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $bEnableTaxZero = false
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTableObj = $tablesObj->get($functablename, false);
+        $tablename = $itemTableObj->getTablename();
+        $foreigntablename = '';
+        $rowMarkerArray = [];
+        if ($GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['type'] == 'group') {
 
-			$foreigntablename = $GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['allowed'];
-			$foreignTableViewObj = $tablesObj->get($foreigntablename, true);
-			if (!$row[$fieldname]) {
-				$foreignMarker = $foreignTableViewObj->getMarker();
+            $foreigntablename = $GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['allowed'];
+            $foreignTableViewObj = $tablesObj->get($foreigntablename, true);
+            if (!$row[$fieldname]) {
+                $foreignMarker = $foreignTableViewObj->getMarker();
 
-				foreach ($tagArray as $theTag => $v) {
-					if (strpos($theTag,$foreignMarker) === 0) {
-						$rowMarkerArray['###'.$theTag.'###'] = '';
-					}
-				}
-			}
-		}
+                foreach ($tagArray as $theTag => $v) {
+                    if (strpos($theTag,$foreignMarker) === 0) {
+                        $rowMarkerArray['###'.$theTag.'###'] = '';
+                    }
+                }
+            }
+        }
 
-		if ($foreigntablename != '' && $row[$fieldname] > 0) {
+        if ($foreigntablename != '' && $row[$fieldname] > 0) {
 
-			$foreignTableObj = $foreignTableViewObj->getModelObj();
-			if ($GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['internal_type'] == 'db') {
-				$foreignRow = $foreignTableObj->get($row[$fieldname]);
-				$foreignTableViewObj->getRowMarkerArray(
-					$foreigntablename,
-					$foreignRow,
-					'',
-					$rowMarkerArray,
-					$tmp=[],
-					$tmp=[],
-					$tagArray,
-					$theCode,
-					$basketExtra,
-					$basketRecs,
-					$bHtml,
-					$charset,
-					$imageNum,
-					$imageRenderObj,
-					$id,
-					$prefix,
-					$suffix,
-					'',
-					$bEnableTaxZero
-				);
-			}
-		//
-		}
-		$markerArray = array_merge($markerArray, $rowMarkerArray);
-	}
+            $foreignTableObj = $foreignTableViewObj->getModelObj();
+            if ($GLOBALS['TCA'][$tablename]['columns'][$fieldname]['config']['internal_type'] == 'db') {
+                $foreignRow = $foreignTableObj->get($row[$fieldname]);
+                $foreignTableViewObj->getRowMarkerArray(
+                    $foreigntablename,
+                    $foreignRow,
+                    '',
+                    $rowMarkerArray,
+                    $tmp=[],
+                    $tmp=[],
+                    $tagArray,
+                    $theCode,
+                    $basketExtra,
+                    $basketRecs,
+                    $bHtml,
+                    $charset,
+                    $imageNum,
+                    $imageRenderObj,
+                    $id,
+                    $prefix,
+                    $suffix,
+                    '',
+                    $bEnableTaxZero
+                );
+            }
+        //
+        }
+        $markerArray = array_merge($markerArray, $rowMarkerArray);
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_graduated_price_view.php
+++ b/view/field/class.tx_ttproducts_field_graduated_price_view.php
@@ -42,82 +42,82 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_field_graduated_price_view extends tx_ttproducts_field_base_view {
 
-	public function getItemSubpartArrays (
-		$templateCode,
-		$markerKey,
-		$functablename,
-		$row,
-		$fieldname,
-		$tableConf,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '1'
-	) {
-		$bTaxIncluded = $this->conf['TAXincluded'];
-		$bEnableTaxZero = 0;
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewItemTableObj = $tablesObj->get($functablename, true);
+    public function getItemSubpartArrays (
+        $templateCode,
+        $markerKey,
+        $functablename,
+        $row,
+        $fieldname,
+        $tableConf,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '1'
+    ) {
+        $bTaxIncluded = $this->conf['TAXincluded'];
+        $bEnableTaxZero = 0;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewItemTableObj = $tablesObj->get($functablename, true);
         $priceFormulaArray = $viewItemTableObj->getModelObj()->getGraduatedPriceObject()->getFormulasByItem($row['uid']);
 
-		$priceTablesViewObj = $viewItemTableObj->getGraduatedPriceObject();
-		$priceTablesViewObj->getPriceSubpartArrays(
-			$templateCode,
-			$row,
-			$fieldname,
-			$bTaxIncluded,
-			$bEnableTaxZero,
-			$priceFormulaArray,
-			$subpartArray,
-			$wrappedSubpartArray,
-			$tagArray,
-			$theCode,
-			$basketExtra,
-			$basketRecs,
-			$id
-		);
-	}
+        $priceTablesViewObj = $viewItemTableObj->getGraduatedPriceObject();
+        $priceTablesViewObj->getPriceSubpartArrays(
+            $templateCode,
+            $row,
+            $fieldname,
+            $bTaxIncluded,
+            $bEnableTaxZero,
+            $priceFormulaArray,
+            $subpartArray,
+            $wrappedSubpartArray,
+            $tagArray,
+            $theCode,
+            $basketExtra,
+            $basketRecs,
+            $id
+        );
+    }
 
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		$bTaxIncluded = $this->conf['TAXincluded'];
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$viewItemTableObj = $tablesObj->get($functablename, true);
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+        $bTaxIncluded = $this->conf['TAXincluded'];
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $viewItemTableObj = $tablesObj->get($functablename, true);
 
-		$priceTablesViewObj = $viewItemTableObj->getGraduatedPriceObject();
-		$priceTablesViewObj->getPriceMarkerArray(
-			$row,
-			$bTaxIncluded,
-			$bEnableTaxZero,
-			$basketExtra,
-			$basketRecs,
-			$markerArray,
-			$tagArray
-		);
-	}
+        $priceTablesViewObj = $viewItemTableObj->getGraduatedPriceObject();
+        $priceTablesViewObj->getPriceMarkerArray(
+            $row,
+            $bTaxIncluded,
+            $bEnableTaxZero,
+            $basketExtra,
+            $basketRecs,
+            $markerArray,
+            $tagArray
+        );
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_image_view.php
+++ b/view/field/class.tx_ttproducts_field_image_view.php
@@ -41,50 +41,50 @@
 class tx_ttproducts_field_image_view extends tx_ttproducts_field_media_view {
 
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
         $linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		parent::getRowMarkerArray(
-			$functablename,
-			$fieldname,
-			$row,
-			$markerKey,
-			$markerArray,
-			$fieldMarkerArray,
-			$tagArray,
-			$theCode,
-			$id,
-			$basketExtra,
-			$basketRecs,
-			$bSkip,
-			$bHtml,
-			$charset,
-			$prefix,
-			$suffix,
-			$imageNum,
-			$imageRenderObj,
-			$linkWrap,
-			$bEnableTaxZero
-		);
-	}
+        $bEnableTaxZero = false
+    ) {
+        parent::getRowMarkerArray(
+            $functablename,
+            $fieldname,
+            $row,
+            $markerKey,
+            $markerArray,
+            $fieldMarkerArray,
+            $tagArray,
+            $theCode,
+            $id,
+            $basketExtra,
+            $basketRecs,
+            $bSkip,
+            $bHtml,
+            $charset,
+            $prefix,
+            $suffix,
+            $imageNum,
+            $imageRenderObj,
+            $linkWrap,
+            $bEnableTaxZero
+        );
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_instock_view.php
+++ b/view/field/class.tx_ttproducts_field_instock_view.php
@@ -40,35 +40,35 @@
 
 class tx_ttproducts_field_instock_view extends tx_ttproducts_field_base_view {
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		if ($row[$fieldname]) {
-			$markerArray['###' . $markerKey . '_INSTOCK_UNIT###'] = $this->conf['inStockPieces'];
-		} else {
-			$value = $this->conf['notInStockMessage'];
-			$markerArray['###'.$markerKey.'_INSTOCK_UNIT###'] = '';
-		}
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+        if ($row[$fieldname]) {
+            $markerArray['###' . $markerKey . '_INSTOCK_UNIT###'] = $this->conf['inStockPieces'];
+        } else {
+            $value = $this->conf['notInStockMessage'];
+            $markerArray['###'.$markerKey.'_INSTOCK_UNIT###'] = '';
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 }

--- a/view/field/class.tx_ttproducts_field_media_view.php
+++ b/view/field/class.tx_ttproducts_field_media_view.php
@@ -43,14 +43,14 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_field_media_view extends tx_ttproducts_field_base_view {
 
-	public function getImageCode ($imageConf, $theCode, $domain = '') {
+    public function getImageCode ($imageConf, $theCode, $domain = '') {
         $cObj = \JambageCom\TtProducts\Api\ControlApi::getCObj();
 
         $contentObject = 'IMAGE';
         $imageCode =
             $cObj->getContentObject($contentObject)->render($imageConf);
 
-		if ($theCode == 'EMAIL') {
+        if ($theCode == 'EMAIL') {
             FrontendUtility::fixImageCodeAbsRefPrefix(
                 $imageCode,
                 $domain
@@ -59,23 +59,23 @@ class tx_ttproducts_field_media_view extends tx_ttproducts_field_base_view {
 //             $imageCode = str_replace('"fileadmin', '"/fileadmin', $imageCode);
         }
 
-		return $imageCode;
-	}
+        return $imageCode;
+    }
 
 
-	/**
-	 * replaces a text string with its markers
-	 * used for JavaScript functions
-	 *
-	 * @access private
-	 */
-	protected function replaceMarkerArray (
-		$markerArray,
-		$fieldMarkerArray, // neu
-		$row,
-		$meta,
-		&$imageConf
-	) {
+    /**
+     * replaces a text string with its markers
+     * used for JavaScript functions
+     *
+     * @access private
+     */
+    protected function replaceMarkerArray (
+        $markerArray,
+        $fieldMarkerArray, // neu
+        $row,
+        $meta,
+        &$imageConf
+    ) {
         $templateService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Service\MarkerBasedTemplateService::class);
         if (!empty($meta)) {
             $this->getExtItemMarkerArray($markerArray, $imageConf, $row);
@@ -183,251 +183,251 @@ class tx_ttproducts_field_media_view extends tx_ttproducts_field_base_view {
     }
 
 
-	/**
-	 * Template marker substitution
-	 * Fills in the markerArray with data for a product
-	 *
-	 * @return	array		Returns a markerArray ready for substitution with information
-	 * 				for the tt_products record, $row
-	 * @access private
-	 */
-	protected function getExtItemMarkerArray (
-		&$markerArray,
-		$imageConf,
-		$row
-	) {
-		$markerArray['###IMAGE_FILE###'] = $imageConf['file'];
+    /**
+     * Template marker substitution
+     * Fills in the markerArray with data for a product
+     *
+     * @return	array		Returns a markerArray ready for substitution with information
+     * 				for the tt_products record, $row
+     * @access private
+     */
+    protected function getExtItemMarkerArray (
+        &$markerArray,
+        $imageConf,
+        $row
+    ) {
+        $markerArray['###IMAGE_FILE###'] = $imageConf['file'];
 
-		foreach ($row as $field => $val) {
-			$key = '###IMAGE_' . strtoupper($field) . '###';
-			if (!isset($markerArray[$key])) {
-				$markerArray[$key] = $val;
-			}
-		}
-	}
-
-
-	/* returns the key for the tag array and marker array without leading and ending '###' */
-	public function getMarkerkey (
-		&$imageMarkerArray,
-		$markerKey,
-		$imageName,
-		$noMarkerArraySuffix = 1,
-		$suffix = ''
-	) {
-		$keyArray = [];
-		$keyArray[] = $markerKey;
-		$imageNameUsed = false;
-
-		if (
-			is_array($imageMarkerArray) &&
-			isset($imageMarkerArray['parts']) &&
-			!empty($imageMarkerArray['parts']) &&
-			$imageMarkerArray['type'] == 'imagename'
-		) {
-			$imageNameUsed = true;
-		}
-
-		if ($suffix) {
-			$keyArray[] = $suffix;
-		}
-
-		if ($imageNameUsed) {
-			$imageNameArray = GeneralUtility::trimExplode('_', $imageName);
-			$partsArray = GeneralUtility::trimExplode(',', $imageMarkerArray['parts']);
-			foreach ($partsArray as $k2 => $part) {
-				if (isset($imageNameArray[$part - 1])) {
-					$keyArray[] = strtoupper($imageNameArray[$part - 1]);
-				}
-			}
-		}
-		$tmp = implode('_', $keyArray);
-		$tmpArray = GeneralUtility::trimExplode('.', $tmp);
-		reset($tmpArray);
-		$key = current($tmpArray);
-
-		if (!$imageNameUsed) {
-			$key .= $noMarkerArraySuffix;
-		}
-		return $key;
-	}
+        foreach ($row as $field => $val) {
+            $key = '###IMAGE_' . strtoupper($field) . '###';
+            if (!isset($markerArray[$key])) {
+                $markerArray[$key] = $val;
+            }
+        }
+    }
 
 
-	public function getCodeMarkerArray (
-		$functablename,
-		$markerKey,
-		$theCode,
-		$imageRow,
-		$imageArray,
-		$fieldMarkerArray, // neu
-		$dirname,
-		$mediaNum = 0,
-		$imageRenderObj,
-		$linkWrap,
-		&$markerArray,
-		&$mediaRowArray,
-		&$specialConf
-	) {
-		$cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$theTableObj = $tablesObj->get($functablename);
-		$theTablename = $theTableObj->getTablename();
-		$cObj->start($imageRow, $theTablename);
-		$tableConf = [];
+    /* returns the key for the tag array and marker array without leading and ending '###' */
+    public function getMarkerkey (
+        &$imageMarkerArray,
+        $markerKey,
+        $imageName,
+        $noMarkerArraySuffix = 1,
+        $suffix = ''
+    ) {
+        $keyArray = [];
+        $keyArray[] = $markerKey;
+        $imageNameUsed = false;
 
-		$imgCodeArray = [];
-		$markerArray['###' . $markerKey . '_PATH###'] = $dirname;
-		$markerArray['###PATH###'] = $dirname;
+        if (
+            is_array($imageMarkerArray) &&
+            isset($imageMarkerArray['parts']) &&
+            !empty($imageMarkerArray['parts']) &&
+            $imageMarkerArray['type'] == 'imagename'
+        ) {
+            $imageNameUsed = true;
+        }
 
-		if (is_array($imageArray) && count($imageArray)) {
-			$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-			$tableConf = $cnf->getTableConf($functablename, $theCode);
-			if (is_array($tableConf) && isset($tableConf['imageMarker.'])) {
-				$imageMarkerArray = $tableConf['imageMarker.'];
-			}
-			$imageConfStart = $this->conf[$imageRenderObj . '.'];
-			$contentObject = $this->conf[$imageRenderObj] ?? '';
-			if ($contentObject == '') {
-				$contentObject = 'IMAGE';
-			}
+        if ($suffix) {
+            $keyArray[] = $suffix;
+        }
 
-			if ($linkWrap && !empty($imageConfStart['imageLinkWrap'])) {
-				$imageConfStart['imageLinkWrap'] = 0;
-				unset($imageConfStart['imageLinkWrap.']);
-				$imageConfStart['wrap'] = $linkWrap;
-			}
+        if ($imageNameUsed) {
+            $imageNameArray = GeneralUtility::trimExplode('_', $imageName);
+            $partsArray = GeneralUtility::trimExplode(',', $imageMarkerArray['parts']);
+            foreach ($partsArray as $k2 => $part) {
+                if (isset($imageNameArray[$part - 1])) {
+                    $keyArray[] = strtoupper($imageNameArray[$part - 1]);
+                }
+            }
+        }
+        $tmp = implode('_', $keyArray);
+        $tmpArray = GeneralUtility::trimExplode('.', $tmp);
+        reset($tmpArray);
+        $key = current($tmpArray);
 
-			if ($linkWrap === false) {
-				$imageConfStart['imageLinkWrap'] = 0;
-			}
+        if (!$imageNameUsed) {
+            $key .= $noMarkerArraySuffix;
+        }
+        return $key;
+    }
 
-			// first loop to get the general markers used also for replacement inside of JavaScript in the setup
-			$count = 0;
-			foreach($imageArray as $c => $val) {
-				if ($count == $mediaNum) {
-					break;
-				}
 
-				if (!$this->conf['separateImage']) {
-					$key = 0;  // show all images together as one image
-				} else if (is_array($val)) {
-					$key = $val['name'];
-				} else {
-					$key = (!empty($val) ? $val : $count);
-				}
-				$tagkey = '';
-				if ($val) {
-					$filetagkey =
-						$this->getMarkerkey(
-							$imageMarkerArray,
-							$markerKey,
-							$key,
-							$count + 1,
-							'FILE'
-						);
+    public function getCodeMarkerArray (
+        $functablename,
+        $markerKey,
+        $theCode,
+        $imageRow,
+        $imageArray,
+        $fieldMarkerArray, // neu
+        $dirname,
+        $mediaNum = 0,
+        $imageRenderObj,
+        $linkWrap,
+        &$markerArray,
+        &$mediaRowArray,
+        &$specialConf
+    ) {
+        $cObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');	// Local cObj.
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $theTableObj = $tablesObj->get($functablename);
+        $theTablename = $theTableObj->getTablename();
+        $cObj->start($imageRow, $theTablename);
+        $tableConf = [];
 
-					$filename = '';
-					if (is_array($val)) {
-						if (isset($val['name'])) {
-							$filename = $val['name'];
-						}
-					} else {
-						$filename = $val;
-					}
-					$markerArray['###' . $filetagkey . '###'] = $filename;
-				}
-				$count++;
-			}
+        $imgCodeArray = [];
+        $markerArray['###' . $markerKey . '_PATH###'] = $dirname;
+        $markerArray['###PATH###'] = $dirname;
 
-			$count = 0;
-			foreach($imageArray as $c => $val) {
-				$imageConf = $imageConfStart;
-				$imageConfFile = $imageConf['file'] ?? '';
-				if ($count == $mediaNum) {
-					break;
-				}
-				$bUseImage = false;
-				$meta = false;
-				if (!empty($val)) {
-					$filename = '';
-					if (is_array($val)) {
-						if (isset($val['name'])) {
-							$filename = 'fileadmin' . $val['identifier'];
-						}
-					} else {
-						$filename = $dirname . $val;
-					}
-					$imageConfFile = $filename;
-					$bUseImage = true;
-				}
+        if (is_array($imageArray) && count($imageArray)) {
+            $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+            $tableConf = $cnf->getTableConf($functablename, $theCode);
+            if (is_array($tableConf) && isset($tableConf['imageMarker.'])) {
+                $imageMarkerArray = $tableConf['imageMarker.'];
+            }
+            $imageConfStart = $this->conf[$imageRenderObj . '.'];
+            $contentObject = $this->conf[$imageRenderObj] ?? '';
+            if ($contentObject == '') {
+                $contentObject = 'IMAGE';
+            }
 
-				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam') && $bUseImage && $bImages) {
-					$damObj = GeneralUtility::makeInstance('tx_dam');
-					if(method_exists($damObj,'meta_getDataForFile')) {
-						$fieldList = 'uid,pid,tstamp,crdate,active,media_type,title,category,index_type,file_mime_type,file_mime_subtype,
+            if ($linkWrap && !empty($imageConfStart['imageLinkWrap'])) {
+                $imageConfStart['imageLinkWrap'] = 0;
+                unset($imageConfStart['imageLinkWrap.']);
+                $imageConfStart['wrap'] = $linkWrap;
+            }
+
+            if ($linkWrap === false) {
+                $imageConfStart['imageLinkWrap'] = 0;
+            }
+
+            // first loop to get the general markers used also for replacement inside of JavaScript in the setup
+            $count = 0;
+            foreach($imageArray as $c => $val) {
+                if ($count == $mediaNum) {
+                    break;
+                }
+
+                if (!$this->conf['separateImage']) {
+                    $key = 0;  // show all images together as one image
+                } else if (is_array($val)) {
+                    $key = $val['name'];
+                } else {
+                    $key = (!empty($val) ? $val : $count);
+                }
+                $tagkey = '';
+                if ($val) {
+                    $filetagkey =
+                        $this->getMarkerkey(
+                            $imageMarkerArray,
+                            $markerKey,
+                            $key,
+                            $count + 1,
+                            'FILE'
+                        );
+
+                    $filename = '';
+                    if (is_array($val)) {
+                        if (isset($val['name'])) {
+                            $filename = $val['name'];
+                        }
+                    } else {
+                        $filename = $val;
+                    }
+                    $markerArray['###' . $filetagkey . '###'] = $filename;
+                }
+                $count++;
+            }
+
+            $count = 0;
+            foreach($imageArray as $c => $val) {
+                $imageConf = $imageConfStart;
+                $imageConfFile = $imageConf['file'] ?? '';
+                if ($count == $mediaNum) {
+                    break;
+                }
+                $bUseImage = false;
+                $meta = false;
+                if (!empty($val)) {
+                    $filename = '';
+                    if (is_array($val)) {
+                        if (isset($val['name'])) {
+                            $filename = 'fileadmin' . $val['identifier'];
+                        }
+                    } else {
+                        $filename = $dirname . $val;
+                    }
+                    $imageConfFile = $filename;
+                    $bUseImage = true;
+                }
+
+                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dam') && $bUseImage && $bImages) {
+                    $damObj = GeneralUtility::makeInstance('tx_dam');
+                    if(method_exists($damObj,'meta_getDataForFile')) {
+                        $fieldList = 'uid,pid,tstamp,crdate,active,media_type,title,category,index_type,file_mime_type,file_mime_subtype,
 							file_type,file_type_version,file_name,file_path,file_size,file_mtime,file_inode,file_ctime,file_hash,file_status,
 							file_orig_location,file_orig_loc_desc,file_creator,file_dl_name,file_usage,meta,ident,creator,
 							keywords,description,alt_text,caption,abstract,search_content,language,pages,publisher,copyright,
 							instructions,date_cr,date_mod,loc_desc,loc_country,loc_city,hres,vres,hpixels,vpixels,color_space,
 							width,height,height_unit';
-						$meta = $damObj->meta_getDataForFile($imageConfFile, $fieldList);
-					}
-				}
+                        $meta = $damObj->meta_getDataForFile($imageConfFile, $fieldList);
+                    }
+                }
 
-				if (!$this->conf['separateImage']) {
-					$key = 0;  // show all images together as one image
-				} else if (is_array($val)) {
-					$key = $val['name'];
-				} else {
-					$key = (!empty($val) ? $val : $count);
-				}
-				$tagkey = '';
-				if (!empty($val)) {
-					$tagkey =
-						$this->getMarkerkey(
-							$imageMarkerArray,
-							$markerKey,
-							$key,
-							$count + 1
-						);
-				}
-				if (is_array($val)) {
-					$meta = $val;
-				}
+                if (!$this->conf['separateImage']) {
+                    $key = 0;  // show all images together as one image
+                } else if (is_array($val)) {
+                    $key = $val['name'];
+                } else {
+                    $key = (!empty($val) ? $val : $count);
+                }
+                $tagkey = '';
+                if (!empty($val)) {
+                    $tagkey =
+                        $this->getMarkerkey(
+                            $imageMarkerArray,
+                            $markerKey,
+                            $key,
+                            $count + 1
+                        );
+                }
+                if (is_array($val)) {
+                    $meta = $val;
+                }
 
-				$cObj->alternativeData = ($meta ? $meta : $imageRow);
-				if (isset($imageConf['params'])) {
+                $cObj->alternativeData = ($meta ? $meta : $imageRow);
+                if (isset($imageConf['params'])) {
                     $imageConf['params'] = preg_replace('/\s+/', ' ', $imageConf['params']);
                 }
 
-				$bGifBuilder = isset($imageConf['file']) && ($imageConf['file'] == 'GIFBUILDER');
-				$imageConf['file'] = $imageConfFile;
-				$filename = '';
-				if (is_array($val)) {
-					$filename = $imageConfFile;
-				} else {
-					$filename = $val;
-				}
+                $bGifBuilder = isset($imageConf['file']) && ($imageConf['file'] == 'GIFBUILDER');
+                $imageConf['file'] = $imageConfFile;
+                $filename = '';
+                if (is_array($val)) {
+                    $filename = $imageConfFile;
+                } else {
+                    $filename = $val;
+                }
 
-				$markerArray['###FILE###'] = $filename;
-				$this->replaceMarkerArray(
-					$markerArray,
-					$fieldMarkerArray,
-					$cObj->alternativeData,
-					$meta,
-					$imageConf
-				);
+                $markerArray['###FILE###'] = $filename;
+                $this->replaceMarkerArray(
+                    $markerArray,
+                    $fieldMarkerArray,
+                    $cObj->alternativeData,
+                    $meta,
+                    $imageConf
+                );
 
-				if ($bGifBuilder) {
-					$imageConf['file'] = 'GIFBUILDER';
-				}
+                if ($bGifBuilder) {
+                    $imageConf['file'] = 'GIFBUILDER';
+                }
 
-				$imageCode = $cObj->getContentObject($contentObject)->render($imageConf);
+                $imageCode = $cObj->getContentObject($contentObject)->render($imageConf);
 
-				if (
-					$theCode == 'EMAIL' &&
-					$GLOBALS['TSFE']->absRefPrefix == ''
-				) {
+                if (
+                    $theCode == 'EMAIL' &&
+                    $GLOBALS['TSFE']->absRefPrefix == ''
+                ) {
                     $domain = $this->conf['domain'];
                     FrontendUtility::fixImageCodeAbsRefPrefix(
                         $imageCode,
@@ -437,470 +437,470 @@ class tx_ttproducts_field_media_view extends tx_ttproducts_field_base_view {
                     $imageCode = str_replace('"fileadmin', '"/fileadmin', $imageCode);
                 }
 
-				if ($imageCode != '') {
+                if ($imageCode != '') {
                     if (!isset($imgCodeArray[$key])) {
                         $imgCodeArray[$key] = '';
                     }
-					$imgCodeArray[$key] .= $imageCode;
-				}
-				if ($meta) {
-					$mediaRowArray[$key] = $meta;
-				}
+                    $imgCodeArray[$key] .= $imageCode;
+                }
+                if ($meta) {
+                    $mediaRowArray[$key] = $meta;
+                }
 
-				if ($tagkey && isset($specialConf[$tagkey])) {
-					foreach ($specialConf[$tagkey] as $specialConfType => $specialImageConf) {
-						$theImageConf = array_merge($imageConf, $specialImageConf);
-						$cObj->alternativeData = ($meta ? $meta : $imageRow); // has to be redone here
+                if ($tagkey && isset($specialConf[$tagkey])) {
+                    foreach ($specialConf[$tagkey] as $specialConfType => $specialImageConf) {
+                        $theImageConf = array_merge($imageConf, $specialImageConf);
+                        $cObj->alternativeData = ($meta ? $meta : $imageRow); // has to be redone here
 
-						$this->replaceMarkerArray(
-							$markerArray,
-							$fieldMarkerArray,
-							$cObj->alternativeData,
-							$meta,
-							$theImageConf
-						);
+                        $this->replaceMarkerArray(
+                            $markerArray,
+                            $fieldMarkerArray,
+                            $cObj->alternativeData,
+                            $meta,
+                            $theImageConf
+                        );
 
-						if ($theImageConf['file'] != 'GIFBUILDER') {
+                        if ($theImageConf['file'] != 'GIFBUILDER') {
 
-							$theImageConf['file'] = $imageConfFile;
-						}
-						$tmpImgCode = $cObj->getContentObject($contentObject)->render($theImageConf);
-						$key1 = $key . ':' . $specialConfType;
-						$imgCodeArray[$key1] .= $tmpImgCode;
-					}
-				}
-				$count++;
-			}	// foreach
-		} else if (
-			!empty($this->conf['noImageAvailable']) &&
-			$this->conf['noImageAvailable'] != '{$plugin.tt_products.file.noImageAvailable}'
-		) {	// if (count($imageArray))
-			$imageConf = $this->conf[$imageRenderObj . '.'];
-			$imageConf['file'] = $this->conf['noImageAvailable'];
+                            $theImageConf['file'] = $imageConfFile;
+                        }
+                        $tmpImgCode = $cObj->getContentObject($contentObject)->render($theImageConf);
+                        $key1 = $key . ':' . $specialConfType;
+                        $imgCodeArray[$key1] .= $tmpImgCode;
+                    }
+                }
+                $count++;
+            }	// foreach
+        } else if (
+            !empty($this->conf['noImageAvailable']) &&
+            $this->conf['noImageAvailable'] != '{$plugin.tt_products.file.noImageAvailable}'
+        ) {	// if (count($imageArray))
+            $imageConf = $this->conf[$imageRenderObj . '.'];
+            $imageConf['file'] = $this->conf['noImageAvailable'];
             $tmpImgCode = $this->getImageCode($imageConf, $theCode);
-			$imgCodeArray[0] = $tmpImgCode;
-		}
+            $imgCodeArray[0] = $tmpImgCode;
+        }
 
-		if (
-			!$this->conf['separateImage'] &&
-			isset($tableConf['joinedImagesWrap.'])
-		) {
- 			$imgCodeArray[0] =
-				$cObj->stdWrap(
-					$imgCodeArray[0],
-					$tableConf['joinedImagesWrap.']
-				);
-		}
+        if (
+            !$this->conf['separateImage'] &&
+            isset($tableConf['joinedImagesWrap.'])
+        ) {
+            $imgCodeArray[0] =
+                $cObj->stdWrap(
+                    $imgCodeArray[0],
+                    $tableConf['joinedImagesWrap.']
+                );
+        }
 
-		return $imgCodeArray;
-	}
+        return $imgCodeArray;
+    }
 
 
-	private function getMediaMarkerArray (
-		$functablename,
-		$fieldname,
-		&$row,
-		$mediaNum,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray, // neu
-		$tagArray,
-		$theCode,
-		$id,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageRenderObj = 'image',
-		$linkWrap = false  // neu
-	) {
-		$imageRow = $row;
-		$bImages = false;
-		$imageMarkerArray = [];
-		$dirname = '';
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableConf = $cnf->getTableConf($functablename, $theCode);
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$theTableObj = $tablesObj->get($functablename);
-		$theTablename = $theTableObj->getTablename();
-		$cObj = FrontendUtility::getContentObjectRenderer();
+    private function getMediaMarkerArray (
+        $functablename,
+        $fieldname,
+        &$row,
+        $mediaNum,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray, // neu
+        $tagArray,
+        $theCode,
+        $id,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageRenderObj = 'image',
+        $linkWrap = false  // neu
+    ) {
+        $imageRow = $row;
+        $bImages = false;
+        $imageMarkerArray = [];
+        $dirname = '';
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableConf = $cnf->getTableConf($functablename, $theCode);
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $theTableObj = $tablesObj->get($functablename);
+        $theTablename = $theTableObj->getTablename();
+        $cObj = FrontendUtility::getContentObjectRenderer();
 
-			// Get image
-		$mediaRowArray = [];
-		$specialImgCode = [];
-		if (
-			is_array($tableConf) &&
-			isset($tableConf['imageMarker.'])
-		) {
-			$imageMarkerArray = $tableConf['imageMarker.'];
-		}
-		$imgs = [];
-		$imageField = 'image';
-		if ($functablename == 'pages') {
-			$imageField = 'media';
-		}
+            // Get image
+        $mediaRowArray = [];
+        $specialImgCode = [];
+        if (
+            is_array($tableConf) &&
+            isset($tableConf['imageMarker.'])
+        ) {
+            $imageMarkerArray = $tableConf['imageMarker.'];
+        }
+        $imgs = [];
+        $imageField = 'image';
+        if ($functablename == 'pages') {
+            $imageField = 'media';
+        }
 
-		if (isset($tableConf['fetchImage.']) &&
-			$tableConf['fetchImage.']['type'] == 'foreigntable'  &&
-			isset($tableConf['fetchImage.']['table'])) {
-			$pageContent = $tablesObj->get($tableConf['fetchImage.']['table'])->getFromPid($pid);
-			foreach ($pageContent as $pid => $contentRow) {
-				if ($contentRow[$imageField]) {
-					$imgs[] = $contentRow[$imageField];
-				}
-			}
-			$bImages = true;
-		}
+        if (isset($tableConf['fetchImage.']) &&
+            $tableConf['fetchImage.']['type'] == 'foreigntable'  &&
+            isset($tableConf['fetchImage.']['table'])) {
+            $pageContent = $tablesObj->get($tableConf['fetchImage.']['table'])->getFromPid($pid);
+            foreach ($pageContent as $pid => $contentRow) {
+                if ($contentRow[$imageField]) {
+                    $imgs[] = $contentRow[$imageField];
+                }
+            }
+            $bImages = true;
+        }
 
-		if (!$bImages) {
-			$fieldconfParent = [];
-			if (is_array($tableConf)) {
-				$tempConf = '';
-				if (
-					isset($tableConf['generateImage.']) &&
-					$tableConf['generateImage.']['type'] == 'foreigntable'
-				) {
-					$tempConf = $tableConf['generateImage.'];
-				}
+        if (!$bImages) {
+            $fieldconfParent = [];
+            if (is_array($tableConf)) {
+                $tempConf = '';
+                if (
+                    isset($tableConf['generateImage.']) &&
+                    $tableConf['generateImage.']['type'] == 'foreigntable'
+                ) {
+                    $tempConf = $tableConf['generateImage.'];
+                }
 
-				$conftable = '';
-				if (is_array($tempConf) && $imageRow) {
-					$conftable = $tempConf['table'];
-					$localfield = $tempConf['uid_local'];
-					$foreignfield = $tempConf['uid_foreign'];
-					$fieldconfParent['generateImage'] = $tempConf['field.'];
-					$where_clause = $conftable . '.' . $foreignfield . '=' . $imageRow[$localfield];
-					$enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields($conftable);
-					$where_clause .= $enableFields;
-					$res =
-						$GLOBALS['TYPO3_DB']->exec_SELECTquery(
-							'*',
-							$conftable,
-							$where_clause,
-							'',
-							$foreignfield,
-							1
-						);
-						// only first found row will be used
-					$imageRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
-				}
-			}
+                $conftable = '';
+                if (is_array($tempConf) && $imageRow) {
+                    $conftable = $tempConf['table'];
+                    $localfield = $tempConf['uid_local'];
+                    $foreignfield = $tempConf['uid_foreign'];
+                    $fieldconfParent['generateImage'] = $tempConf['field.'];
+                    $where_clause = $conftable . '.' . $foreignfield . '=' . $imageRow[$localfield];
+                    $enableFields = \JambageCom\Div2007\Utility\TableUtility::enableFields($conftable);
+                    $where_clause .= $enableFields;
+                    $res =
+                        $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                            '*',
+                            $conftable,
+                            $where_clause,
+                            '',
+                            $foreignfield,
+                            1
+                        );
+                        // only first found row will be used
+                    $imageRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
+                }
+            }
 
-			// $confParentTableConf = $this->getTableConf($conftable, $theCode);
-			$conftable = ($conftable ? $conftable : $functablename);
-			$generateArray = ['generateImage', 'generatePath'];
-			$nameArray = [];
+            // $confParentTableConf = $this->getTableConf($conftable, $theCode);
+            $conftable = ($conftable ? $conftable : $functablename);
+            $generateArray = ['generateImage', 'generatePath'];
+            $nameArray = [];
 
-			$conftableConf = $cnf->getTableConf($conftable, $theCode);
+            $conftableConf = $cnf->getTableConf($conftable, $theCode);
 
-			foreach ($generateArray as $k => $generate) {
-				if (is_array($conftableConf) &&
-				 	isset($conftableConf[$generate . '.'])) {
-				 	$genPartArray = $conftableConf[$generate . '.'];
-				 	$tableFieldsCode = '';
+            foreach ($generateArray as $k => $generate) {
+                if (is_array($conftableConf) &&
+                    isset($conftableConf[$generate . '.'])) {
+                    $genPartArray = $conftableConf[$generate . '.'];
+                    $tableFieldsCode = '';
 
-				 	if ($genPartArray['type'] == 'tablefields') {
-				 		$nameArray[$generate] = '';
-						if ($genPartArray['prefix'] != '')	{
-							$nameArray[$generate] = $genPartArray['prefix'];
-						}
-				 		$fieldConf = $genPartArray['field.'];
+                    if ($genPartArray['type'] == 'tablefields') {
+                        $nameArray[$generate] = '';
+                        if ($genPartArray['prefix'] != '')	{
+                            $nameArray[$generate] = $genPartArray['prefix'];
+                        }
+                        $fieldConf = $genPartArray['field.'];
 
-						if (is_array($fieldConf)) {
-							if (isset($fieldconfParent[$generate]) && is_array($fieldconfParent[$generate])) {
-								$fieldConf = array_merge($fieldConf, $fieldconfParent[$generate]);
-							}
+                        if (is_array($fieldConf)) {
+                            if (isset($fieldconfParent[$generate]) && is_array($fieldconfParent[$generate])) {
+                                $fieldConf = array_merge($fieldConf, $fieldconfParent[$generate]);
+                            }
 
-							foreach ($fieldConf as $field => $count) {
-								if ($imageRow[$field]) {
-									$nameArray[$generate] .= substr($imageRow[$field], 0, $count);
-									if ($generate == 'generateImage') {
-										$bImages = true;
-									}
-								}
-							}
-				 		}
-				 	}
+                            foreach ($fieldConf as $field => $count) {
+                                if ($imageRow[$field]) {
+                                    $nameArray[$generate] .= substr($imageRow[$field], 0, $count);
+                                    if ($generate == 'generateImage') {
+                                        $bImages = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
 
-					if ($generate == 'generatePath') {
-						$dirname = $conftableConf['generatePath.']['base'];
-						if ($dirname != '' && !empty($nameArray['generatePath'])) {
-							$dirname .= '/';
-						}
-						$dirname .= $nameArray['generatePath'];
-					}
-				}
-			}
+                    if ($generate == 'generatePath') {
+                        $dirname = $conftableConf['generatePath.']['base'];
+                        if ($dirname != '' && !empty($nameArray['generatePath'])) {
+                            $dirname .= '/';
+                        }
+                        $dirname .= $nameArray['generatePath'];
+                    }
+                }
+            }
 
-			if (!empty($nameArray['generateImage']) && is_dir($dirname)) {
-				$directory = dir($dirname);
-				$separator = '_';
+            if (!empty($nameArray['generateImage']) && is_dir($dirname)) {
+                $directory = dir($dirname);
+                $separator = '_';
 
-				if (
-					is_array($conftableConf) &&
-					is_array($conftableConf['generateImage.'])
-				) {
-					$separator = $conftableConf['separator'];
-				}
+                if (
+                    is_array($conftableConf) &&
+                    is_array($conftableConf['generateImage.'])
+                ) {
+                    $separator = $conftableConf['separator'];
+                }
 
-				while($entry = $directory->read()) {
-					if (strpos($entry, $nameArray['generateImage'] . $separator) !== false) {
-						$imgs[] = $entry;
-					}
-				}
-				$directory->close();
-			}
+                while($entry = $directory->read()) {
+                    if (strpos($entry, $nameArray['generateImage'] . $separator) !== false) {
+                        $imgs[] = $entry;
+                    }
+                }
+                $directory->close();
+            }
 
-			if (is_array($imgs) && count($imgs)) {
-				$bImages = true;
-			}
-		} // if (!$bImages) {
+            if (is_array($imgs) && count($imgs)) {
+                $bImages = true;
+            }
+        } // if (!$bImages) {
 
-		if (!$bImages) {
-			$imgs = $this->getModelObj()->getFileArray($theTablename, $imageRow, $fieldname, true);
-		}
+        if (!$bImages) {
+            $imgs = $this->getModelObj()->getFileArray($theTablename, $imageRow, $fieldname, true);
+        }
 
-		$specialConf = [];
-		$tempImageConf = '';
+        $specialConf = [];
+        $tempImageConf = '';
 
-		if (isset($tableConf['image.'])) {
-			$tempImageConf = $tableConf['image.'];
-		}
+        if (isset($tableConf['image.'])) {
+            $tempImageConf = $tableConf['image.'];
+        }
 
-		if (is_array($tempImageConf)) {
-			foreach ($tagArray as $key => $value) {
-				$keyArray = GeneralUtility::trimExplode (':', $key);
-				$specialConfType = '';
-				if (isset($keyArray[1])) {
+        if (is_array($tempImageConf)) {
+            foreach ($tagArray as $key => $value) {
+                $keyArray = GeneralUtility::trimExplode (':', $key);
+                $specialConfType = '';
+                if (isset($keyArray[1])) {
                     $specialConfType = strtolower($keyArray[1]);
                 }
-				$tagKey = $keyArray[0];
-				if ($specialConfType &&
-					(
-						!isset($specialConf[$tagKey]) ||
-						!is_array($specialConf[$tagKey]) ||
-						!isset($specialConf[$tagKey][$specialConfType])
-					) &&
-					isset($tempImageConf[$specialConfType . '.'])
-				) {
-					// add the special configuration
-					if (!is_array($specialConf[$tagKey])) {
-						$specialConf[$tagKey] = [];
-					}
-					$specialConf[$tagKey][$specialConfType] = $tempImageConf[$specialConfType . '.'];
-				}
-			}
-		}
+                $tagKey = $keyArray[0];
+                if ($specialConfType &&
+                    (
+                        !isset($specialConf[$tagKey]) ||
+                        !is_array($specialConf[$tagKey]) ||
+                        !isset($specialConf[$tagKey][$specialConfType])
+                    ) &&
+                    isset($tempImageConf[$specialConfType . '.'])
+                ) {
+                    // add the special configuration
+                    if (!is_array($specialConf[$tagKey])) {
+                        $specialConf[$tagKey] = [];
+                    }
+                    $specialConf[$tagKey][$specialConfType] = $tempImageConf[$specialConfType . '.'];
+                }
+            }
+        }
 
-		if ($dirname != '') {
-			$dirname .= '/';
-		} else {
-			$dirname = $this->getModelObj()->getDirname($imageRow);
-		}
+        if ($dirname != '') {
+            $dirname .= '/';
+        } else {
+            $dirname = $this->getModelObj()->getDirname($imageRow);
+        }
 
 // +++		$linkWrap = false;
-		$theImgCode =
-			$this->getCodeMarkerArray(
-				$functablename,
-				$markerKey,
-				$theCode,
-				$imageRow,
-				$imgs,
-				$fieldMarkerArray, // neu
-				$dirname,
-				$mediaNum,
-				$imageRenderObj,
-				$linkWrap,
-				$markerArray,
-				$mediaRowArray,
-				$specialConf
-			);
+        $theImgCode =
+            $this->getCodeMarkerArray(
+                $functablename,
+                $markerKey,
+                $theCode,
+                $imageRow,
+                $imgs,
+                $fieldMarkerArray, // neu
+                $dirname,
+                $mediaNum,
+                $imageRenderObj,
+                $linkWrap,
+                $markerArray,
+                $mediaRowArray,
+                $specialConf
+            );
 
-		$actImgCode = current($theImgCode);
-		$markerArray['###'.$markerKey.'###'] = $actImgCode ? $actImgCode : ''; // for compatibility only
+        $actImgCode = current($theImgCode);
+        $markerArray['###'.$markerKey.'###'] = $actImgCode ? $actImgCode : ''; // for compatibility only
 
-		$c = 1;
-		$countArray = [];
+        $c = 1;
+        $countArray = [];
 
-		foreach($theImgCode as $k1 => $val) {
+        foreach($theImgCode as $k1 => $val) {
 
-			$bIsSpecial = true;
-			if (strpos($k1, ':') === false) {
-				$bIsSpecial = false;
-			} else {
-				$c--; // the former index mus be used again
-			}
-			$key = $markerKey . intval($c);
+            $bIsSpecial = true;
+            if (strpos($k1, ':') === false) {
+                $bIsSpecial = false;
+            } else {
+                $c--; // the former index mus be used again
+            }
+            $key = $markerKey . intval($c);
 
- 			if ($bIsSpecial) {
-				$keyArray = GeneralUtility::trimExplode(':', $k1);
-				$count = $countArray[$keyArray[0]];
-				$key =  $markerKey . intval($count);
+            if ($bIsSpecial) {
+                $keyArray = GeneralUtility::trimExplode(':', $k1);
+                $count = $countArray[$keyArray[0]];
+                $key =  $markerKey . intval($count);
 
-				if (
-					isset($count) &&
-					is_array($specialConf[$key]) &&
-					isset($specialConf[$key][$keyArray[1]]) &&
-					is_array($specialConf[$key][$keyArray[1]])
-				) {
-					$combkey = $key . ':' . strtoupper($keyArray[1]);
+                if (
+                    isset($count) &&
+                    is_array($specialConf[$key]) &&
+                    isset($specialConf[$key][$keyArray[1]]) &&
+                    is_array($specialConf[$key][$keyArray[1]])
+                ) {
+                    $combkey = $key . ':' . strtoupper($keyArray[1]);
 
-					if (isset($tagArray[$combkey])) {
-						$markerArray['###' . $combkey . '###'] = $val;
-					}
-				}
-			} else {
-				if (isset($tagArray[$key])) {
-					$markerArray['###' . $key . '###'] = $val;
-				}
-				$countArray[$k1] = $c;
-			}
+                    if (isset($tagArray[$combkey])) {
+                        $markerArray['###' . $combkey . '###'] = $val;
+                    }
+                }
+            } else {
+                if (isset($tagArray[$key])) {
+                    $markerArray['###' . $key . '###'] = $val;
+                }
+                $countArray[$k1] = $c;
+            }
 
-			if (is_array($mediaRowArray[$k1])) {
+            if (is_array($mediaRowArray[$k1])) {
 
-				foreach ($mediaRowArray[$k1] as $field => $val2) {
-					$key1 = $key . '_' . strtoupper($field);
-					if (isset($tagArray[$key1])) {
-						$markerArray['###' . $key1 . '###'] = $val2;
-					}
-				}
-			}
-			$c++;
-		} // foreach
-
-		$bImageMarker = false;
-		if (
-			!empty($imageMarkerArray) &&
-			isset($imageMarkerArray['type']) &&
-			!empty($imageMarkerArray['type'])
-		) {
-			$bImageMarker = true;
-		}
-
-		if ($bImageMarker) {
-			$k = 0;
-			foreach ($theImgCode as $imageName => $imgValue) {
-				$k++;
-				$suffix = $k;
-				if ($imageMarkerArray['type'] == 'imagename') {
-					$suffix = '';
-				}
-
-				$tagkey =
-					$this->getMarkerkey(
-						$imageMarkerArray,
-						$markerKey,
-						$imageName,
-						$suffix
-					);
-
-				if ($imageMarkerArray['type'] == 'imagename') {
-					$nameArray = GeneralUtility::trimExplode(':', $imageName);
-					$tagkey .= (empty($nameArray) || empty($nameArray['1']) ? '' : ':' . $nameArray['1']);
-				}
-
-				if (isset($tagArray[$tagkey])) {
-					$markerArray['###' . $tagkey . '###'] = $imgValue;
-				}
-
-				if (is_array($mediaRowArray[$imageName])) {
-					foreach ($mediaRowArray[$imageName] as $field => $val2) {
-						$key1 = $tagkey . '_' . strtoupper($field);
+                foreach ($mediaRowArray[$k1] as $field => $val2) {
+                    $key1 = $key . '_' . strtoupper($field);
+                    if (isset($tagArray[$key1])) {
                         $markerArray['###' . $key1 . '###'] = $val2;
-					}
-				}
-			}
-		}
-	}
+                    }
+                }
+            }
+            $c++;
+        } // foreach
+
+        $bImageMarker = false;
+        if (
+            !empty($imageMarkerArray) &&
+            isset($imageMarkerArray['type']) &&
+            !empty($imageMarkerArray['type'])
+        ) {
+            $bImageMarker = true;
+        }
+
+        if ($bImageMarker) {
+            $k = 0;
+            foreach ($theImgCode as $imageName => $imgValue) {
+                $k++;
+                $suffix = $k;
+                if ($imageMarkerArray['type'] == 'imagename') {
+                    $suffix = '';
+                }
+
+                $tagkey =
+                    $this->getMarkerkey(
+                        $imageMarkerArray,
+                        $markerKey,
+                        $imageName,
+                        $suffix
+                    );
+
+                if ($imageMarkerArray['type'] == 'imagename') {
+                    $nameArray = GeneralUtility::trimExplode(':', $imageName);
+                    $tagkey .= (empty($nameArray) || empty($nameArray['1']) ? '' : ':' . $nameArray['1']);
+                }
+
+                if (isset($tagArray[$tagkey])) {
+                    $markerArray['###' . $tagkey . '###'] = $imgValue;
+                }
+
+                if (is_array($mediaRowArray[$imageName])) {
+                    foreach ($mediaRowArray[$imageName] as $field => $val2) {
+                        $key1 = $tagkey . '_' . strtoupper($field);
+                        $markerArray['###' . $key1 . '###'] = $val2;
+                    }
+                }
+            }
+        }
+    }
 
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$mediaNum = 0,
-		$imageRenderObj = 'image',
-		$linkWrap = false, // neu
-		$bEnableTaxZero = false
-	) {
-		if ($bHtml) {
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $mediaNum = 0,
+        $imageRenderObj = 'image',
+        $linkWrap = false, // neu
+        $bEnableTaxZero = false
+    ) {
+        if ($bHtml) {
 
-			$bSkip = true;
-			if (strpos($fieldname, 'smallimage') !== false) {
-				$imageRenderObj = 'smallImage';
-			}
-			$mediaMarkerKeyArray = [];
+            $bSkip = true;
+            if (strpos($fieldname, 'smallimage') !== false) {
+                $imageRenderObj = 'smallImage';
+            }
+            $mediaMarkerKeyArray = [];
 
-			if (isset($tagArray) && is_array($tagArray)) {
-				foreach ($tagArray as $value => $k1) {
-					if (strpos($value, $markerKey) !== false) {
-						$keyMarker = '###' . $value . '###';
-						$foundPos = strpos($value, $markerKey . '_ID');
+            if (isset($tagArray) && is_array($tagArray)) {
+                foreach ($tagArray as $value => $k1) {
+                    if (strpos($value, $markerKey) !== false) {
+                        $keyMarker = '###' . $value . '###';
+                        $foundPos = strpos($value, $markerKey . '_ID');
 
-						if ($foundPos !== false) {
-							$c = substr($value, strlen($markerKey . '_ID'));
-							$markerArray[$keyMarker] = $id . '-' . $c;
-						} else {
-							$mediaMarkerKeyArray[] = $keyMarker;
-						}
+                        if ($foundPos !== false) {
+                            $c = substr($value, strlen($markerKey . '_ID'));
+                            $markerArray[$keyMarker] = $id . '-' . $c;
+                        } else {
+                            $mediaMarkerKeyArray[] = $keyMarker;
+                        }
 
-						// empty all image fields with no available image
-						if (!isset($markerArray[$keyMarker])) {
-							$markerArray[$keyMarker] = '';
-						}
-					}
-				}
-			}
+                        // empty all image fields with no available image
+                        if (!isset($markerArray[$keyMarker])) {
+                            $markerArray[$keyMarker] = '';
+                        }
+                    }
+                }
+            }
 
-			if (is_array($mediaMarkerKeyArray) && count($mediaMarkerKeyArray)) {
-				// example: plugin.tt_products.conf.tt_products.ALL.limitImage = 10
-				if (!$mediaNum) {
-					$mediaNum =
-						$this->getModelObj()->getMediaNum(
-							$functablename,
-							$fieldname,
-							$theCode
-						);
-				}
+            if (is_array($mediaMarkerKeyArray) && count($mediaMarkerKeyArray)) {
+                // example: plugin.tt_products.conf.tt_products.ALL.limitImage = 10
+                if (!$mediaNum) {
+                    $mediaNum =
+                        $this->getModelObj()->getMediaNum(
+                            $functablename,
+                            $fieldname,
+                            $theCode
+                        );
+                }
 
-				if ($mediaNum) {
+                if ($mediaNum) {
 
-					$this->getMediaMarkerArray(
-						$functablename,
-						$fieldname,
-						$row,
-						$mediaNum,
-						$markerKey,
-						$markerArray,
-						$fieldMarkerArray,
-						$tagArray,
-						$theCode,
-						$id,
-						$bSkip,
-						$bHtml,
-						$charset,
-						$prefix,
-						$suffix,
-						$imageRenderObj,
-						$linkWrap
-					);
-				}
-			}
-		}
-	}
+                    $this->getMediaMarkerArray(
+                        $functablename,
+                        $fieldname,
+                        $row,
+                        $mediaNum,
+                        $markerKey,
+                        $markerArray,
+                        $fieldMarkerArray,
+                        $tagArray,
+                        $theCode,
+                        $id,
+                        $bSkip,
+                        $bHtml,
+                        $charset,
+                        $prefix,
+                        $suffix,
+                        $imageRenderObj,
+                        $linkWrap
+                    );
+                }
+            }
+        }
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_note_view.php
+++ b/view/field/class.tx_ttproducts_field_note_view.php
@@ -44,28 +44,28 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 class tx_ttproducts_field_note_view extends tx_ttproducts_field_base_view {
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
         $value = $this->getModelObj()->getFieldValue(
             $dummy,
             $row,
@@ -75,23 +75,23 @@ class tx_ttproducts_field_note_view extends tx_ttproducts_field_base_view {
             $dummy
         );
 
-		if (
-			$bHtml &&
-			($theCode != 'EMAIL' || $this->conf['orderEmail_htmlmail'])
-		) {
+        if (
+            $bHtml &&
+            ($theCode != 'EMAIL' || $this->conf['orderEmail_htmlmail'])
+        ) {
             $cObj = FrontendUtility::getContentObjectRenderer();
 
-				// Extension CSS styled content
-			if (FrontendUtility::hasRTEparser()) {
-				$value = FrontendUtility::RTEcssText($cObj, $value);
-			} else if (is_array($this->conf['parseFunc.'])) {
-				$value = $cObj->parseFunc($value, $this->conf['parseFunc.']);
-			} else if ($this->conf['nl2brNote']) {
-				$value = nl2br($value);
-			}
-		}
+                // Extension CSS styled content
+            if (FrontendUtility::hasRTEparser()) {
+                $value = FrontendUtility::RTEcssText($cObj, $value);
+            } else if (is_array($this->conf['parseFunc.'])) {
+                $value = $cObj->parseFunc($value, $this->conf['parseFunc.']);
+            } else if ($this->conf['nl2brNote']) {
+                $value = nl2br($value);
+            }
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_price_view.php
+++ b/view/field/class.tx_ttproducts_field_price_view.php
@@ -45,51 +45,51 @@ use JambageCom\Div2007\Utility\FrontendUtility;
 
 
 class tx_ttproducts_field_price_view extends tx_ttproducts_field_base_view {
-	static protected $convertArray = [
-		'price' => [
-			'tax' => 'PRICE_TAX',
-			'taxperc' => 'TAX',
-			'0tax' => 'OLD_PRICE_TAX',
-			'0notax' => 'OLD_PRICE_NO_TAX',
-			'calc' => 'calcprice',
-			'notax' => 'PRICE_NO_TAX',
-			'onlytax' => 'PRICE_ONLY_TAX',
-			'skontotax' => 'PRICE_TAX_DISCOUNT',
-			'skontonotax' => 'PRICE_NO_TAX_DISCOUNT',
-			'skontotaxperc' => 'PRICE_TAX_DISCOUNT_PERCENT',
-			'unotax' => 'UNIT_PRICE_NO_TAX',
-			'utax' => 'UNIT_PRICE_TAX',
-			'wnotax' => 'WEIGHT_UNIT_PRICE_NO_TAX',
-			'wtax' => 'WEIGHT_UNIT_PRICE_TAX',
+    static protected $convertArray = [
+        'price' => [
+            'tax' => 'PRICE_TAX',
+            'taxperc' => 'TAX',
+            '0tax' => 'OLD_PRICE_TAX',
+            '0notax' => 'OLD_PRICE_NO_TAX',
+            'calc' => 'calcprice',
+            'notax' => 'PRICE_NO_TAX',
+            'onlytax' => 'PRICE_ONLY_TAX',
+            'skontotax' => 'PRICE_TAX_DISCOUNT',
+            'skontonotax' => 'PRICE_NO_TAX_DISCOUNT',
+            'skontotaxperc' => 'PRICE_TAX_DISCOUNT_PERCENT',
+            'unotax' => 'UNIT_PRICE_NO_TAX',
+            'utax' => 'UNIT_PRICE_TAX',
+            'wnotax' => 'WEIGHT_UNIT_PRICE_NO_TAX',
+            'wtax' => 'WEIGHT_UNIT_PRICE_TAX',
 
-			'surchargetax' => 'SURCHARGE_TAX',
-			'surchargenotax' => 'SURCHARGE_NO_TAX',
-			'discountbyproductpricetax' => 'PRICE_TAX_RECORD_DISCOUNTED',
-			'discountbyproductpricenotax' => 'PRICE_NO_TAX_RECORD_DISCOUNTED',
-			'discountbyproductutax' => 'UNIT_PRICE_TAX_RECORD_DISCOUNTED',
-			'discountbyproductunotax' => 'UNIT_PRICE_NO_TAX_RECORD_DISCOUNTED',
-			'discountbyproductwtax' => 'WEIGHT_UNIT_PRICE_TAX_RECORD_DISCOUNTED',
-			'discountbyproductwnotax' => 'WEIGHT_UNIT_PRICE_NO_TAX_RECORD_DISCOUNTED',
-		],
-		'price2' => [
-			'2tax' => 'PRICE2_TAX',
-			'2notax' => 'PRICE2_NO_TAX',
-			'2onlytax' => 'PRICE2_ONLY_TAX',
-			'2skontotax' => 'PRICE2_TAX_DISCOUNT',
-			'2skontotaxperc' => 'PRICE2_TAX_DISCOUNT_PERCENT',
+            'surchargetax' => 'SURCHARGE_TAX',
+            'surchargenotax' => 'SURCHARGE_NO_TAX',
+            'discountbyproductpricetax' => 'PRICE_TAX_RECORD_DISCOUNTED',
+            'discountbyproductpricenotax' => 'PRICE_NO_TAX_RECORD_DISCOUNTED',
+            'discountbyproductutax' => 'UNIT_PRICE_TAX_RECORD_DISCOUNTED',
+            'discountbyproductunotax' => 'UNIT_PRICE_NO_TAX_RECORD_DISCOUNTED',
+            'discountbyproductwtax' => 'WEIGHT_UNIT_PRICE_TAX_RECORD_DISCOUNTED',
+            'discountbyproductwnotax' => 'WEIGHT_UNIT_PRICE_NO_TAX_RECORD_DISCOUNTED',
+        ],
+        'price2' => [
+            '2tax' => 'PRICE2_TAX',
+            '2notax' => 'PRICE2_NO_TAX',
+            '2onlytax' => 'PRICE2_ONLY_TAX',
+            '2skontotax' => 'PRICE2_TAX_DISCOUNT',
+            '2skontotaxperc' => 'PRICE2_TAX_DISCOUNT_PERCENT',
 
-			'surcharge2tax' => 'SURCHARGE2_TAX',
-			'surcharge2notax' => 'SURCHARGE2_NO_TAX',
-		],
-		'deposit' => [
-			'deposittax' => 'DEPOSIT_TAX',
-			'depositnotax' => 'DEPOSIT_NO_TAX',
-		],
-		'directcost' => [
-			'directcosttax' => 'DIRECTCOST_TAX',
-			'directcostnotax' => 'DIRECTCOST_NO_TAX',
-		],
-	];
+            'surcharge2tax' => 'SURCHARGE2_TAX',
+            'surcharge2notax' => 'SURCHARGE2_NO_TAX',
+        ],
+        'deposit' => [
+            'deposittax' => 'DEPOSIT_TAX',
+            'depositnotax' => 'DEPOSIT_NO_TAX',
+        ],
+        'directcost' => [
+            'directcosttax' => 'DIRECTCOST_TAX',
+            'directcostnotax' => 'DIRECTCOST_NO_TAX',
+        ],
+    ];
 
     static public function getConvertedPriceFieldArray ($priceType) {
         $priceFieldArray = [];
@@ -106,289 +106,289 @@ class tx_ttproducts_field_price_view extends tx_ttproducts_field_base_view {
         return $priceFieldArray;
     }
 
-	/**
-	 * Generate a graphical price tag or print the price as text
-	 */
-	public function printPrice ($priceText, $taxInclExcl = '') {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+    /**
+     * Generate a graphical price tag or print the price as text
+     */
+    public function printPrice ($priceText, $taxInclExcl = '') {
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
 
-		if (($conf['usePriceTag']) && (isset($conf['priceTagObj.']))) {
-			$cObj = FrontendUtility::getContentObjectRenderer();
+        if (($conf['usePriceTag']) && (isset($conf['priceTagObj.']))) {
+            $cObj = FrontendUtility::getContentObjectRenderer();
 
-			$ptconf = $conf['priceTagObj.'];
-			$markContentArray = [];
-			$markContentArray['###PRICE###'] = $priceText;
-			$markContentArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
+            $ptconf = $conf['priceTagObj.'];
+            $markContentArray = [];
+            $markContentArray['###PRICE###'] = $priceText;
+            $markContentArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
 
-			$cObj->substituteMarkerInObject($ptconf, $markContentArray);
-			$result = $cObj->cObjGetSingle($conf['priceTagObj'], $ptconf);
-		} else {
-			$result = $priceText;
-		}
-		return $result;
-	}
+            $cObj->substituteMarkerInObject($ptconf, $markContentArray);
+            $result = $cObj->cObjGetSingle($conf['priceTagObj'], $ptconf);
+        } else {
+            $result = $priceText;
+        }
+        return $result;
+    }
 
 
-	/**
-	 * Formatting a price
-	 */
-	public function priceFormat ($double) {
+    /**
+     * Formatting a price
+     */
+    public function priceFormat ($double) {
         if (!is_numeric($double)) {
             return $double;
         }
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$double = round($double, 10);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $double = round($double, 10);
 
-		if (
-			$conf['noZeroDecimalPoint'] &&
-			round($double, 2) == intval($double)
-		) {
-			$result = number_format($double, 0, $conf['priceDecPoint'], $conf['priceThousandPoint']);
-		} else {
-			$result =
-				number_format(
-					$double,
-					intval($conf['priceDec']),
-					$conf['priceDecPoint'],
-					$conf['priceThousandPoint']
-				);
-		}
+        if (
+            $conf['noZeroDecimalPoint'] &&
+            round($double, 2) == intval($double)
+        ) {
+            $result = number_format($double, 0, $conf['priceDecPoint'], $conf['priceThousandPoint']);
+        } else {
+            $result =
+                number_format(
+                    $double,
+                    intval($conf['priceDec']),
+                    $conf['priceDecPoint'],
+                    $conf['priceThousandPoint']
+                );
+        }
 
-		if ($result == '-0,00') {
-			$result = '0,00';
-		}
+        if ($result == '-0,00') {
+            $result = '0,00';
+        }
 
-		if ($result == '-0.00') {
-			$result = '0.00';
-		}
+        if ($result == '-0.00') {
+            $result = '0.00';
+        }
 
-		return $result;
-	} // priceFormat
-
-
-	/**
-	 * Formatting a percentage
-	 */
-	public function percentageFormat ($double) {
-		$result = false;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->conf;
-		$double = round($double, 10);
-
-		$percentDecPoint = $conf['percentDecPoint'];
-		$percentThousandPoint = $conf['percentThousandPoint'];
-		$percentDec = $conf['percentDec'];
-		$percentNoZeroDecimalPoint = $conf['percentNoZeroDecimalPoint'];
-
-		if ($percentNoZeroDecimalPoint && round($double, 2) == intval($double)) {
-			$result = number_format($double, 0, $percentDecPoint, $percentThousandPoint);
-		} else {
-			$result = number_format($double, intval($percentDec), $percentDecPoint, $percentThousandPoint);
-		}
-		if ($result == '-0,00') {
-			$result = '0,00';
-		}
-		if ($result == '-0.00') {
-			$result = '0.00';
-		}
-		return $result;
-	} // percentageFormat
+        return $result;
+    } // priceFormat
 
 
-	static public function convertKey ($priceType, $fieldname) {
-		$result = false;
-		if (
-			isset(self::$convertArray[$fieldname]) &&
-			is_array(self::$convertArray[$fieldname])
-		) {
-			if (strpos($priceType, $fieldname) === 0) {
-				$priceType = substr($priceType, strlen($fieldname));
-			}
+    /**
+     * Formatting a percentage
+     */
+    public function percentageFormat ($double) {
+        $result = false;
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->conf;
+        $double = round($double, 10);
 
-			if (
-				isset(self::$convertArray[$fieldname][$priceType])
-			) {
-				$result = self::$convertArray[$fieldname][$priceType];
-			}
-		}
-		return $result;
-	}
+        $percentDecPoint = $conf['percentDecPoint'];
+        $percentThousandPoint = $conf['percentThousandPoint'];
+        $percentDec = $conf['percentDec'];
+        $percentNoZeroDecimalPoint = $conf['percentNoZeroDecimalPoint'];
 
-	public function getModelMarkerArray (
-		$functablename,
-		$basketExtra,
-		$basketRecs,
-		$field,
-		$row,
-		&$markerArray,
-		$priceMarkerPrefix,
-		$id,
-		$bEnableTaxZero = false,
+        if ($percentNoZeroDecimalPoint && round($double, 2) == intval($double)) {
+            $result = number_format($double, 0, $percentDecPoint, $percentThousandPoint);
+        } else {
+            $result = number_format($double, intval($percentDec), $percentDecPoint, $percentThousandPoint);
+        }
+        if ($result == '-0,00') {
+            $result = '0,00';
+        }
+        if ($result == '-0.00') {
+            $result = '0.00';
+        }
+        return $result;
+    } // percentageFormat
+
+
+    static public function convertKey ($priceType, $fieldname) {
+        $result = false;
+        if (
+            isset(self::$convertArray[$fieldname]) &&
+            is_array(self::$convertArray[$fieldname])
+        ) {
+            if (strpos($priceType, $fieldname) === 0) {
+                $priceType = substr($priceType, strlen($fieldname));
+            }
+
+            if (
+                isset(self::$convertArray[$fieldname][$priceType])
+            ) {
+                $result = self::$convertArray[$fieldname][$priceType];
+            }
+        }
+        return $result;
+    }
+
+    public function getModelMarkerArray (
+        $functablename,
+        $basketExtra,
+        $basketRecs,
+        $field,
+        $row,
+        &$markerArray,
+        $priceMarkerPrefix,
+        $id,
+        $bEnableTaxZero = false,
         $notOverwritePriceIfSet = true
     ) {
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$config = $cnf->getConfig();
-		$languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $config = $cnf->getConfig();
+        $languageObj = GeneralUtility::makeInstance(\JambageCom\TtProducts\Api\Localization::class);
 
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTableView = $tablesObj->get($functablename, true);
-		$itemTable = $itemTableView->getModelObj();
-		$modelObj = $this->getModelObj();
-		$totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTableView = $tablesObj->get($functablename, true);
+        $itemTable = $itemTableView->getModelObj();
+        $modelObj = $this->getModelObj();
+        $totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
 
-		if ($priceMarkerPrefix != '') {
-			$priceMarkerPrefix .= '_';
-		}
-		$priceMarkerArray = [];
-		$modelObj = $this->getModelObj();
-		$taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
-		$taxInclExcl =
-			(
-				isset($taxFromShipping) &&
-				is_double($taxFromShipping) &&
-				$taxFromShipping == 0 ?
-					'tax_zero' :
-					'tax_included'
-			);
-		$taxInfoArray = [];
+        if ($priceMarkerPrefix != '') {
+            $priceMarkerPrefix .= '_';
+        }
+        $priceMarkerArray = [];
+        $modelObj = $this->getModelObj();
+        $taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
+        $taxInclExcl =
+            (
+                isset($taxFromShipping) &&
+                is_double($taxFromShipping) &&
+                $taxFromShipping == 0 ?
+                    'tax_zero' :
+                    'tax_included'
+            );
+        $taxInfoArray = [];
 
-		$priceTaxArray =
-			$modelObj->getPriceTaxArray(
-				$taxInfoArray,
-				$conf['discountPriceMode'] ?? '',
-				$basketExtra,
-				$basketRecs,
-				$field,
-				tx_ttproducts_control_basket::getRoundFormat(),
-				tx_ttproducts_control_basket::getRoundFormat('discount'),
-				$row,
-				$totalDiscountField,
-				$bEnableTaxZero,
-				$notOverwritePriceIfSet
-			);
+        $priceTaxArray =
+            $modelObj->getPriceTaxArray(
+                $taxInfoArray,
+                $conf['discountPriceMode'] ?? '',
+                $basketExtra,
+                $basketRecs,
+                $field,
+                tx_ttproducts_control_basket::getRoundFormat(),
+                tx_ttproducts_control_basket::getRoundFormat('discount'),
+                $row,
+                $totalDiscountField,
+                $bEnableTaxZero,
+                $notOverwritePriceIfSet
+            );
 
-		foreach ($priceTaxArray as $priceKey => $priceValue) {
-			$displayTax = $this->convertKey($priceKey, $field);
+        foreach ($priceTaxArray as $priceKey => $priceValue) {
+            $displayTax = $this->convertKey($priceKey, $field);
 
-			if ($displayTax !== false) {
-				$displayKey = $priceMarkerPrefix . $displayTax;
-				if ($priceKey == 'skontotaxperc') {
-					$priceMarkerArray['###' . $displayKey . '###'] = $priceValue;
-				} else {
-					$priceMarkerArray['###' . $displayKey . '###'] =
-						$this->printPrice(
-							$this->priceFormat($priceValue, $taxInclExcl)
-						);
-				}
+            if ($displayTax !== false) {
+                $displayKey = $priceMarkerPrefix . $displayTax;
+                if ($priceKey == 'skontotaxperc') {
+                    $priceMarkerArray['###' . $displayKey . '###'] = $priceValue;
+                } else {
+                    $priceMarkerArray['###' . $displayKey . '###'] =
+                        $this->printPrice(
+                            $this->priceFormat($priceValue, $taxInclExcl)
+                        );
+                }
 
-				$displaySuffixId = str_replace('_', '', strtolower($displayTax));
-				$priceMarkerArray['###' . $displayKey . '_ID###'] = $id . '-' . $displaySuffixId;
-			}
-		}
+                $displaySuffixId = str_replace('_', '', strtolower($displayTax));
+                $priceMarkerArray['###' . $displayKey . '_ID###'] = $id . '-' . $displaySuffixId;
+            }
+        }
 
 
 // Todo: The following markers must not be set here. This function is called in a loop for each field.
 
-		$priceMarkerArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
+        $priceMarkerArray['###TAX_INCL_EXCL###'] = ($taxInclExcl ? $languageObj->getLabel($taxInclExcl) : '');
 
         if (!isset($markerArray['###TAX###'])) {
             $priceMarkerArray['###TAX###'] = strval($row['tax']);
-		}
+        }
 
         $pricefactor = 0;
         if (isset($conf['creditpoints.']['priceprod'])) {
             $pricefactor = doubleval($conf['creditpoints.']['priceprod']);
         }
         
-		if ($field == 'price') {
+        if ($field == 'price') {
             // price if discounted by credipoints
             $priceMarkerArray['###PRICE_IF_DISCOUNTED_BY_CREDITPOINTS_TAX###'] = $this->printPrice($this->priceFormat(($priceTaxArray['tax'] - $pricefactor * ($row['creditpoints'] ?? 0)), $taxInclExcl));
             $priceMarkerArray['###PRICE_IF_DISCOUNTED_BY_CREDITPOINTS_NO_TAX###'] = $this->printPrice($this->priceFormat(($priceTaxArray['notax'] - $pricefactor * ($row['creditpoints'] ?? 0)), $taxInclExcl));
         }
 
-		if (is_array($markerArray)) {
-			$markerArray = array_merge($markerArray, $priceMarkerArray);
-		} else {
-			$markerArray = $priceMarkerArray;
-		}
+        if (is_array($markerArray)) {
+            $markerArray = array_merge($markerArray, $priceMarkerArray);
+        } else {
+            $markerArray = $priceMarkerArray;
+        }
 
-	} // getModelMarkerArray
+    } // getModelMarkerArray
 
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
         $notOverwritePriceIfSet = true;
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$conf = $cnf->getConf();
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$itemTableView = $tablesObj->get($functablename, true);
-		$itemTable = $itemTableView->getModelObj();
-		$modelObj = $this->getModelObj();
-		$totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
-		$marker = strtoupper($fieldname);
-		$taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
-		$taxInclExcl = (
-			isset($taxFromShipping) && is_double($taxFromShipping) && ($taxFromShipping == 0) ?
-				'tax_zero' :
-				'tax_included'
-			);
-		$taxInfoArray = [];
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $conf = $cnf->getConf();
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $itemTableView = $tablesObj->get($functablename, true);
+        $itemTable = $itemTableView->getModelObj();
+        $modelObj = $this->getModelObj();
+        $totalDiscountField = \JambageCom\TtProducts\Model\Field\FieldInterface::DISCOUNT;
+        $marker = strtoupper($fieldname);
+        $taxFromShipping = PaymentShippingHandling::getReplaceTaxPercentage($basketExtra);
+        $taxInclExcl = (
+            isset($taxFromShipping) && is_double($taxFromShipping) && ($taxFromShipping == 0) ?
+                'tax_zero' :
+                'tax_included'
+            );
+        $taxInfoArray = [];
 // tt-products-single-1-pricetax
-		$priceArray = $modelObj->getPriceTaxArray(
-			$taxInfoArray,
-			$conf['discountPriceMode'] ?? '',
-			$basketExtra,
-			$basketRecs,
-			$fieldname,
-			tx_ttproducts_control_basket::getRoundFormat(),
-			tx_ttproducts_control_basket::getRoundFormat('discount'),
-			$row,
-			$totalDiscountField,
-			$bEnableTaxZero,
+        $priceArray = $modelObj->getPriceTaxArray(
+            $taxInfoArray,
+            $conf['discountPriceMode'] ?? '',
+            $basketExtra,
+            $basketRecs,
+            $fieldname,
+            tx_ttproducts_control_basket::getRoundFormat(),
+            tx_ttproducts_control_basket::getRoundFormat('discount'),
+            $row,
+            $totalDiscountField,
+            $bEnableTaxZero,
             $notOverwritePriceIfSet = true
-		);
+        );
 
-		$priceMarkerPrefix = $itemTableView->getMarker() . '_';
-		foreach ($priceArray as $priceType => $priceValue) {
-			$displayTax = self::convertKey($priceType, $fieldname);
-			if ($displayTax === false) {
-				continue;
-			}
-			$taxMarker = $priceMarkerPrefix . strtoupper($displayTax);
-			$markerArray['###' . $taxMarker . '###'] =
-				$this->printPrice(
-					$this->priceFormat($priceValue),
-					$taxInclExcl
-				);
+        $priceMarkerPrefix = $itemTableView->getMarker() . '_';
+        foreach ($priceArray as $priceType => $priceValue) {
+            $displayTax = self::convertKey($priceType, $fieldname);
+            if ($displayTax === false) {
+                continue;
+            }
+            $taxMarker = $priceMarkerPrefix . strtoupper($displayTax);
+            $markerArray['###' . $taxMarker . '###'] =
+                $this->printPrice(
+                    $this->priceFormat($priceValue),
+                    $taxInclExcl
+                );
 
-			$displaySuffixId = str_replace('_', '', strtolower($displayTax));
-			$displaySuffixId = str_replace($fieldname, '', $displaySuffixId);
-			$markerArray['###' . $taxMarker . '_ID###'] = $id . $displaySuffixId;
-		}
-	}
+            $displaySuffixId = str_replace('_', '', strtolower($displayTax));
+            $displaySuffixId = str_replace($fieldname, '', $displaySuffixId);
+            $markerArray['###' . $taxMarker . '_ID###'] = $id . $displaySuffixId;
+        }
+    }
 }
 

--- a/view/field/class.tx_ttproducts_field_tax_view.php
+++ b/view/field/class.tx_ttproducts_field_tax_view.php
@@ -42,64 +42,64 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_field_tax_view extends tx_ttproducts_field_base_view {
 
-	public function getItemSubpartArrays (
-		&$templateCode,
-		$markerKey,
-		$functablename,
-		$row,
-		$fieldname,
-		$tableConf,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		&$tagArray,
-		$theCode = '',
-		$basketExtra = [],
-		$basketRecs = [],
-		$id = '1'
-	) {
-		$tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
-		$staticTaxViewObj = $tablesObj->get('static_taxes', true);
+    public function getItemSubpartArrays (
+        &$templateCode,
+        $markerKey,
+        $functablename,
+        $row,
+        $fieldname,
+        $tableConf,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        &$tagArray,
+        $theCode = '',
+        $basketExtra = [],
+        $basketRecs = [],
+        $id = '1'
+    ) {
+        $tablesObj = GeneralUtility::makeInstance('tx_ttproducts_tables');
+        $staticTaxViewObj = $tablesObj->get('static_taxes', true);
 
-		if (is_object($staticTaxViewObj)) {
-			$staticTaxFuncTableName = $staticTaxViewObj->getModelObj()->getFuncTablename();
-			$staticTaxViewObj->getItemSubpartArrays(
-				$templateCode,
-				$staticTaxFuncTableName,
-				$row,
-				$subpartArray,
-				$wrappedSubpartArray,
-				$tagArray,
-				$theCode,
-				$basketExtra,
-				$basketRecs,
-				$id
-			);
-		}
-	}
+        if (is_object($staticTaxViewObj)) {
+            $staticTaxFuncTableName = $staticTaxViewObj->getModelObj()->getFuncTablename();
+            $staticTaxViewObj->getItemSubpartArrays(
+                $templateCode,
+                $staticTaxFuncTableName,
+                $row,
+                $subpartArray,
+                $wrappedSubpartArray,
+                $tagArray,
+                $theCode,
+                $basketExtra,
+                $basketRecs,
+                $id
+            );
+        }
+    }
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-	}
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+    }
 }
 
 

--- a/view/field/class.tx_ttproducts_field_text_view.php
+++ b/view/field/class.tx_ttproducts_field_text_view.php
@@ -42,61 +42,61 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_ttproducts_field_text_view extends tx_ttproducts_field_base_view {
 
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	) {
-		$htmlentitiesArray = [];
-		$cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
-		$tableconf = $cnf->getTableConf($functablename, $theCode);
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    ) {
+        $htmlentitiesArray = [];
+        $cnf = GeneralUtility::makeInstance('tx_ttproducts_config');
+        $tableconf = $cnf->getTableConf($functablename, $theCode);
 
-		if (is_array($tableconf['functions.']) && isset($tableconf['functions.']['htmlentities'])) {
-			$htmlentitiesArray = GeneralUtility::trimExplode(',', $tableconf['functions.']['htmlentities']);
-		}
+        if (is_array($tableconf['functions.']) && isset($tableconf['functions.']['htmlentities'])) {
+            $htmlentitiesArray = GeneralUtility::trimExplode(',', $tableconf['functions.']['htmlentities']);
+        }
 
-		$value =
-			$this->getModelObj()->getFieldValue(
-				$dummy,
-				$row,
-				$fieldname,
-				$basketExtra,
-				$basketRecs,
-				$dummy
-			);
+        $value =
+            $this->getModelObj()->getFieldValue(
+                $dummy,
+                $row,
+                $fieldname,
+                $basketExtra,
+                $basketRecs,
+                $dummy
+            );
 
-		if ($bHtml && $charset != '' && in_array($fieldname, $htmlentitiesArray))	{
-			$bConvertNewlines = $this->conf['nl2brNote'];
-			if (
-				$bConvertNewlines &&
-				(
-					$theCode != 'EMAIL' || $this->conf['orderEmail_htmlmail']
-				)
-			) {
-				$value = nl2br($value);
-			} else {
-				$value = htmlentities($value, ENT_QUOTES, $charset);
-			}
-		}
+        if ($bHtml && $charset != '' && in_array($fieldname, $htmlentitiesArray))	{
+            $bConvertNewlines = $this->conf['nl2brNote'];
+            if (
+                $bConvertNewlines &&
+                (
+                    $theCode != 'EMAIL' || $this->conf['orderEmail_htmlmail']
+                )
+            ) {
+                $value = nl2br($value);
+            } else {
+                $value = htmlentities($value, ENT_QUOTES, $charset);
+            }
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 }
 

--- a/view/field/interface.tx_ttproducts_field_view_int.php
+++ b/view/field/interface.tx_ttproducts_field_view_int.php
@@ -39,30 +39,30 @@
 
 
 interface tx_ttproducts_field_view_int {
-	public function init ($modelObj);
-	public function needsInit ();
-	public function getModelObj ();
-	public function getRowMarkerArray (
-		$functablename,
-		$fieldname,
-		$row,
-		$markerKey,
-		&$markerArray,
-		$fieldMarkerArray,
-		$tagArray,
-		$theCode,
-		$id,
-		$basketExtra,
-		$basketRecs,
-		&$bSkip,
-		$bHtml = true,
-		$charset = '',
-		$prefix = '',
-		$suffix = '',
-		$imageNum = 0,
-		$imageRenderObj = '',
-		$linkWrap = false,
-		$bEnableTaxZero = false
-	);
+    public function init ($modelObj);
+    public function needsInit ();
+    public function getModelObj ();
+    public function getRowMarkerArray (
+        $functablename,
+        $fieldname,
+        $row,
+        $markerKey,
+        &$markerArray,
+        $fieldMarkerArray,
+        $tagArray,
+        $theCode,
+        $id,
+        $basketExtra,
+        $basketRecs,
+        &$bSkip,
+        $bHtml = true,
+        $charset = '',
+        $prefix = '',
+        $suffix = '',
+        $imageNum = 0,
+        $imageRenderObj = '',
+        $linkWrap = false,
+        $bEnableTaxZero = false
+    );
 }
 

--- a/view/interface.tx_ttproducts_edit_variant_view_int.php
+++ b/view/interface.tx_ttproducts_edit_variant_view_int.php
@@ -39,17 +39,17 @@
 
 interface tx_ttproducts_edit_variant_view_int {
 
-	public function init ($modelObj);
-	public function getSubpartMarkerArray (
-		$templateCode,
-		$functablename,
-		$row,
-		$theCode,
-		$bEditable,
-		$tagArray,
-		&$subpartArray,
-		&$wrappedSubpartArray
-	);
+    public function init ($modelObj);
+    public function getSubpartMarkerArray (
+        $templateCode,
+        $functablename,
+        $row,
+        $theCode,
+        $bEditable,
+        $tagArray,
+        &$subpartArray,
+        &$wrappedSubpartArray
+    );
 }
 
 

--- a/view/interface.tx_ttproducts_variant_view_int.php
+++ b/view/interface.tx_ttproducts_variant_view_int.php
@@ -39,29 +39,29 @@
 
 interface tx_ttproducts_variant_view_int {
 
-	public function init ($modelObj);
-	public function getVariantSubpartMarkerArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$tempContent,
-		$bUseSelects,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	);
+    public function init ($modelObj);
+    public function getVariantSubpartMarkerArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $tempContent,
+        $bUseSelects,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    );
 
 
-	public function removeEmptyMarkerSubpartArray (
-		&$markerArray,
-		&$subpartArray,
-		&$wrappedSubpartArray,
-		$row,
-		$conf,
-		$bHasAdditional,
-		$bGiftService
-	);
+    public function removeEmptyMarkerSubpartArray (
+        &$markerArray,
+        &$subpartArray,
+        &$wrappedSubpartArray,
+        $row,
+        $conf,
+        $bHasAdditional,
+        $bGiftService
+    );
 
 }
 


### PR DESCRIPTION
Hi,

this is just a preparatory change for a bigger change (reformatting the code with php-cs-fixer) and an idea to make it easier for contributors to contribute because they don't unintentionally change whitespace and other things.

It's just an idea and you can very well say you don't want or need it. But I think it would be much easier if you had code style rules in place that can be enforced automatically.

Also, an `.editorconfig` file helps to let several IDE's behave the correct way.

This PR only changes whitespaces. You can manually check this with a git command:
`git diff master task/use-spaces-in-php-files -w`