### PR TITLE
prevent exception caused by Dependency Injection

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,7 +5,7 @@ services:
     public: false
   JambageCom\TtProducts\:
     resource: '../Classes/*'
-    exclude: ['../Classes/{Middleware,UserFunc,Api}/*']
+    exclude: ['../Classes/{Backend,Middleware,UserFunc,Api}/*']
 
   JambageCom\TtProducts\Domain\Model\Dto\EmConfiguration:
     public: true


### PR DESCRIPTION
The Backend folder causes a fatal erro exception with 


`Fatal error: Declaration of JambageCom\TtProducts\Backend\OldBackendUserSimulation::checkAuthMode($table, $field, $value, $authMode) must be compatible with TYPO3\CMS\Core\Authentication\BackendUserAuthentication::checkAuthMode($table, $field, $value) in /home/users/bjoern-hahnefeld-it/path/typo3conf/ext/tt_products/Classes/Backend/OldBackendUserSimulation.php on line 108`
